### PR TITLE
Initialize HTTP2Parser handler in the handlerAdded event hook.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Parser.swift
+++ b/Sources/NIOHTTP2/HTTP2Parser.swift
@@ -185,15 +185,17 @@ public final class HTTP2Parser: ChannelInboundHandler, ChannelOutboundHandler {
     }
 
     public func channelActive(ctx: ChannelHandlerContext) {
-        self.session = NGHTTP2Session(mode: self.mode,
-                                      allocator: ctx.channel.allocator,
-                                      maxCachedStreamIDs: self.maxCachedClosedStreams,
-                                      frameReceivedHandler: { ctx.fireChannelRead(self.wrapInboundOut($0)) },
-                                      sendFunction: { ctx.write(self.wrapOutboundOut($0), promise: $1) },
-                                      userEventFunction: { ctx.fireUserInboundEventTriggered($0) })
-
-        self.flushPreamble(ctx: ctx)
+        self.initializeSession(ctx: ctx)
         ctx.fireChannelActive()
+    }
+
+    public func handlerAdded(ctx: ChannelHandlerContext) {
+        // Check if the channel is already active when this handler is being added,
+        // in case the handler was added dynamically into the pipeline. If so,
+        // call channelActive to set up the handler.
+        if ctx.channel.isActive {
+            self.initializeSession(ctx: ctx)
+        }
     }
 
     public func handlerRemoved(ctx: ChannelHandlerContext) {
@@ -234,6 +236,19 @@ public final class HTTP2Parser: ChannelInboundHandler, ChannelOutboundHandler {
     public func flush(ctx: ChannelHandlerContext) {
         self.reentrancyManager.markFlushPoint()
         self.reentrancyManager.process(ctx: ctx, self.process)
+    }
+  
+    private func initializeSession(ctx: ChannelHandlerContext) {
+      if self.session == nil {
+          self.session = NGHTTP2Session(mode: self.mode,
+                                        allocator: ctx.channel.allocator,
+                                        maxCachedStreamIDs: self.maxCachedClosedStreams,
+                                        frameReceivedHandler: { ctx.fireChannelRead(self.wrapInboundOut($0)) },
+                                        sendFunction: { ctx.write(self.wrapOutboundOut($0), promise: $1) },
+                                        userEventFunction: { ctx.fireUserInboundEventTriggered($0) })
+      
+          self.flushPreamble(ctx: ctx)
+      }
     }
 
     private func flushPreamble(ctx: ChannelHandlerContext) {

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -27,6 +27,7 @@ extension SimpleClientServerTests {
    static var allTests : [(String, (SimpleClientServerTests) -> () throws -> Void)] {
       return [
                 ("testBasicRequestResponse", testBasicRequestResponse),
+                ("testBasicRequestResponseWithDynamicPipeline", testBasicRequestResponseWithDynamicPipeline),
                 ("testManyRequestsAtOnce", testManyRequestsAtOnce),
                 ("testNothingButGoaway", testNothingButGoaway),
                 ("testGoAwayWithStreamsUpQuiescing", testGoAwayWithStreamsUpQuiescing),

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -79,8 +79,13 @@ extension XCTestCase {
     func assertDoHandshake(client: EmbeddedChannel, server: EmbeddedChannel,
                            clientSettings: [HTTP2Setting] = nioDefaultSettings, serverSettings: [HTTP2Setting] = nioDefaultSettings,
                            file: StaticString = #file, line: UInt = #line) throws {
-        client.pipeline.fireChannelActive()
-        server.pipeline.fireChannelActive()
+        // This connects are not semantically right, but are required in order to activate the
+        // channels.
+        //! FIXME: Replace with registerAlreadyConfigured0 once EmbeddedChannel propagates this
+        //         call to its channelcore.
+        let socket = try SocketAddress(unixDomainSocketPath: "/fake")
+        _ = try client.connect(to: socket).wait()
+        _ = try server.connect(to: socket).wait()
 
         // First the channels need to interact.
         self.interactInMemory(client, server, file: file, line: line)


### PR DESCRIPTION
By initializing the handler in the handlerAdded hook, HTTP2Parser supports
being added dynamically in a channelRead event, after the channel has sent
the channelActive event.