### PR TITLE
Remove flushability of streams when stream window size is set to zero.

### DIFF
--- a/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
+++ b/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
@@ -103,6 +103,9 @@ internal struct OutboundFlowControlBuffer {
             if $0.hasPendingData && !hadData {
                 assert(!self.flushableStreams.contains($0.streamID))
                 self.flushableStreams.insert($0.streamID)
+            } else if !$0.hasPendingData && hadData {
+                assert(self.flushableStreams.contains($0.streamID))
+                self.flushableStreams.remove($0.streamID)
             }
         }
     }

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
@@ -37,6 +37,7 @@ extension OutboundFlowControlBufferTests {
                 ("testWritesForUnknownStreamsFail", testWritesForUnknownStreamsFail),
                 ("testOverlargeFramesAreSplitOnMaxFrameSizeByteBuffer", testOverlargeFramesAreSplitOnMaxFrameSizeByteBuffer),
                 ("testOverlargeFramesAreSplitOnMaxFrameSizeFileRegion", testOverlargeFramesAreSplitOnMaxFrameSizeFileRegion),
+                ("testChangingStreamWindowSizeToZeroAndBack", testChangingStreamWindowSizeToZeroAndBack),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When setting the stream window size for a stream which had data but
couldn't write it (because of a zero window size) the stream would be
marked as flushable. Setting the window size to zero again would not
mark it as unflushable. On the following window (non-zero) resize it
would be marked as flushable again. However, since this is preceeded by
an assertion that it wasn't already marked as flushable it would cause a
crash.

Modifications:

- Mark the stream as unflushable if it previously had data which it
  couldn't write.

Result:

Fewer crashes