### PR TITLE
Add interface for creating channels from the client side.

### DIFF
--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -50,6 +50,10 @@ extension HTTP2StreamMultiplexerTests {
                 ("testReadWithNoPendingDataCausesReadOnParentChannel", testReadWithNoPendingDataCausesReadOnParentChannel),
                 ("testHandlersAreRemovedOnClosure", testHandlersAreRemovedOnClosure),
                 ("testHandlersAreRemovedOnClosureWithError", testHandlersAreRemovedOnClosureWithError),
+                ("testCreatingOutboundChannel", testCreatingOutboundChannel),
+                ("testWritesOnCreatedChannelAreDelayed", testWritesOnCreatedChannelAreDelayed),
+                ("testWritesAreCancelledOnFailingInitializer", testWritesAreCancelledOnFailingInitializer),
+                ("testFailingInitializerDoesNotWrite", testFailingInitializerDoesNotWrite),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

While the HTTP2StreamMultiplexer could create channels in response to
inbound request streams on the server side, there was no interface for
creating channels locally.

That would make having a HTTP/2 client kinda tricky!

Modifications:

Added HTTP2StreamMultiplexer.createStreamChannel.

Result:

Possible to write HTTP/2 clients.