### PR TITLE
Remove crashers from HTTP2ToHTTP1Codecs.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -153,6 +153,43 @@ public enum NIOHTTP2Errors {
     public struct UnableToParseFrame: NIOHTTP2Error {
         public init() { }
     }
+
+    /// A pseudo-header field is missing.
+    public struct MissingPseudoHeader: NIOHTTP2Error {
+        public var name: String
+
+        public init(_ name: String) {
+            self.name = name
+        }
+    }
+
+    /// A pseudo-header field has been duplicated.
+    public struct DuplicatePseudoHeader: NIOHTTP2Error {
+        public var name: String
+
+        public init(_ name: String) {
+            self.name = name
+        }
+    }
+
+    /// An outbound request was about to be sent, but does not contain a Host header.
+    public struct MissingHostHeader: NIOHTTP2Error {
+        public init() { }
+    }
+
+    /// An outbound request was about to be sent, but it contains a duplicated Host header.
+    public struct DuplicateHostHeader: NIOHTTP2Error {
+        public init() { }
+    }
+
+    /// A :status header was received with an invalid value.
+    public struct InvalidStatusValue: NIOHTTP2Error {
+        var value: String
+
+        public init(_ value: String) {
+            self.value = value
+        }
+    }
 }
 
 

--- a/Sources/NIOHTTP2Server/main.swift
+++ b/Sources/NIOHTTP2Server/main.swift
@@ -102,6 +102,8 @@ let bootstrap = ServerBootstrap(group: group)
         return channel.configureHTTP2Pipeline(mode: .server) { (streamChannel, streamID) -> EventLoopFuture<Void> in
             return streamChannel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).flatMap { () -> EventLoopFuture<Void> in
                 streamChannel.pipeline.addHandler(HTTP1TestServer())
+            }.flatMap { () -> EventLoopFuture<Void> in
+                streamChannel.pipeline.addHandler(ErrorHandler())
             }
         }.flatMap { (_: HTTP2StreamMultiplexer) in
             return channel.pipeline.addHandler(ErrorHandler())

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
@@ -40,6 +40,19 @@ extension HTTP2ToHTTP1CodecTests {
                 ("testRequestWithoutTrailers", testRequestWithoutTrailers),
                 ("testResponseWith100BlocksClientSide", testResponseWith100BlocksClientSide),
                 ("testPassingPromisesThroughWritesOnClient", testPassingPromisesThroughWritesOnClient),
+                ("testReceiveRequestWithoutMethod", testReceiveRequestWithoutMethod),
+                ("testReceiveRequestWithDuplicateMethod", testReceiveRequestWithDuplicateMethod),
+                ("testReceiveRequestWithoutPath", testReceiveRequestWithoutPath),
+                ("testReceiveRequestWithDuplicatePath", testReceiveRequestWithDuplicatePath),
+                ("testReceiveRequestWithoutAuthority", testReceiveRequestWithoutAuthority),
+                ("testReceiveRequestWithDuplicateAuthority", testReceiveRequestWithDuplicateAuthority),
+                ("testReceiveRequestWithoutScheme", testReceiveRequestWithoutScheme),
+                ("testReceiveRequestWithDuplicateScheme", testReceiveRequestWithDuplicateScheme),
+                ("testReceiveResponseWithoutStatus", testReceiveResponseWithoutStatus),
+                ("testReceiveResponseWithDuplicateStatus", testReceiveResponseWithDuplicateStatus),
+                ("testReceiveResponseWithNonNumericalStatus", testReceiveResponseWithNonNumericalStatus),
+                ("testSendRequestWithoutHost", testSendRequestWithoutHost),
+                ("testSendRequestWithDuplicateHost", testSendRequestWithDuplicateHost),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
@@ -451,4 +451,193 @@ final class HTTP2ToHTTP1CodecTests: XCTestCase {
 
         XCTAssertNoThrow(try self.channel.finish())
     }
+
+    func testReceiveRequestWithoutMethod() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":path", "/post"), (":scheme", "https"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingPseudoHeader, NIOHTTP2Errors.MissingPseudoHeader(":method"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithDuplicateMethod() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":path", "/post"), (":method", "GET"), (":method", "GET"), (":scheme", "https"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicatePseudoHeader, NIOHTTP2Errors.DuplicatePseudoHeader(":method"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithoutPath() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":method", "GET"), (":scheme", "https"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingPseudoHeader, NIOHTTP2Errors.MissingPseudoHeader(":path"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithDuplicatePath() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":path", "/post"), (":path", "/post"), (":method", "GET"), (":scheme", "https"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicatePseudoHeader, NIOHTTP2Errors.DuplicatePseudoHeader(":path"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithoutAuthority() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":method", "GET"), (":scheme", "https"), (":path", "/post"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingPseudoHeader, NIOHTTP2Errors.MissingPseudoHeader(":authority"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithDuplicateAuthority() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":path", "/post"), (":method", "GET"), (":scheme", "https"), (":authority", "example.org"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicatePseudoHeader, NIOHTTP2Errors.DuplicatePseudoHeader(":authority"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithoutScheme() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":method", "GET"), (":authority", "example.org"), (":path", "/post"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingPseudoHeader, NIOHTTP2Errors.MissingPseudoHeader(":scheme"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveRequestWithDuplicateScheme() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":path", "/post"), (":method", "GET"), (":scheme", "https"), (":scheme", "https"), (":authority", "example.org"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicatePseudoHeader, NIOHTTP2Errors.DuplicatePseudoHeader(":scheme"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveResponseWithoutStatus() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https)).wait())
+
+        // A basic response.
+        let requestHeaders = HPACKHeaders([("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingPseudoHeader, NIOHTTP2Errors.MissingPseudoHeader(":status"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveResponseWithDuplicateStatus() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https)).wait())
+
+        // A basic request.
+        let requestHeaders = HPACKHeaders([(":status", "200"), (":status", "404"), ("other", "header")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicatePseudoHeader, NIOHTTP2Errors.DuplicatePseudoHeader(":status"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testReceiveResponseWithNonNumericalStatus() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https)).wait())
+
+        // A basic response.
+        let requestHeaders = HPACKHeaders([(":status", "captivating")])
+        XCTAssertThrowsError(try self.channel.writeInbound(HTTP2Frame(streamID: streamID, payload: .headers(.init(headers: requestHeaders))))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.InvalidStatusValue, NIOHTTP2Errors.InvalidStatusValue("captivating"))
+        }
+
+        // We already know there's an error here.
+        _ = try? self.channel.finish()
+    }
+
+    func testSendRequestWithoutHost() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https)).wait())
+
+        // A basic request without Host.
+        let request = HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1), method: .GET, uri: "/"))
+        XCTAssertThrowsError(try self.channel.writeOutbound(request)) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingHostHeader, NIOHTTP2Errors.MissingHostHeader())
+        }
+
+        // We check the channel for an error as the above only checks the promise.
+        XCTAssertThrowsError(try self.channel.finish()) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.MissingHostHeader, NIOHTTP2Errors.MissingHostHeader())
+        }
+    }
+
+    func testSendRequestWithDuplicateHost() throws {
+        let streamID = HTTP2StreamID(1)
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https)).wait())
+
+        // A basic request with too many host headers.
+        var requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/")
+        requestHead.headers.add(name: "Host", value: "fish")
+        requestHead.headers.add(name: "Host", value: "cat")
+        let request = HTTPClientRequestPart.head(requestHead)
+        XCTAssertThrowsError(try self.channel.writeOutbound(request)) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicateHostHeader, NIOHTTP2Errors.DuplicateHostHeader())
+        }
+
+        // We check the channel for an error as the above only checks the promise.
+        XCTAssertThrowsError(try self.channel.finish()) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.DuplicateHostHeader, NIOHTTP2Errors.DuplicateHostHeader())
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

When we spiked out these codecs we were missing a number of error handling
paths, which meant that erroneous input would lead to crashes. While we
don't expect these handlers to have to face that kind of input, we should
still aim to tolerate it where doing so is reasonable.

Modifications:

- Replaced all force unwraps and preconditions with throwing.

Result:

Fewer crashes on bad input.