### PR TITLE
Require END_STREAM to be set on trailers.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -200,6 +200,16 @@ public enum NIOHTTP2Errors {
             self.streamID = streamID
         }
     }
+
+    /// An attempt was made to send trailers without setting END_STREAM on them.
+    public struct TrailersWithoutEndStream: NIOHTTP2Error {
+        /// The affected stream ID.
+        public var streamID: HTTP2StreamID
+
+        public init(streamID: HTTP2StreamID) {
+            self.streamID = streamID
+        }
+    }
 }
 
 

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -850,6 +850,12 @@ extension HTTP2StreamStateMachine {
     /// target final state.
     private mutating func processTrailers(_ headers: HPACKHeaders, isEndStreamSet endStream: Bool, targetState target: State, targetEffect effect: StreamStateChange?) -> StateMachineResultWithStreamEffect {
         // TODO(cory): Implement
+
+        // End stream must be set on trailers.
+        guard endStream else {
+            return StateMachineResultWithStreamEffect(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.TrailersWithoutEndStream(streamID: self.streamID), type: .protocolError), effect: nil)
+        }
+
         self.state = target
         return StateMachineResultWithStreamEffect(result: .succeed, effect: effect)
     }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -81,6 +81,8 @@ extension ConnectionStateMachineTests {
                 ("testDisablingPushPreventsPush", testDisablingPushPreventsPush),
                 ("testRatchetingGoawayEvenWhenFullyQueisced", testRatchetingGoawayEvenWhenFullyQueisced),
                 ("testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced", testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced),
+                ("testClientTrailersMustHaveEndStreamSet", testClientTrailersMustHaveEndStreamSet),
+                ("testServerTrailersMustHaveEndStreamSet", testServerTrailersMustHaveEndStreamSet),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

RFC 7540 requires that the END_STREAM bit be set on a HEADERS frame that
sends trailers. We should enforce that.

Modifications:

- Require that the END_STREAM bit is set on trailers.

Result:

We reject more incorrect flows.