### PR TITLE
Clarify cleanup docs for stream channel creation

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -121,6 +121,9 @@ extension HTTP2StreamMultiplexer {
     /// This method is intended for situations where the NIO application is initiating the stream. For clients,
     /// this is for all request streams. For servers, this is for pushed streams.
     ///
+    /// - note:
+    /// Resources for the stream will be freed after it has been closed.
+    ///
     /// - parameters:
     ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
     ///         failed if an error occurs.


### PR DESCRIPTION
Motivation:

The documentation for creating a new stream channel didn't indicate
whether the user had to do any cleanup on the multiplexer once a stream
was no longer in use.

Modifications:

Added a note to the documentation indicating that no additional action
is required by the user beyond closing the stream.

Result:

The documentation is less ambiguous.