### PR TITLE
Basic PRIORITY frame validation.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -184,10 +184,20 @@ public enum NIOHTTP2Errors {
 
     /// A :status header was received with an invalid value.
     public struct InvalidStatusValue: NIOHTTP2Error {
-        var value: String
+        public var value: String
 
         public init(_ value: String) {
             self.value = value
+        }
+    }
+
+    /// A priority update was received that would create a PRIORITY cycle.
+    public struct PriorityCycle: NIOHTTP2Error {
+        /// The affected stream ID.
+        public var streamID: HTTP2StreamID
+
+        public init(streamID: HTTP2StreamID) {
+            self.streamID = streamID
         }
     }
 }

--- a/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
+++ b/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
@@ -176,6 +176,20 @@ internal struct OutboundFlowControlBuffer {
 }
 
 
+// MARK: Priority API
+extension OutboundFlowControlBuffer {
+    /// A frame with new priority data has been received that affects prioritisation of outbound frames.
+    internal mutating func priorityUpdate(streamID: HTTP2StreamID, priorityData: HTTP2Frame.StreamPriorityData) throws {
+        // Right now we don't actually do anything with priority information. However, we do want to police some parts of
+        // RFC 7540 § 5.3, where we can, so this hook is already in place for us to extend later.
+        if streamID == priorityData.dependency {
+            // Streams may not depend on themselves!
+            throw NIOHTTP2Errors.PriorityCycle(streamID: streamID)
+        }
+    }
+}
+
+
 private struct StreamFlowControlState {
     let streamID: HTTP2StreamID
     var currentWindowSize: Int

--- a/Sources/NIOHTTP2/OutboundFrameBuffer.swift
+++ b/Sources/NIOHTTP2/OutboundFrameBuffer.swift
@@ -181,6 +181,10 @@ extension CompoundOutboundBuffer {
         self.flowControlBuffer.initialWindowSizeChanged(delta)
     }
 
+    mutating func priorityUpdate(streamID: HTTP2StreamID, priorityData: HTTP2Frame.StreamPriorityData) throws {
+        try self.flowControlBuffer.priorityUpdate(streamID: streamID, priorityData: priorityData)
+    }
+
     var maxFrameSize: Int {
         get {
             return self.flowControlBuffer.maxFrameSize

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
@@ -33,6 +33,7 @@ extension CompoundOutboundBufferTest {
                 ("testFlowControlStreamThrows", testFlowControlStreamThrows),
                 ("testDelayedFlowControlStreamErrors", testDelayedFlowControlStreamErrors),
                 ("testBufferedFrameDrops", testBufferedFrameDrops),
+                ("testRejectsPrioritySelfDependency", testRejectsPrioritySelfDependency),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
@@ -208,6 +208,17 @@ final class CompoundOutboundBufferTest: XCTestCase {
         }
         XCTAssertEqual(results, [true, false, false, false])
     }
+
+    func testRejectsPrioritySelfDependency() {
+        var buffer = CompoundOutboundBuffer(mode: .client, initialMaxOutboundStreams: 1)
+
+        XCTAssertThrowsError(try buffer.priorityUpdate(streamID: 1, priorityData: .init(exclusive: false, dependency: 1, weight: 36))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.PriorityCycle, NIOHTTP2Errors.PriorityCycle(streamID: 1))
+        }
+        XCTAssertThrowsError(try buffer.priorityUpdate(streamID: 1, priorityData: .init(exclusive: true, dependency: 1, weight: 36))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.PriorityCycle, NIOHTTP2Errors.PriorityCycle(streamID: 1))
+        }
+    }
 }
 
 

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
@@ -39,6 +39,7 @@ extension OutboundFlowControlBufferTests {
                 ("testOverlargeFramesAreSplitOnMaxFrameSizeFileRegion", testOverlargeFramesAreSplitOnMaxFrameSizeFileRegion),
                 ("testChangingStreamWindowSizeToZeroAndBack", testChangingStreamWindowSizeToZeroAndBack),
                 ("testStreamWindowChanges", testStreamWindowChanges),
+                ("testRejectsPrioritySelfDependency", testRejectsPrioritySelfDependency),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
@@ -371,6 +371,15 @@ class OutboundFlowControlBufferTests: XCTestCase {
         self.buffer.flushReceived()
         XCTAssertNil(self.buffer.nextFlushedWritableFrame())
     }
+
+    func testRejectsPrioritySelfDependency() {
+        XCTAssertThrowsError(try self.buffer.priorityUpdate(streamID: 1, priorityData: .init(exclusive: false, dependency: 1, weight: 36))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.PriorityCycle, NIOHTTP2Errors.PriorityCycle(streamID: 1))
+        }
+        XCTAssertThrowsError(try self.buffer.priorityUpdate(streamID: 1, priorityData: .init(exclusive: true, dependency: 1, weight: 36))) { error in
+            XCTAssertEqual(error as? NIOHTTP2Errors.PriorityCycle, NIOHTTP2Errors.PriorityCycle(streamID: 1))
+        }
+    }
 }
 
 

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -53,6 +53,8 @@ extension SimpleClientServerTests {
                 ("testSettingsAckNotifiesAboutChangedFlowControl", testSettingsAckNotifiesAboutChangedFlowControl),
                 ("testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges", testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges),
                 ("testChangingMaxFrameSize", testChangingMaxFrameSize),
+                ("testStreamErrorOnSelfDependentPriorityFrames", testStreamErrorOnSelfDependentPriorityFrames),
+                ("testStreamErrorOnSelfDependentHeadersFrames", testStreamErrorOnSelfDependentHeadersFrames),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In the future we'll want to use PRIORITY frames to provide feedback on
how we emit data. Additionally, RFC 7540 forbids certain kinds of
PRIORITY frame, which right now we tolerate receiving. We can design a
minor PRIORITY shim to ensure that we have a code path for PRIORITY data
to be passed around, and then use this shim to enforce RFC 7540's
requirements.

Modifications:

- Added support for PRIORITY frame data inbound.
- Enforce that frames may not establish self-dependency.

Result:

Better policing of RFC 7540 constraints.