### PR TITLE
Validate no uppercase characters in header field names.

### DIFF
--- a/Sources/NIOHTTP2/HPACKHeaders+Validation.swift
+++ b/Sources/NIOHTTP2/HPACKHeaders+Validation.swift
@@ -1,0 +1,159 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOHPACK
+
+extension HPACKHeaders {
+    /// Checks that a given HPACKHeaders block is a valid request header block, meeting all of the constraints of RFC 7540.
+    ///
+    /// If the header block is not valid, throws an error.
+    internal func validateRequestBlock() throws {
+        return try RequestBlockValidator.validateBlock(self)
+    }
+
+    /// Checks that a given HPACKHeaders block is a valid response header block, meeting all of the constraints of RFC 7540.
+    ///
+    /// If the header block is not valid, throws an error.
+    internal func validateResponseBlock() throws {
+        return try ResponseBlockValidator.validateBlock(self)
+    }
+
+    /// Checks that a given HPACKHeaders block is a valid trailer block, meeting all of the constraints of RFC 7540.
+    ///
+    /// If the header block is not valid, throws an error.
+    internal func validateTrailersBlock() throws {
+        return try TrailersValidator.validateBlock(self)
+    }
+}
+
+
+/// A `HeaderBlockValidator` is an object that can confirm that a HPACK block meets certain constraints.
+fileprivate protocol HeaderBlockValidator {
+    init()
+
+    mutating func validateNextField(name: HeaderFieldName, value: String) throws
+}
+
+extension HeaderBlockValidator {
+    /// Validates that a header block meets the requirements of this `HeaderBlockValidator`.
+    fileprivate static func validateBlock(_ block: HPACKHeaders) throws {
+        var validator = Self()
+        for (name, value, _) in block {
+            let fieldName = try HeaderFieldName(name)
+            try validator.validateNextField(name: fieldName, value: value)
+        }
+    }
+}
+
+/// An object that can be used to validate if a given header block is a valid request header block.
+fileprivate struct RequestBlockValidator { }
+
+extension RequestBlockValidator: HeaderBlockValidator {
+    fileprivate mutating func validateNextField(name: HeaderFieldName, value: String) throws {
+        return
+    }
+}
+
+
+/// An object that can be used to validate if a given header block is a valid response header block.
+fileprivate struct ResponseBlockValidator { }
+
+extension ResponseBlockValidator: HeaderBlockValidator {
+    fileprivate mutating func validateNextField(name: HeaderFieldName, value: String) throws {
+        return
+    }
+}
+
+
+/// An object that can be used to validate if a given header block is a valid trailer block.
+fileprivate struct TrailersValidator { }
+
+extension TrailersValidator: HeaderBlockValidator {
+    fileprivate mutating func validateNextField(name: HeaderFieldName, value: String) throws {
+        return
+    }
+}
+
+
+/// A structure that carries the details of a specific header field name.
+///
+/// Used to validate the correctness of a specific header field name at a given
+/// point in a header block.
+fileprivate struct HeaderFieldName { }
+
+extension HeaderFieldName {
+    fileprivate init(_ fieldName: String) throws {
+        let fieldBytes = Substring(fieldName).utf8
+
+        let baseName: Substring.UTF8View
+        if fieldBytes.first == UInt8(ascii: ":") {
+            baseName = fieldBytes.dropFirst()
+        } else {
+            baseName = fieldBytes
+        }
+
+        guard baseName.isValidFieldName else {
+            throw NIOHTTP2Errors.InvalidHTTP2HeaderFieldName(fieldName)
+        }
+    }
+}
+
+
+extension Substring.UTF8View {
+    /// Whether this is a valid HTTP/2 header field name.
+    fileprivate var isValidFieldName: Bool {
+        /// RFC 7230 defines header field names as matching the `token` ABNF, which is:
+        ///
+        ///     token          = 1*tchar
+        ///
+        ///     tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+        ///                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        ///                    / DIGIT / ALPHA
+        ///                    ; any VCHAR, except delimiters
+        ///
+        ///     DIGIT          =  %x30-39
+        ///                    ; 0-9
+        ///
+        ///     ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z
+        ///
+        /// RFC 7540 subsequently clarifies that HTTP/2 headers must be converted to lowercase before
+        /// sending. This therefore excludes the range A-Z in ALPHA. If we convert tchar to the range syntax
+        /// used in DIGIT and ALPHA, and then collapse the ranges that are more than two elements long, we get:
+        ///
+        ///     tchar          = %x21 / %x23-27 / %x2A / %x2B / %x2D / %x2E / %x5E-60 / %x7C / %x7E / %x30-39 /
+        ///                    / %x41-5A / %x61-7A
+        ///
+        /// Now we can strip out the uppercase characters, and shuffle these so they're in ascending order:
+        ///
+        ///     tchar          = %x21 / %x23-27 / %x2A / %x2B / %x2D / %x2E / %x30-39 / %x5E-60 / %x61-7A
+        ///                    / %x7C / %x7E
+        ///
+        /// Then we can also spot that we have a pair of ranges that bump into each other and do one further level
+        /// of collapsing.
+        ///
+        ///     tchar          = %x21 / %x23-27 / %x2A / %x2B / %x2D / %x2E / %x30-39 / %x5E-7A
+        ///                    / %x7C / %x7E
+        ///
+        /// We can then translate this into a straightforward switch statement to check whether the code
+        /// units are valid.
+        return self.allSatisfy { codeUnit in
+            switch codeUnit {
+            case 0x21, 0x23...0x27, 0x2a, 0x2b, 0x2d, 0x2e, 0x30...0x39,
+                 0x5e...0x7a, 0x7c, 0x7e:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -88,8 +88,15 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
         case server
     }
 
-    public init(mode: ParserMode, initialSettings: HTTP2Settings = nioDefaultSettings) {
-        self.stateMachine = HTTP2ConnectionStateMachine(role: .init(mode))
+    /// Whether a certain operation has validation enabled or not.
+    public enum ValidationState {
+        case enabled
+
+        case disabled
+    }
+
+    public init(mode: ParserMode, initialSettings: HTTP2Settings = nioDefaultSettings, headerBlockValidation: ValidationState = .enabled) {
+        self.stateMachine = HTTP2ConnectionStateMachine(role: .init(mode), headerBlockValidation: .init(headerBlockValidation))
         self.mode = mode
         self.initialSettings = initialSettings
         self.outboundBuffer = CompoundOutboundBuffer(mode: mode, initialMaxOutboundStreams: 100)
@@ -526,6 +533,18 @@ private extension HTTP2ConnectionStateMachine.ConnectionRole {
             self = .client
         case .server:
             self = .server
+        }
+    }
+}
+
+
+extension HTTP2ConnectionStateMachine.ValidationState {
+    init(_ state: NIOHTTP2Handler.ValidationState) {
+        switch state {
+        case .enabled:
+            self = .enabled
+        case .disabled:
+            self = .disabled
         }
     }
 }

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -210,6 +210,15 @@ public enum NIOHTTP2Errors {
             self.streamID = streamID
         }
     }
+
+    /// An attempt was made to send a header field with a field name that is not valid in HTTP/2.
+    public struct InvalidHTTP2HeaderFieldName: NIOHTTP2Error {
+        public var fieldName: String
+
+        public init(_ fieldName: String) {
+            self.fieldName = fieldName
+        }
+    }
 }
 
 

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -83,6 +83,8 @@ extension ConnectionStateMachineTests {
                 ("testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced", testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced),
                 ("testClientTrailersMustHaveEndStreamSet", testClientTrailersMustHaveEndStreamSet),
                 ("testServerTrailersMustHaveEndStreamSet", testServerTrailersMustHaveEndStreamSet),
+                ("testRejectHeadersWithUppercaseHeaderFieldName", testRejectHeadersWithUppercaseHeaderFieldName),
+                ("testAllowHeadersWithUppercaseHeaderFieldNameWhenValidationDisabled", testAllowHeadersWithUppercaseHeaderFieldNameWhenValidationDisabled),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -1753,5 +1753,77 @@ class ConnectionStateMachineTests: XCTestCase {
         assertStreamError(type: .protocolError, self.server.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.trailers, isEndStreamSet: false))
         assertStreamError(type: .protocolError, self.client.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.trailers, isEndStreamSet: false))
     }
+
+    func testRejectHeadersWithUppercaseHeaderFieldName() {
+        let streamOne = HTTP2StreamID(1)
+        let streamThree = HTTP2StreamID(3)
+        let streamFive = HTTP2StreamID(5)
+
+        self.exchangePreamble()
+
+        let invalidExtraHeaders = [("UppercaseFieldName", "value")]
+
+        // First, test that client initial headers may not contain uppercase headers.
+        assertStreamError(type: .protocolError, self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertStreamError(type: .protocolError, self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+
+        // Next, set up a valid stream for the client and confirm that the server response cannot have uppercase headers.
+        assertSucceeds(self.client.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertStreamError(type: .protocolError, self.server.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.responseHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertStreamError(type: .protocolError, self.client.receiveHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.responseHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+
+        // Next, test this with trailers.
+        assertSucceeds(self.client.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+        assertStreamError(type: .protocolError, self.server.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.trailers.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertStreamError(type: .protocolError, self.client.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.trailers.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+    }
+
+    func testAllowHeadersWithUppercaseHeaderFieldNameWhenValidationDisabled() {
+        let streamOne = HTTP2StreamID(1)
+        let streamThree = HTTP2StreamID(3)
+        let streamFive = HTTP2StreamID(5)
+
+        // Override the setup with validation disabled.
+        self.server = .init(role: .server, headerBlockValidation: .disabled)
+        self.client = .init(role: .client, headerBlockValidation: .disabled)
+
+        self.exchangePreamble()
+
+        let invalidExtraHeaders = [("UppercaseFieldName", "value")]
+
+        // First, test that client initial headers may not contain uppercase headers.
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+
+        // Next, set up a valid stream for the client and confirm that the server response cannot have uppercase headers.
+        assertSucceeds(self.client.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.responseHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.responseHeaders.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+
+        // Next, test this with trailers.
+        assertSucceeds(self.client.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.server.sendHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.trailers.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamFive, headers: ConnectionStateMachineTests.trailers.withExtraHeaders(invalidExtraHeaders), isEndStreamSet: true))
+    }
+}
+
+
+extension HPACKHeaders {
+    /// Take the header block and add some more.
+    internal func withExtraHeaders(_ headers: [(String, String)]) -> HPACKHeaders {
+        var newHeaders = self
+        for header in headers {
+            newHeaders.add(name: header.0, value: header.1)
+        }
+        return newHeaders
+    }
 }
 

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -55,6 +55,7 @@ extension SimpleClientServerTests {
                 ("testChangingMaxFrameSize", testChangingMaxFrameSize),
                 ("testStreamErrorOnSelfDependentPriorityFrames", testStreamErrorOnSelfDependentPriorityFrames),
                 ("testStreamErrorOnSelfDependentHeadersFrames", testStreamErrorOnSelfDependentHeadersFrames),
+                ("testInvalidRequestHeaderBlockAllowsRstStream", testInvalidRequestHeaderBlockAllowsRstStream),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

RFC 7540 forbids uppercase characters in header field names, but we
currently allow them. We shouldn't.

This is the first in a series of patches that will validate header blocks
when reasonable. As a result, it seems larger than necessary, as it adds
a bunch of scaffolding for extending with further validation code.

Modifications:

- Added header field validation scaffolding.
- Validates that header field names do not contain uppercase chars.
- Allows sending RST_STREAM frame before stream setup.

Result:

Better header field validation.