### PR TITLE
Clean up tests.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Parser.swift
+++ b/Sources/NIOHTTP2/HTTP2Parser.swift
@@ -192,7 +192,6 @@ public final class HTTP2Parser: ChannelInboundHandler, ChannelOutboundHandler {
     public func channelInactive(ctx: ChannelHandlerContext) {
         self.reentrancyManager.eofType = .channelInactive
         self.reentrancyManager.process(ctx: ctx, self.process)
-        ctx.fireChannelInactive()
     }
 
     public func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any) {

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -79,6 +79,9 @@ extension XCTestCase {
     func assertDoHandshake(client: EmbeddedChannel, server: EmbeddedChannel,
                            clientSettings: [HTTP2Setting] = nioDefaultSettings, serverSettings: [HTTP2Setting] = nioDefaultSettings,
                            file: StaticString = #file, line: UInt = #line) throws {
+        client.pipeline.fireChannelActive()
+        server.pipeline.fireChannelActive()
+
         // First the channels need to interact.
         self.interactInMemory(client, server, file: file, line: line)
 


### PR DESCRIPTION
Motivation:

Our tests were failing as a result of the previous commit changing the
HTTP/2 lifecycle.

Modifications:

Fired channelActive in a few tests, correctly propagated
channelInactive.

Result:

Tests should pass.