### PR TITLE
Forward channelActive from stream multiplexer.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -91,6 +91,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                 channel.performActivation()
             }
         }
+        context.fireChannelActive()
     }
 
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -59,6 +59,7 @@ extension HTTP2StreamMultiplexerTests {
                 ("testCreatedChildChannelActivatesIfParentIsActive", testCreatedChildChannelActivatesIfParentIsActive),
                 ("testInitiatedChildChannelActivates", testInitiatedChildChannelActivates),
                 ("testMultiplexerIgnoresPriorityFrames", testMultiplexerIgnoresPriorityFrames),
+                ("testMultiplexerForwardsActiveToParent", testMultiplexerForwardsActiveToParent),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -1299,4 +1299,20 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
 
         XCTAssertNoThrow(try self.channel.finish())
     }
+
+    func testMultiplexerForwardsActiveToParent() throws {
+        self.channel.addNoOpMultiplexer(mode: .client)
+
+        var didActivate = false
+
+        let activePromise = self.channel.eventLoop.makePromise(of: Void.self)
+        activePromise.futureResult.whenSuccess {
+            didActivate = true
+        }
+        XCTAssertNoThrow(try self.channel.pipeline.addHandler(ActiveHandler(activatedPromise: activePromise)).wait())
+        XCTAssertNoThrow(try self.channel.connect(to: SocketAddress(unixDomainSocketPath: "/nothing")).wait())
+        XCTAssertTrue(didActivate)
+        
+        XCTAssertNoThrow(try self.channel.finish())
+    }
 }


### PR DESCRIPTION
Motivation:

The stream multiplexer was incorrectly eating channelActive on its own
channel, and failing to pass them on to subsequent channel handlers, if
there were any.

Modifications:

- Passed channelActive on from stream multiplexer.

Result:

Easier to handle things on the parent channel.
Resolves #75.