### PR TITLE
don't crash when client sends bad magic

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CNIONghttp2
+
 public protocol NIOHTTP2Error: Equatable, Error { }
 
 /// Errors that NIO raises when handling HTTP/2 connections.
@@ -43,6 +45,18 @@ public enum NIOHTTP2Errors {
         public init(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode) {
             self.streamID = streamID
             self.errorCode = errorCode
+        }
+    }
+
+    public struct BadClientMagic: NIOHTTP2Error {
+        public init() {}
+    }
+
+    public struct InternalError: NIOHTTP2Error {
+        internal var nghttp2ErrorCode: nghttp2_error
+
+        internal init(nghttp2ErrorCode: nghttp2_error) {
+            self.nghttp2ErrorCode = nghttp2ErrorCode
         }
     }
 }

--- a/Tests/NIOHTTP2Tests/BasicTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/BasicTests+XCTest.swift
@@ -27,6 +27,7 @@ extension BasicTests {
    static var allTests : [(String, (BasicTests) -> () throws -> Void)] {
       return [
                 ("testCanInitializeInnerSession", testCanInitializeInnerSession),
+                ("testThrowsErrorOnBasicProtocolViolation", testThrowsErrorOnBasicProtocolViolation),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -58,6 +58,7 @@ extension SimpleClientServerTests {
                 ("testManyConcurrentInactiveStreams", testManyConcurrentInactiveStreams),
                 ("testDontRemoveActiveStreams", testDontRemoveActiveStreams),
                 ("testCachingInteractionWithMaxConcurrentStreams", testCachingInteractionWithMaxConcurrentStreams),
+                ("testBadClientMagic", testBadClientMagic),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We shouldn't just crash if the client sends bad magic.

Changes:

Send an error through the pipeline instead of crashing on bad client
magic.

Result:

fewer crashes