### PR TITLE
require Swift 4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project


### PR DESCRIPTION
Motivation:

We never supported Swift 4.0 in this repository and Swift 4.0 is quite a
pain mostly because of the Unsafe*Pointer API differences.

Changes:

Require 4.1

Result:

fewer lies, fixes #17