### PR TITLE
Avoid crashing when MAX_CONCURRENT_STREAMS exceeds old cache size

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -57,6 +57,7 @@ extension SimpleClientServerTests {
                 ("testStreamCloseEventForGoawayFiresAfterFrame", testStreamCloseEventForGoawayFiresAfterFrame),
                 ("testManyConcurrentInactiveStreams", testManyConcurrentInactiveStreams),
                 ("testDontRemoveActiveStreams", testDontRemoveActiveStreams),
+                ("testCachingInteractionWithMaxConcurrentStreams", testCachingInteractionWithMaxConcurrentStreams),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Our dead stream cache should not cause us to crash when we can have more
active streams than the entire size of the cache. These things are
at least nominally unrelated.

Modifications:

Rewrote the code to avoid asserting that we'll always be able to shrink
down to the dead cache size.

Result:

Fewer crashes