### PR TITLE
depend on swift-nio 2.0.0 convergence

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1"),
     ],
     targets: [
         .target(name: "NIOHTTP2Server",


### PR DESCRIPTION
This package is currently incompatible with `swift-nio-ssl` and `swift-nio-extras` since it relies on `branch("master")` and the other packages rely on the convergence tag. This PR updates this package to also rely on the convergence tag.