### PR TITLE
Correctly notify StreamMultiplexer of SETTINGS changes.

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
@@ -37,6 +37,8 @@ extension HasLocalSettings {
             swap(&temporarySettings, &self.localSettings)
         }
 
+        var effect = NIOHTTP2ConnectionStateChange.LocalSettingsChanged()
+
         do {
             try temporarySettings.receiveSettingsAck { (setting, originalValue, newValue) in
                 switch setting {
@@ -56,6 +58,10 @@ extension HasLocalSettings {
                     try self.streamState.forAllStreams {
                         try $0.localInitialWindowSizeChanged(by: delta)
                     }
+
+                    // We do a += here because the value may change multiple times in one settings block. This way, we correctly
+                    // respect that possibility.
+                    effect.streamWindowSizeChange += Int(delta)
                 case .maxFrameSize:
                     // TODO(cory): Implement!
                     break
@@ -64,7 +70,7 @@ extension HasLocalSettings {
                     return
                 }
             }
-            return .init(result: .succeed, effect: nil)
+            return .init(result: .succeed, effect: .localSettingsChanged(effect))
         } catch {
             return .init(result: .connectionError(underlyingError: error, type: .protocolError), effect: nil)
         }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -464,6 +464,10 @@ extension NIOHTTP2Handler {
             if settingsChange.streamWindowSizeChange != 0 {
                 self.outboundBuffer.initialWindowSizeChanged(settingsChange.streamWindowSizeChange)
             }
+        case .localSettingsChanged(let settingsChange):
+            if settingsChange.streamWindowSizeChange != 0 {
+                self.inboundEventBuffer.pendingUserEvent(NIOHTTP2BulkStreamWindowChangeEvent(delta: settingsChange.streamWindowSizeChange))
+            }
         }
     }
 

--- a/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
+++ b/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
@@ -39,6 +39,9 @@ internal enum NIOHTTP2ConnectionStateChange: Hashable {
     /// The remote peer's settings have been changed.
     case remoteSettingsChanged(RemoteSettingsChanged)
 
+    /// The local peer's settings have been changed.
+    case localSettingsChanged(LocalSettingsChanged)
+
     /// A stream has been created.
     internal struct StreamCreated: Hashable {
         internal var streamID: HTTP2StreamID
@@ -142,6 +145,14 @@ internal enum NIOHTTP2ConnectionStateChange: Hashable {
     /// This object keeps track of the change on all stream window sizes via
     /// SETTINGS frame.
     internal struct RemoteSettingsChanged: Hashable {
+        internal var streamWindowSizeChange: Int = 0
+    }
+
+    /// The local peer's settings have changed in a way that is not trivial to decode.
+    ///
+    /// This object keeps track of the change on all stream window sizes via
+    /// SETTINGS frame.
+    internal struct LocalSettingsChanged: Hashable {
         internal var streamWindowSizeChange: Int = 0
     }
 }

--- a/Sources/NIOHTTP2/HTTP2UserEvents.swift
+++ b/Sources/NIOHTTP2/HTTP2UserEvents.swift
@@ -33,7 +33,7 @@ public struct StreamClosedEvent {
     }
 }
 
-extension StreamClosedEvent: Equatable { }
+extension StreamClosedEvent: Hashable { }
 
 
 /// A `NIOHTTP2WindowUpdatedEvent` is fired whenever a flow control window is changed.
@@ -63,7 +63,7 @@ public struct NIOHTTP2WindowUpdatedEvent {
     }
 }
 
-extension NIOHTTP2WindowUpdatedEvent: Equatable { }
+extension NIOHTTP2WindowUpdatedEvent: Hashable { }
 
 
 /// A `NIOHTTP2StreamCreatedEvent` is fired whenever a HTTP/2 stream is created.
@@ -83,4 +83,19 @@ public struct NIOHTTP2StreamCreatedEvent {
     }
 }
 
-extension NIOHTTP2StreamCreatedEvent: Equatable { }
+extension NIOHTTP2StreamCreatedEvent: Hashable { }
+
+/// A `NIOHTTP2BulkStreamWindowChangeEvent` is fired whenever all of the remote flow control windows for a given stream have been changed.
+///
+/// This occurs when an ACK to a SETTINGS frame is received that changes the value of SETTINGS_INITIAL_WINDOW_SIZE. This is only fired
+/// when the local peer has changed its settings.
+public struct NIOHTTP2BulkStreamWindowChangeEvent {
+    /// The change in the remote stream window sizes.
+    public let delta: Int
+
+    public init(delta: Int) {
+        self.delta = delta
+    }
+}
+
+extension NIOHTTP2BulkStreamWindowChangeEvent: Hashable  { }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -50,6 +50,8 @@ extension SimpleClientServerTests {
                 ("testManyConcurrentInactiveStreams", testManyConcurrentInactiveStreams),
                 ("testBadClientMagic", testBadClientMagic),
                 ("testOpeningWindowsViaSettingsInitialWindowSize", testOpeningWindowsViaSettingsInitialWindowSize),
+                ("testSettingsAckNotifiesAboutChangedFlowControl", testSettingsAckNotifiesAboutChangedFlowControl),
+                ("testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges", testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The StreamMultiplexer and StreamChannels are responsible for sending
WINDOW_UPDATE frames, but they were never told if the user changed the
value of SETTINGS_INITIAL_WINDOW_SIZE. They should be.

Modifications:

- Send user events when SETTINGS_INITIAL_WINDOW_SIZE changes.
- Use those window events to change the target window size in
    HTTP2StreamChannel.
- Keep track of the last stream window size we knew.

Result:

Less chance of flow control mess.