### PR TITLE
Refuse to decode indexed header with index 0.

### DIFF
--- a/Sources/NIOHPACK/HPACKDecoder.swift
+++ b/Sources/NIOHPACK/HPACKDecoder.swift
@@ -120,6 +120,9 @@ public struct HPACKDecoder {
             // 0b1xxxxxxx -- one-bit prefix, seven bits of value
             // purely-indexed header field/value
             let hidx = try buffer.readEncodedInteger(withPrefix: 7)
+            guard hidx != 0 else {
+                throw NIOHPACKErrors.ZeroHeaderIndex()
+            }
             return try self.decodeIndexedHeader(from: Int(hidx))
             
         case let x where x & 0b1100_0000 == 0b0100_0000:

--- a/Sources/NIOHPACK/HPACKErrors.swift
+++ b/Sources/NIOHPACK/HPACKErrors.swift
@@ -102,4 +102,9 @@ public enum NIOHPACKErrors {
     
     /// HPACK encoder asked to append a header without first calling `beginEncoding(allocator:)`.
     public struct EncoderNotStarted : NIOHPACKError {}
+
+    /// HPACK decoder asked to decode an indexed header with index zero.
+    public struct ZeroHeaderIndex: NIOHPACKError {
+        public init() { }
+    }
 }

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -34,6 +34,7 @@ extension HPACKCodingTests {
                 ("testInlineDynamicTableResize", testInlineDynamicTableResize),
                 ("testHPACKHeadersDescription", testHPACKHeadersDescription),
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
+                ("testHPACKHeadersWithZeroIndex", testHPACKHeadersWithZeroIndex),
            ]
    }
 }

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -580,4 +580,13 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqual(headers["set-cookie"], ["abcdefg,hijklmn,opqrst"])
         XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["abcdefg,hijklmn,opqrst"])
     }
+
+    func testHPACKHeadersWithZeroIndex() throws {
+        var request = buffer(wrapping: [0x80])
+        var decoder = HPACKDecoder(allocator: ByteBufferAllocator())
+
+        XCTAssertThrowsError(try decoder.decodeHeaders(from: &request)) { error in
+            XCTAssertEqual(error as? NIOHPACKErrors.ZeroHeaderIndex, NIOHPACKErrors.ZeroHeaderIndex())
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

RFC 7541 is pretty clear that index 0 is no bueno in the indexed
header representation, so we should forbid it.

Modifications:

- Detected attempts to decode index 0.

Result:

Index 0 is now forbidden.