### PR TITLE
Remove handlers from stream channel pipelines on shutdown.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-nio-nghttp2-support.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -340,7 +340,11 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
             promise.succeed(result: ())
         }
         self.pipeline.fireChannelInactive()
-        self.closePromise.succeed(result: ())
+
+        self.eventLoop.execute {
+            self.removeHandlers(channel: self)
+            self.closePromise.succeed(result: ())
+        }
     }
 
     fileprivate func errorEncountered(error: Error) {
@@ -356,7 +360,11 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         }
         self.pipeline.fireErrorCaught(error)
         self.pipeline.fireChannelInactive()
-        self.closePromise.fail(error: error)
+
+        self.eventLoop.execute {
+            self.removeHandlers(channel: self)
+            self.closePromise.fail(error: error)
+        }
     }
 
     private func tryToRead() {

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -48,6 +48,8 @@ extension HTTP2StreamMultiplexerTests {
                 ("testReadIsPerChannel", testReadIsPerChannel),
                 ("testReadWillCauseAutomaticFrameDelivery", testReadWillCauseAutomaticFrameDelivery),
                 ("testReadWithNoPendingDataCausesReadOnParentChannel", testReadWithNoPendingDataCausesReadOnParentChannel),
+                ("testHandlersAreRemovedOnClosure", testHandlersAreRemovedOnClosure),
+                ("testHandlersAreRemovedOnClosureWithError", testHandlersAreRemovedOnClosureWithError),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When closing a stream channel, it must remove its channel handlers.

Modifications:

Call ChannelCore.removeHandlers on shutdown.

Result:

Handlers are removed on channel shutdown.