### PR TITLE
Correctly discard only inactive streams.

### DIFF
--- a/Sources/NIOHTTP2/NGHTTP2Session.swift
+++ b/Sources/NIOHTTP2/NGHTTP2Session.swift
@@ -285,7 +285,7 @@ fileprivate struct StreamManager {
     // Discard old and unnecessary streams.
     private mutating func purgeOldStreams() {
         while self.streamMap.count >= maxSize {
-            let lowestStreamID = self.streamMap.filter { $0.value.active }.keys.sorted().first { $0 != 0 && $0 != Int32.max }!
+            let lowestStreamID = self.streamMap.filter { !$0.value.active }.keys.sorted().first { $0 != 0 && $0 != Int32.max }!
             self.streamMap.removeValue(forKey: lowestStreamID)
         }
     }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -55,6 +55,8 @@ extension SimpleClientServerTests {
                 ("testStreamClosedViaGoaway", testStreamClosedViaGoaway),
                 ("testStreamCloseEventForRstStreamFiresAfterFrame", testStreamCloseEventForRstStreamFiresAfterFrame),
                 ("testStreamCloseEventForGoawayFiresAfterFrame", testStreamCloseEventForGoawayFiresAfterFrame),
+                ("testManyConcurrentInactiveStreams", testManyConcurrentInactiveStreams),
+                ("testDontRemoveActiveStreams", testDontRemoveActiveStreams),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Long-lived connections that have many inactive streams would cause
crashes. Crashes are, in my professional opinion, less than ideal
when they occur under expected usage cases.

Modifications:

- Fixed an inverted boolean check that would discard only *active*
  streams.
- Added tests.

Result:

Fewer crashes, better software.