### PR TITLE
Removes wrong return type documentation

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -115,7 +115,6 @@ extension HTTP2StreamMultiplexer {
     ///         failed if an error occurs.
     ///     - streamStateInitializer: A callback that will be invoked to allow you to configure the
     ///         `ChannelPipeline` for the newly created channel.
-    /// - returns: An `EventLoopFuture` that completes with the new channel.
     public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping (Channel, HTTP2StreamID) -> EventLoopFuture<Void>) {
         guard let ourChannel = self.channel else {
             promise?.fail(error: ChannelError.ioOnClosedChannel)


### PR DESCRIPTION
The documentation previously stated that `createStreamChannel` returns an "`EventLoopFuture` that completes with the new channel", where in reality the method returns `Void` and you instead supply an `EventLoopPromise` that is succeeded with the new activated channel. This PR removes the `returns:` line from the documentation comment.