### PR TITLE
update to latest NIO 2 code

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -90,55 +90,55 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
         self.initialSettings = initialSettings
     }
 
-    public func handlerAdded(ctx: ChannelHandlerContext) {
-        self.frameDecoder = HTTP2FrameDecoder(allocator: ctx.channel.allocator, expectClientMagic: self.mode == .server)
-        self.frameEncoder = HTTP2FrameEncoder(allocator: ctx.channel.allocator)
-        self.writeBuffer = ctx.channel.allocator.buffer(capacity: 128)
+    public func handlerAdded(context: ChannelHandlerContext) {
+        self.frameDecoder = HTTP2FrameDecoder(allocator: context.channel.allocator, expectClientMagic: self.mode == .server)
+        self.frameEncoder = HTTP2FrameEncoder(allocator: context.channel.allocator)
+        self.writeBuffer = context.channel.allocator.buffer(capacity: 128)
 
-        if ctx.channel.isActive {
-            self.writeAndFlushPreamble(ctx: ctx)
+        if context.channel.isActive {
+            self.writeAndFlushPreamble(context: context)
         }
     }
 
-    public func channelActive(ctx: ChannelHandlerContext) {
-        self.writeAndFlushPreamble(ctx: ctx)
-        ctx.fireChannelActive()
+    public func channelActive(context: ChannelHandlerContext) {
+        self.writeAndFlushPreamble(context: context)
+        context.fireChannelActive()
     }
 
-    public func channelInactive(ctx: ChannelHandlerContext) {
+    public func channelInactive(context: ChannelHandlerContext) {
         self.channelClosed = true
-        ctx.fireChannelInactive()
+        context.fireChannelInactive()
     }
 
-    public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var data = self.unwrapInboundIn(data)
         self.frameDecoder.append(bytes: &data)
 
         // Before we go in here we need to deliver any pending user events. This is because
         // we may have been called re-entrantly.
-        self.processPendingUserEvents(ctx: ctx)
+        self.processPendingUserEvents(context: context)
 
         // We parse eagerly to attempt to give back buffers to the reading channel wherever possible.
-        self.frameDecodeLoop(ctx: ctx)
+        self.frameDecodeLoop(context: context)
     }
 
-    public func channelReadComplete(ctx: ChannelHandlerContext) {
+    public func channelReadComplete(context: ChannelHandlerContext) {
         if self.wroteAutomaticFrame {
             self.wroteAutomaticFrame = false
-            ctx.flush()
+            context.flush()
         }
 
-        ctx.fireChannelReadComplete()
+        context.fireChannelReadComplete()
     }
 
-    public func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let frame = self.unwrapOutboundIn(data)
-        self.processOutboundFrame(ctx: ctx, frame: frame, promise: promise)
+        self.processOutboundFrame(context: context, frame: frame, promise: promise)
     }
 
-    public func flush(ctx: ChannelHandlerContext) {
+    public func flush(context: ChannelHandlerContext) {
         self.wroteAutomaticFrame = false
-        ctx.flush()
+        context.flush()
     }
 }
 
@@ -146,26 +146,26 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
 /// Inbound frame handling.
 extension NIOHTTP2Handler {
     /// Spins over the frame decoder parsing frames and sending them down the channel pipeline.
-    private func frameDecodeLoop(ctx: ChannelHandlerContext) {
-        while !self.channelClosed, let (nextFrame, length) = self.decodeFrame(ctx: ctx) {
-            guard case .continue = self.processFrame(nextFrame, flowControlledLength: length, ctx: ctx) else {
+    private func frameDecodeLoop(context: ChannelHandlerContext) {
+        while !self.channelClosed, let (nextFrame, length) = self.decodeFrame(context: context) {
+            guard case .continue = self.processFrame(nextFrame, flowControlledLength: length, context: context) else {
                 break
             }
         }
     }
 
     /// Decodes a single frame. Returns `nil` if there is no frame to process, or if an error occurred.
-    private func decodeFrame(ctx: ChannelHandlerContext) -> (HTTP2Frame, flowControlledLength: Int)? {
+    private func decodeFrame(context: ChannelHandlerContext) -> (HTTP2Frame, flowControlledLength: Int)? {
         do {
             return try self.frameDecoder.nextFrame()
         } catch InternalError.codecError(let code) {
-            self.inboundConnectionErrorTriggered(ctx: ctx, underlyingError: NIOHTTP2Errors.UnableToParseFrame(), reason: code)
+            self.inboundConnectionErrorTriggered(context: context, underlyingError: NIOHTTP2Errors.UnableToParseFrame(), reason: code)
             return nil
         } catch is NIOHTTP2Errors.BadClientMagic {
-            self.inboundConnectionErrorTriggered(ctx: ctx, underlyingError: NIOHTTP2Errors.BadClientMagic(), reason: .protocolError)
+            self.inboundConnectionErrorTriggered(context: context, underlyingError: NIOHTTP2Errors.BadClientMagic(), reason: .protocolError)
             return nil
         } catch {
-            self.inboundConnectionErrorTriggered(ctx: ctx, underlyingError: error, reason: .internalError)
+            self.inboundConnectionErrorTriggered(context: context, underlyingError: error, reason: .internalError)
             return nil
         }
     }
@@ -175,7 +175,7 @@ extension NIOHTTP2Handler {
         case stop
     }
 
-    private func processFrame(_ frame: HTTP2Frame, flowControlledLength: Int, ctx: ChannelHandlerContext) -> FrameProcessResult {
+    private func processFrame(_ frame: HTTP2Frame, flowControlledLength: Int, context: ChannelHandlerContext) -> FrameProcessResult {
         // All frames have one basic processing step: do we send them on, or drop them?
         // Some frames have further processing steps, regarding triggering user events or other operations.
         // Here we centralise this processing.
@@ -201,7 +201,7 @@ extension NIOHTTP2Handler {
                 self.writeBuffer.clear()
                 var responseFrame = frame
                 responseFrame.flags.insert(.ack)
-                self.encodeAndWriteFrame(ctx: ctx, frame: responseFrame, promise: nil)
+                self.encodeAndWriteFrame(context: context, frame: responseFrame, promise: nil)
                 self.wroteAutomaticFrame = true
             }
         case .priority:
@@ -221,7 +221,7 @@ extension NIOHTTP2Handler {
                 break
             case .sendAck:
                 self.writeBuffer.clear()
-                self.encodeAndWriteFrame(ctx: ctx, frame: HTTP2Frame(streamID: .rootStream, flags: .ack, payload: .settings([])), promise: nil)
+                self.encodeAndWriteFrame(context: context, frame: HTTP2Frame(streamID: .rootStream, flags: .ack, payload: .settings([])), promise: nil)
                 self.wroteAutomaticFrame = true
             }
 
@@ -235,55 +235,55 @@ extension NIOHTTP2Handler {
         switch result.result {
         case .succeed:
             // Frame is good, we can pass it on.
-            ctx.fireChannelRead(self.wrapInboundOut(frame))
+            context.fireChannelRead(self.wrapInboundOut(frame))
             returnValue = .continue
         case .ignoreFrame:
             // Frame is good but no action needs to be taken.
             returnValue = .continue
         case .connectionError(let underlyingError, let errorCode):
             // We should stop parsing on received connection errors, the connection is going away anyway.
-            self.inboundConnectionErrorTriggered(ctx: ctx, underlyingError: underlyingError, reason: errorCode)
+            self.inboundConnectionErrorTriggered(context: context, underlyingError: underlyingError, reason: errorCode)
             returnValue = .stop
         case .streamError(let streamID, let underlyingError, let errorCode):
             // We can continue parsing on stream errors in most cases, the frame is just ignored.
-            self.inboundStreamErrorTriggered(ctx: ctx, streamID: streamID, underlyingError: underlyingError, reason: errorCode)
+            self.inboundStreamErrorTriggered(context: context, streamID: streamID, underlyingError: underlyingError, reason: errorCode)
             returnValue = .continue
         }
 
         // Before we return the loop we process any user events that are currently pending.
         // These will likely only be ones that were generated now.
-        self.processPendingUserEvents(ctx: ctx)
+        self.processPendingUserEvents(context: context)
 
         return returnValue
     }
 
     /// A connection error was hit while receiving a frame.
-    private func inboundConnectionErrorTriggered(ctx: ChannelHandlerContext, underlyingError: Error, reason: HTTP2ErrorCode) {
+    private func inboundConnectionErrorTriggered(context: ChannelHandlerContext, underlyingError: Error, reason: HTTP2ErrorCode) {
         // A connection error brings the entire connection down. We attempt to write a GOAWAY frame, and then report this
         // error. It's possible that we'll be unable to write the GOAWAY frame, but that also just logs the error.
         // Because we don't know what data the user handled before we got this, we propose that they may have seen all of it.
         // The user may choose to fire a more specific error if they wish.
         let goAwayFrame = HTTP2Frame(streamID: .rootStream, payload: .goAway(lastStreamID: .maxID, errorCode: reason, opaqueData: nil))
-        self.processOutboundFrame(ctx: ctx, frame: goAwayFrame, promise: nil)
-        ctx.flush()
-        ctx.fireErrorCaught(underlyingError)
+        self.processOutboundFrame(context: context, frame: goAwayFrame, promise: nil)
+        context.flush()
+        context.fireErrorCaught(underlyingError)
     }
 
     /// A stream error was hit while receiving a frame.
-    private func inboundStreamErrorTriggered(ctx: ChannelHandlerContext, streamID: HTTP2StreamID, underlyingError: Error, reason: HTTP2ErrorCode) {
+    private func inboundStreamErrorTriggered(context: ChannelHandlerContext, streamID: HTTP2StreamID, underlyingError: Error, reason: HTTP2ErrorCode) {
         // A stream error brings down a single stream, causing a RST_STREAM frame. We attempt to write this, and then report
         // the error. It's possible that we'll be unable to write this, which will likely escalate this error, but that's
         // the user's issue.
         let rstStreamFrame = HTTP2Frame(streamID: streamID, payload: .rstStream(reason))
-        self.processOutboundFrame(ctx: ctx, frame: rstStreamFrame, promise: nil)
-        ctx.flush()
-        ctx.fireErrorCaught(underlyingError)
+        self.processOutboundFrame(context: context, frame: rstStreamFrame, promise: nil)
+        context.flush()
+        context.fireErrorCaught(underlyingError)
     }
 
     /// Emit any pending user events.
-    private func processPendingUserEvents(ctx: ChannelHandlerContext) {
+    private func processPendingUserEvents(context: ChannelHandlerContext) {
         for event in self.inboundEventBuffer {
-            ctx.fireUserInboundEventTriggered(event)
+            context.fireUserInboundEventTriggered(event)
         }
     }
 }
@@ -292,19 +292,19 @@ extension NIOHTTP2Handler {
 /// Outbound frame handling.
 extension NIOHTTP2Handler {
     /// Issues the preamble when necessary.
-    private func writeAndFlushPreamble(ctx: ChannelHandlerContext) {
+    private func writeAndFlushPreamble(context: ChannelHandlerContext) {
         if case .client = self.mode {
             self.writeBuffer.clear()
             self.writeBuffer.writeStaticString(NIOHTTP2Handler.clientMagic)
-            ctx.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: nil)
+            context.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: nil)
         }
 
         let initialSettingsFrame = HTTP2Frame(streamID: .rootStream, payload: .settings(self.initialSettings))
-        self.processOutboundFrame(ctx: ctx, frame: initialSettingsFrame, promise: nil)
-        ctx.flush()
+        self.processOutboundFrame(context: context, frame: initialSettingsFrame, promise: nil)
+        context.flush()
     }
 
-    private func processOutboundFrame(ctx: ChannelHandlerContext, frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {
+    private func processOutboundFrame(context: ChannelHandlerContext, frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {
         let result: StateMachineResultWithEffect
 
         switch frame.payload {
@@ -338,45 +338,45 @@ extension NIOHTTP2Handler {
         case .ignoreFrame:
             preconditionFailure("Cannot be asked to ignore outbound frames.")
         case .connectionError(let underlyingError, _), .streamError(_, let underlyingError, _):
-            self.outboundErrorTriggered(ctx: ctx, promise: promise, underlyingError: underlyingError)
+            self.outboundErrorTriggered(context: context, promise: promise, underlyingError: underlyingError)
             return
         case .succeed:
             self.writeBuffer.clear()
-            self.encodeAndWriteFrame(ctx: ctx, frame: frame, promise: promise)
+            self.encodeAndWriteFrame(context: context, frame: frame, promise: promise)
         }
 
         // This may have caused user events that need to be fired, so do so.
-        self.processPendingUserEvents(ctx: ctx)
+        self.processPendingUserEvents(context: context)
     }
 
     /// Encodes a frame and writes it to the network.
-    private func encodeAndWriteFrame(ctx: ChannelHandlerContext, frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {
+    private func encodeAndWriteFrame(context: ChannelHandlerContext, frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {
         let extraFrameData: IOData?
 
         do {
             extraFrameData = try self.frameEncoder.encode(frame: frame, to: &self.writeBuffer)
         } catch InternalError.codecError {
-            self.outboundErrorTriggered(ctx: ctx, promise: promise, underlyingError: NIOHTTP2Errors.UnableToSerializeFrame())
+            self.outboundErrorTriggered(context: context, promise: promise, underlyingError: NIOHTTP2Errors.UnableToSerializeFrame())
             return
         } catch {
-            self.outboundErrorTriggered(ctx: ctx, promise: promise, underlyingError: error)
+            self.outboundErrorTriggered(context: context, promise: promise, underlyingError: error)
             return
         }
 
         // Ok, if we got here we're good to send data. We want to attach the promise to the latest write, not
         // always the frame header.
         if let extraFrameData = extraFrameData {
-            ctx.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: nil)
-            ctx.write(self.wrapOutboundOut(extraFrameData), promise: promise)
+            context.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: nil)
+            context.write(self.wrapOutboundOut(extraFrameData), promise: promise)
         } else {
-            ctx.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: promise)
+            context.write(self.wrapOutboundOut(.byteBuffer(self.writeBuffer)), promise: promise)
         }
     }
 
     /// A stream or connection error was hit while attempting to send a frame.
-    private func outboundErrorTriggered(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?, underlyingError: Error) {
+    private func outboundErrorTriggered(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?, underlyingError: Error) {
         promise?.fail(underlyingError)
-        ctx.fireErrorCaught(underlyingError)
+        context.fireErrorCaught(underlyingError)
     }
 }
 

--- a/Sources/NIOHTTP2Server/main.swift
+++ b/Sources/NIOHTTP2Server/main.swift
@@ -24,23 +24,23 @@ final class HTTP1TestServer: ChannelInboundHandler {
     public typealias InboundIn = HTTPServerRequestPart
     public typealias OutboundOut = HTTPServerResponsePart
 
-    public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         guard case .end = self.unwrapInboundIn(data) else {
             return
         }
 
-        ctx.channel.getOption(HTTP2StreamChannelOptions.streamID).flatMap { (streamID) -> EventLoopFuture<Void> in
+        context.channel.getOption(HTTP2StreamChannelOptions.streamID).flatMap { (streamID) -> EventLoopFuture<Void> in
             var headers = HTTPHeaders()
             headers.add(name: "content-length", value: "5")
             headers.add(name: "x-stream-id", value: String(Int(streamID)))
-            ctx.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.head(HTTPResponseHead(version: .init(major: 2, minor: 0), status: .ok, headers: headers))), promise: nil)
+            context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.head(HTTPResponseHead(version: .init(major: 2, minor: 0), status: .ok, headers: headers))), promise: nil)
 
-            var buffer = ctx.channel.allocator.buffer(capacity: 12)
+            var buffer = context.channel.allocator.buffer(capacity: 12)
             buffer.writeStaticString("hello")
-            ctx.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
-            return ctx.channel.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)))
+            context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
+            return context.channel.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)))
         }.whenComplete { _ in
-            ctx.close(promise: nil)
+            context.close(promise: nil)
         }
     }
 }
@@ -49,9 +49,9 @@ final class HTTP1TestServer: ChannelInboundHandler {
 final class ErrorHandler: ChannelInboundHandler {
     typealias InboundIn = Never
     
-    func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
         print("Server received error: \(error)")
-        ctx.close(promise: nil)
+        context.close(promise: nil)
     }
 }
 

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
@@ -25,9 +25,9 @@ class FailOnWriteHandler: ChannelOutboundHandler {
     typealias OutboundIn = Never
     typealias OutboundOut = Never
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         XCTFail("Write received")
-        ctx.write(data, promise: promise)
+        context.write(data, promise: promise)
     }
 }
 

--- a/Tests/NIOHTTP2Tests/FlowControlHandlerTests.swift
+++ b/Tests/NIOHTTP2Tests/FlowControlHandlerTests.swift
@@ -30,13 +30,13 @@ class DataFrameCatcher: ChannelOutboundHandler {
 
     var writtenFrames: [HTTP2Frame] = []
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let frame = self.unwrapOutboundIn(data)
         self.writtenFrames.append(frame)
 
         switch frame.payload {
         case .data(let data):
-            ctx.write(self.wrapOutboundOut(data), promise: promise)
+            context.write(self.wrapOutboundOut(data), promise: promise)
         default:
             promise?.succeed(())
         }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -43,13 +43,13 @@ final class FrameExpecter: ChannelInboundHandler {
         self.expectedFrames = expectedFrames
     }
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         XCTAssertFalse(self.inactive)
         let frame = self.unwrapInboundIn(data)
         self.actualFrames.append(frame)
     }
 
-    func channelInactive(ctx: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
         XCTAssertFalse(self.inactive)
         self.inactive = true
 
@@ -72,15 +72,15 @@ final class FrameWriteRecorder: ChannelOutboundHandler {
     var flushedWrites: [HTTP2Frame] = []
     private var unflushedWrites: [HTTP2Frame] = []
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         self.unflushedWrites.append(self.unwrapOutboundIn(data))
-        ctx.write(data, promise: promise)
+        context.write(data, promise: promise)
     }
 
-    func flush(ctx: ChannelHandlerContext) {
+    func flush(context: ChannelHandlerContext) {
         self.flushedWrites.append(contentsOf: self.unflushedWrites)
         self.unflushedWrites = []
-        ctx.flush()
+        context.flush()
     }
 }
 
@@ -91,7 +91,7 @@ final class InboundFrameRecorder: ChannelInboundHandler {
 
     var receivedFrames: [HTTP2Frame] = []
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         self.receivedFrames.append(self.unwrapInboundIn(data))
     }
 }
@@ -104,7 +104,7 @@ final class ReadCounter: ChannelOutboundHandler {
 
     var readCount = 0
 
-    func read(ctx: ChannelHandlerContext) {
+    func read(context: ChannelHandlerContext) {
         readCount += 1
     }
 }
@@ -121,7 +121,7 @@ final class HandlerRemovedHandler: ChannelInboundHandler {
         self.removedPromise = removedPromise
     }
 
-    func handlerRemoved(ctx: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         self.removedPromise.succeed(())
     }
 }
@@ -137,13 +137,13 @@ final class ActiveHandler: ChannelInboundHandler {
         self.activatedPromise = activatedPromise
     }
 
-    func handlerAdded(ctx: ChannelHandlerContext) {
-        if ctx.channel.isActive {
+    func handlerAdded(context: ChannelHandlerContext) {
+        if context.channel.isActive {
             self.activatedPromise.succeed(())
         }
     }
 
-    func channelActive(ctx: ChannelHandlerContext) {
+    func channelActive(context: ChannelHandlerContext) {
         self.activatedPromise.succeed(())
     }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
@@ -70,9 +70,9 @@ final class PromiseRecorder: ChannelOutboundHandler {
 
     var recordedPromises: [EventLoopPromise<Void>?] = []
 
-    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         recordedPromises.append(promise)
-        ctx.write(data, promise: promise)
+        context.write(data, promise: promise)
     }
 }
 

--- a/Tests/NIOHTTP2Tests/ReentrancyTests.swift
+++ b/Tests/NIOHTTP2Tests/ReentrancyTests.swift
@@ -31,14 +31,14 @@ final class ReenterOnReadHandler: ChannelInboundHandler {
         self.reEnterCallback = reEnterCallback
     }
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         guard self.shouldReenter else {
-            ctx.fireChannelRead(data)
+            context.fireChannelRead(data)
             return
         }
         self.shouldReenter = false
-        ctx.fireChannelRead(data)
-        self.reEnterCallback(ctx.pipeline)
+        context.fireChannelRead(data)
+        self.reEnterCallback(context.pipeline)
     }
 }
 


### PR DESCRIPTION
Motivation:

Code should compile and have the latest NIO 2 API.

Modifications:

- rename `ctx` to `context`

Result:

compiles again