### PR TITLE
Be emphatic about remote peers making mistakes.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -201,4 +201,6 @@ internal enum InternalError: Error {
     case codecError(code: HTTP2ErrorCode)
 }
 
+extension InternalError: Hashable { }
+
 

--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -390,7 +390,7 @@ struct HTTP2FrameDecoder {
             }
             guard state.header.type != 9 else {
                 // we shouldn't see any CONTINUATION frames in this state
-                throw InternalError.codecError(code: .internalError)
+                throw InternalError.codecError(code: .protocolError)
             }
             guard state.accumulatedBytes.readableBytes >= state.header.length else {
                 return .needMoreData

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
@@ -78,6 +78,7 @@ extension HTTP2FrameParserTests {
                 ("testWindowUpdateFrameEncoding", testWindowUpdateFrameEncoding),
                 ("testHeadersContinuationFrameDecoding", testHeadersContinuationFrameDecoding),
                 ("testPushPromiseContinuationFrameDecoding", testPushPromiseContinuationFrameDecoding),
+                ("testUnsolicitedContinuationFrame", testUnsolicitedContinuationFrame),
                 ("testAltServiceFrameDecoding", testAltServiceFrameDecoding),
                 ("testAltServiceFrameDecodingFailure", testAltServiceFrameDecodingFailure),
                 ("testAltServiceFrameEncoding", testAltServiceFrameEncoding),


### PR DESCRIPTION
Motivation:

Receiving a CONTINUATION frame at the wrong stage of a connection is
a PROTOCOL_ERROR, but out of an abundance of caution we were categorising
it as an INTERNAL_ERROR. We should be more confident about our error
categories.

Modifications:

- Changed INTERNAL_ERROR to PROTOCOL_ERROR.
- Added a test for this error case.

Result:

More confidence, more style, more pizazz.