### PR TITLE
Fix tests on nghttp2-1.34.0

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
@@ -966,8 +966,8 @@ class SimpleClientServerTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         try self.clientChannel.assertReceivedFrame().assertGoAwayFrame(lastStreamID: 0, errorCode: UInt32(http2ErrorCode: HTTP2ErrorCode.inadequateSecurity), opaqueData: nil)
 
-        // The data frame write should have exploded. nghttp2 synthesises a "refusedStream" error code for this.
-        XCTAssertEqual(writeError as? NIOHTTP2Errors.StreamClosed, NIOHTTP2Errors.StreamClosed(streamID: clientStreamID, errorCode: .refusedStream))
+        // The data frame write should have exploded. nghttp2 synthesises an error code for this.
+        XCTAssertEqual((writeError as? NIOHTTP2Errors.StreamClosed)?.streamID, clientStreamID)
 
         // No other frames should be emitted.
         self.clientChannel.assertNoFramesReceived()
@@ -1170,8 +1170,8 @@ class SimpleClientServerTests: XCTestCase {
         // Now the streams are closed, they should have seen user events.
         XCTAssertEqual(clientHandler.events.count, 1)
         XCTAssertEqual(serverHandler.events.count, 1)
-        XCTAssertEqual(clientHandler.events[0] as? StreamClosedEvent, StreamClosedEvent(streamID: clientStreamID, reason: .refusedStream))
-        XCTAssertEqual(serverHandler.events[0] as? StreamClosedEvent, StreamClosedEvent(streamID: serverStreamID, reason: .refusedStream))
+        XCTAssertEqual((clientHandler.events[0] as? StreamClosedEvent)?.streamID, clientStreamID)
+        XCTAssertEqual((serverHandler.events[0] as? StreamClosedEvent)?.streamID, serverStreamID)
 
         XCTAssertNoThrow(try self.clientChannel.finish())
         XCTAssertNoThrow(try self.serverChannel.finish())


### PR DESCRIPTION
Motivation:

nghttp2 changed the error code it returns when the server sends a GOAWAY.
It's now `.cancelled` instead of `.refusedStream`.

Modifications:

Don't require a specific error code in the tests, just require that an
error matching the expected stream ID occurred.

Result:

Tests will pass on nghttp2-1.34.0.