### PR TITLE
CONTINUATION frames must be for the correct stream.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -528,6 +528,11 @@ struct HTTP2FrameDecoder {
                 throw InternalError.codecError(code: .protocolError)
             }
 
+            // This must be for the stream we're buffering header block fragments for, or this is an error.
+            guard header.rawStreamID == state.header.rawStreamID else {
+                throw InternalError.codecError(code: .protocolError)
+            }
+
             self.state = .accumulatingContinuationPayload(AccumulatingContinuationPayloadParserState(fromAccumulatingHeaderBlockFragments: state, continuationHeader: header))
         }
 

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
@@ -79,6 +79,8 @@ extension HTTP2FrameParserTests {
                 ("testHeadersContinuationFrameDecoding", testHeadersContinuationFrameDecoding),
                 ("testPushPromiseContinuationFrameDecoding", testPushPromiseContinuationFrameDecoding),
                 ("testUnsolicitedContinuationFrame", testUnsolicitedContinuationFrame),
+                ("testContinuationFrameStreamZero", testContinuationFrameStreamZero),
+                ("testContinuationFrameWrongStream", testContinuationFrameWrongStream),
                 ("testAltServiceFrameDecoding", testAltServiceFrameDecoding),
                 ("testAltServiceFrameDecodingFailure", testAltServiceFrameDecodingFailure),
                 ("testAltServiceFrameEncoding", testAltServiceFrameEncoding),


### PR DESCRIPTION
Motivation:

We mustn't allow CONTINUATION frames to be sent on invalid stream IDs.

Modifications:

- Police that the CONTINUATION frame raw stream ID matches the previous
    frame's raw stream ID.

Result:

Better conformance to the RFC