### PR TITLE
add hpack-test-case to NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -41,3 +41,12 @@ This product contains a derivation of the Tony Stone's 'process_test_files.rb'.
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://codegists.com/snippet/ruby/generate_xctest_linux_runnerrb_tonystone_ruby
+
+---
+
+The unit tests make use of 'hpack-test-case' by jxck, summerwind, kazu-yamamoto, and tatsuhiro-t.
+
+  * LICENSE (MIT):
+    * https://opensource.org/licenses/MIT
+  * HOMEPAGE:
+    * https://github.com/http2jp/hpack-test-case


### PR DESCRIPTION
see also: https://github.com/http2jp/hpack-test-case/issues/27

Motivation:

We should attribute all external code/data we make use of, even in unit
tests.

Modifications:

Added hpack-test-case to NOTICE.txt

Result:

More attribution