### PR TITLE
Deliver PRIORITY frames to the parent stream.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -49,6 +49,12 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             return
         }
 
+        if case .priority = frame.payload {
+            // Priority frames are special cases, and are always forwarded to the parent stream.
+            context.fireChannelRead(data)
+            return
+        }
+
         if let channel = streams[streamID] {
             channel.receiveInboundFrame(frame)
         } else if case .headers = frame.payload {

--- a/Sources/NIOHTTP2Server/main.swift
+++ b/Sources/NIOHTTP2Server/main.swift
@@ -29,18 +29,22 @@ final class HTTP1TestServer: ChannelInboundHandler {
             return
         }
 
-        context.channel.getOption(HTTP2StreamChannelOptions.streamID).flatMap { (streamID) -> EventLoopFuture<Void> in
-            var headers = HTTPHeaders()
-            headers.add(name: "content-length", value: "5")
-            headers.add(name: "x-stream-id", value: String(Int(streamID)))
-            context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.head(HTTPResponseHead(version: .init(major: 2, minor: 0), status: .ok, headers: headers))), promise: nil)
+        // Insert an event loop tick here. This more accurately represents real workloads in SwiftNIO, which will not
+        // re-entrantly write their response frames.
+        context.eventLoop.execute {
+            context.channel.getOption(HTTP2StreamChannelOptions.streamID).flatMap { (streamID) -> EventLoopFuture<Void> in
+                var headers = HTTPHeaders()
+                headers.add(name: "content-length", value: "5")
+                headers.add(name: "x-stream-id", value: String(Int(streamID)))
+                context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.head(HTTPResponseHead(version: .init(major: 2, minor: 0), status: .ok, headers: headers))), promise: nil)
 
-            var buffer = context.channel.allocator.buffer(capacity: 12)
-            buffer.writeStaticString("hello")
-            context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
-            return context.channel.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)))
-        }.whenComplete { _ in
-            context.close(promise: nil)
+                var buffer = context.channel.allocator.buffer(capacity: 12)
+                buffer.writeStaticString("hello")
+                context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
+                return context.channel.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)))
+            }.whenComplete { _ in
+                context.close(promise: nil)
+            }
         }
     }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -58,6 +58,7 @@ extension HTTP2StreamMultiplexerTests {
                 ("testCreatedChildChannelDoesNotActivateEarly", testCreatedChildChannelDoesNotActivateEarly),
                 ("testCreatedChildChannelActivatesIfParentIsActive", testCreatedChildChannelActivatesIfParentIsActive),
                 ("testInitiatedChildChannelActivates", testInitiatedChildChannelActivates),
+                ("testMultiplexerIgnoresPriorityFrames", testMultiplexerIgnoresPriorityFrames),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -1289,4 +1289,14 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
 
         XCTAssertNoThrow(try self.channel.finish())
     }
+
+    func testMultiplexerIgnoresPriorityFrames() throws {
+        self.channel.addNoOpMultiplexer(mode: .server)
+
+        let simplePingFrame = HTTP2Frame(streamID: 106, payload: .priority(.init(exclusive: true, dependency: .rootStream, weight: 15)))
+        XCTAssertNoThrow(try self.channel.writeInbound(simplePingFrame))
+        XCTAssertNoThrow(try self.channel.assertReceivedFrame().assertFrameMatches(this: simplePingFrame))
+
+        XCTAssertNoThrow(try self.channel.finish())
+    }
 }


### PR DESCRIPTION
Motivation:

PRIORITY frames aren't really sent on a single stream, so we shouldn't
attempt to deliver them to the child channels. Instead, we deliver them on
the parent channel.

Modifications:

Moved PRIORITY frames to the parent channel.

Result:

Less confusion about where PRIORTY frames go