### PR TITLE
Clean up new NIO breaking changes.

### DIFF
--- a/Sources/NIOHPACK/HPACKDecoder.swift
+++ b/Sources/NIOHPACK/HPACKDecoder.swift
@@ -200,8 +200,9 @@ public struct HPACKDecoder {
         valueLen = try self.readEncodedString(from: &buffer)
         
         if addToIndex {
-            let nameView = self.decodeBuffer.viewBytes(at: nameStart, length: nameLen)
-            let valueView = self.decodeBuffer.viewBytes(at: nameStart + nameLen, length: valueLen)
+            // These views are safe to force-unwrap as we have just written these bytes into the decode buffer.
+            let nameView = self.decodeBuffer.viewBytes(at: nameStart, length: nameLen)!
+            let valueView = self.decodeBuffer.viewBytes(at: nameStart + nameLen, length: valueLen)!
             
             try headerTable.add(headerNamed: nameView, value: valueView)
         }
@@ -226,7 +227,8 @@ public struct HPACKDecoder {
         if huffmanEncoded {
             outputLength = try buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: len, into: &self.decodeBuffer)
         } else {
-            outputLength = self.decodeBuffer.writeBytes(buffer.viewBytes(at: buffer.readerIndex, length: len))
+            // This force-unwrap is safe as we have checked above that len is less than or equal to the buffer readable bytes.
+            outputLength = self.decodeBuffer.writeBytes(buffer.viewBytes(at: buffer.readerIndex, length: len)!)
         }
         
         buffer.moveReaderIndex(forwardBy: len)

--- a/Sources/NIOHPACK/HuffmanCoding.swift
+++ b/Sources/NIOHPACK/HuffmanCoding.swift
@@ -189,8 +189,9 @@ extension ByteBuffer {
         var state: UInt8 = 0
         var acceptable = false
         let start = output.writerIndex
-        
-        for ch in self.viewBytes(at: index, length: length) {
+
+        // We force-unwrap here to crash if we attempt to decode out of bounds.
+        for ch in self.viewBytes(at: index, length: length)! {
             var t = decoderTable[state: state, nybble: ch >> 4]
             if t.flags.contains(.failure) {
                 throw HuffmanDecodeError.InvalidState()

--- a/Sources/NIOHPACK/RingBufferView.swift
+++ b/Sources/NIOHPACK/RingBufferView.swift
@@ -23,14 +23,15 @@ extension ByteBufferView {
 
 extension StringRing {
     func viewBytes(at index: Int, length: Int) -> ByteBufferView {
+        // We force unwrap in here as the backing buffer of a StringRing is always entirely readable.
         let endIndex = index + length
         if endIndex < self.capacity {
-            return self._storage.viewBytes(at: index, length: length)
+            return self._storage.viewBytes(at: index, length: length)!
         } else {
             // need to allocate a copy to get contiguous access :(
             // we know this will work, because we're constraining the bounds
             var buf = self._storage.getSlice(at: index, length: self._storage.capacity - index)!
-            _ = buf.writeBytes(self._storage.viewBytes(at: 0, length: length - buf.readableBytes))
+            _ = buf.writeBytes(self._storage.viewBytes(at: 0, length: length - buf.readableBytes)!)
             return buf.readableBytesView
         }
     }

--- a/Sources/NIOHPACK/StringRing.swift
+++ b/Sources/NIOHPACK/StringRing.swift
@@ -36,10 +36,12 @@ struct StringRing {
         case (0, _):
             // indices don't need to change
             self._storage.reserveCapacity(capacity)
+            self._storage.markAllReadable()
             
         case let (r, w) where r == w:
             // make a new store and zero indices
             self._storage.reserveCapacity(capacity)
+            self._storage.markAllReadable()
             self.moveHead(to: 0)
             self.moveTail(to: 0)
             
@@ -48,7 +50,8 @@ struct StringRing {
             var newBytes = self._storage
             newBytes.clear()
             newBytes.reserveCapacity(capacity)
-            _ = newBytes.writeBytes(self._storage.viewBytes(at: r, length: w - r))
+            // This force-unwrap is safe as the StringRing backing buffer is always entirely readable.
+            _ = newBytes.writeBytes(self._storage.viewBytes(at: r, length: w - r)!)
             self._storage = newBytes
             self._storage.markAllReadable()
             self.moveHead(to: 0)
@@ -59,8 +62,10 @@ struct StringRing {
             var newBytes = self._storage
             newBytes.clear()
             newBytes.reserveCapacity(capacity)
-            newBytes.writeBytes(self._storage.viewBytes(at: r, length: self._storage.capacity - r))
-            _ = newBytes.writeBytes(self._storage.viewBytes(at: 0, length: w))
+            // This force-unwrap is safe as the StringRing backing buffer is always entirely readable.
+            newBytes.writeBytes(self._storage.viewBytes(at: r, length: self._storage.capacity - r)!)
+            // This force-unwrap is safe as the StringRing backing buffer is always entirely readable.
+            _ = newBytes.writeBytes(self._storage.viewBytes(at: 0, length: w)!)
             self.moveHead(to: 0)
             self.moveTail(to: self._storage.capacity - r + w)
             self._storage = newBytes

--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -430,7 +430,7 @@ fileprivate extension HTTPHeaders {
         if authority.count > 0 {
             precondition(authority.count == 1)
             headers.remove(name: "host")
-            self.add(name: ":authority", value: authority[0])
+            self.add(name: ":authority", value: String(authority[0]))
         }
 
         headers.forEach { self.add(name: $0.name, value: $0.value) }

--- a/Tests/NIOHPACKTests/IntegerCodingTests.swift
+++ b/Tests/NIOHPACKTests/IntegerCodingTests.swift
@@ -26,7 +26,7 @@ class IntegerCodingTests : XCTestCase {
         var data = [UInt8]()
         scratchBuffer.clear()
         let len = NIOHPACK.encodeInteger(value, to: &scratchBuffer, prefix: prefix)
-        data.append(contentsOf: scratchBuffer.viewBytes(at: 0, length: len))
+        data.append(contentsOf: scratchBuffer.viewBytes(at: 0, length: len)!)
         return data
     }
     


### PR DESCRIPTION
Motivation:

Code should be able to compile.

Modifications:

- Add necessary force-unwraps to ByteBufferViews.
- Remove use of now-dead HTTPHeaders storage and indices API.

Result:

No compile errors.