### PR TITLE
Add Dockerfile to run h2spec.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,14 @@ RUN [ -z $install_nghttp2_from_source ] || tar xzf $HOME/nghttp2.tar.gz --direct
 RUN [ -z $install_nghttp2_from_source ] || ( cd $HOME/.nghttp2 && ./configure && make && make install && cd - )
 RUN [ -z $install_nghttp2_from_source ] || ldconfig
 
+# h2spec
+ARG h2spec_version
+RUN [ -z $h2spec_version ] || mkdir $HOME/.h2spec
+RUN [ -z $h2spec_version ] || wget -q https://github.com/summerwind/h2spec/releases/download/v$h2spec_version/h2spec_linux_amd64.tar.gz -O $HOME/h2spec.tar.gz
+RUN [ -z $h2spec_version ] || tar xzf $HOME/h2spec.tar.gz --directory $HOME/.h2spec
+RUN [ -z $h2spec_version ] || mv $HOME/.h2spec/h2spec /usr/local/bin/h2spec
+
+
 # swift
 ARG swift_version=4.0.3
 ARG swift_flavour=RELEASE

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -10,6 +10,11 @@ services:
         swift_version: "5.0"
         swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-02-17-a"
         swift_builds_suffix: "branch"
+        h2spec_version: "2.2.1"
 
   test:
     image: swift-nio-http2:18.04-5.0
+
+  h2spec:
+    image: swift-nio-http2:18.04-5.0
+

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,3 +26,8 @@ services:
   test:
     <<: *common
     command: /bin/bash -cl "swift test"
+
+  h2spec:
+    <<: *common
+    command: /bin/bash -cl "./scripts/test_h2spec.sh"
+

--- a/scripts/test_h2spec.sh
+++ b/scripts/test_h2spec.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eou pipefail
+
+function server_lsof() {
+    lsof -a -P -d 0-1024 -p "$1"
+}
+
+function stop_server() {
+    sleep 0.5 # just to make sure all the fds could be closed
+    kill -0 "$1" # assert server is still running
+    kill "$1" # tell server to shut down gracefully
+    for f in $(seq 20); do
+        if ! kill -0 "$1" 2> /dev/null; then
+            break # good, dead
+        fi
+        ps auxw | grep "$1" || true
+        sleep 0.1
+    done
+    if kill -0 "$1" 2> /dev/null; then
+        fail "server $1 still running"
+    fi
+}
+
+# Simple thing to do. Start the server in the background.
+swift build
+"$(swift build --show-bin-path)/NIOHTTP2Server" 127.0.0.1 8888 &
+SERVER_PID=$!
+echo "$SERVER_PID"
+
+# Wait for the server to bind a socket.
+worked=false
+for f in $(seq 20); do
+    port=$(server_lsof "$SERVER_PID" | grep -Eo 'TCP .*:[0-9]+ ' | grep -Eo '[0-9]{4,5} ' | tr -d ' ' || true)
+    if [[ -n "$port" ]]; then
+	worked=true
+	break
+    else
+	sleep 0.1 # wait for the socket to be bound
+    fi
+done
+"$worked" || fail "Could not reach server 2s after lauching..."
+
+# Run h2spec
+h2spec -p 8888
+
+stop_server "$SERVER_PID"


### PR DESCRIPTION
Motivation:

When we get around to it we should aim for our example server to pass
h2spec with flying colours. We aren't there yet, but it's helpful to
be able to run h2spec easily.

Modifications:

Add a docker-compose recipe for running h2spec.

Result:

It'll be easier to run h2spec.