### PR TITLE
update to latest EmbeddedChannel API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.4"),
     ],
     targets: [
         .target(name: "NIOHTTP2Server",

--- a/Tests/NIOHTTP2Tests/ReentrancyTests.swift
+++ b/Tests/NIOHTTP2Tests/ReentrancyTests.swift
@@ -91,7 +91,7 @@ final class ReentrancyTests: XCTestCase {
         XCTAssertNoThrow(try self.serverChannel.pipeline.addHandler(reEntrancyHandler).wait())
 
         // Now we can deliver these bytes.
-        XCTAssertTrue(try self.serverChannel.writeInbound(frameBuffer))
+        XCTAssertTrue(try self.serverChannel.writeInbound(frameBuffer).isFull)
 
         // If this worked, we want to see that the server received SETTINGS, PING, SETTINGS, PING. No other order is
         // ok, no errors should have been hit.

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
@@ -1029,8 +1029,8 @@ class SimpleClientServerTests: XCTestCase {
             XCTFail("No Goaway frame")
         }
 
-        XCTAssertNoThrow(try XCTAssertFalse(self.clientChannel.finish()))
-        XCTAssertNoThrow(try XCTAssertFalse(self.serverChannel.finish()))
+        XCTAssertNoThrow(try XCTAssertTrue(self.clientChannel.finish().isClean))
+        XCTAssertNoThrow(try XCTAssertTrue(self.serverChannel.finish().isClean))
     }
 
     func testOpeningWindowsViaSettingsInitialWindowSize() throws {


### PR DESCRIPTION
Motivation:

EmbeddedChannel's API has changed a litle bit, we should update.

Modifications:

update

Result:

code will continue to work