### PR TITLE
Decrease allocations in encode loop.

### DIFF
--- a/Sources/NIOHPACK/DynamicHeaderTable.swift
+++ b/Sources/NIOHPACK/DynamicHeaderTable.swift
@@ -105,25 +105,12 @@ struct DynamicHeaderTable {
         // If we have a value, locate the index of the lowest header which contains that
         // value, but if no value matches, return the index of the lowest header with a
         // matching name alone.
-        var firstNameMatch: Int? = nil
-        for index in self.storage.indices(matching: name) {
-            if firstNameMatch == nil {
-                // record the first (most recent) index with a matching header name,
-                // in case there's no value match.
-                firstNameMatch = index
-            }
-            
-            if self.storage.view(of: self.storage[index].value).matches(value) {
-                // this entry has both the name and the value we're seeking
-                return (index, true)
-            }
-        }
-        
-        // no value matches -- but did we find a name?
-        if let index = firstNameMatch {
+        switch self.storage.closestMatch(name: name, value: value) {
+        case .full(let index):
+            return (index, true)
+        case .partial(let index):
             return (index, false)
-        } else {
-            // no matches at all
+        case .none:
             return nil
         }
     }

--- a/Sources/NIOHPACK/IndexedHeaderTable.swift
+++ b/Sources/NIOHPACK/IndexedHeaderTable.swift
@@ -85,15 +85,14 @@ public struct IndexedHeaderTable {
         }
         
         var firstHeaderIndex: Int? = nil
-        for index in self.staticTable.indices(matching: name) {
-            // we've found a name, at least
-            if firstHeaderIndex == nil {
-                firstHeaderIndex = index
-            }
-            
-            if self.staticTable.view(of: self.staticTable[index].value).matches(value) {
-                return (index, true)
-            }
+
+        switch self.staticTable.closestMatch(name: name, value: value) {
+        case .full(let index):
+            return (index, true)
+        case .partial(let index):
+            firstHeaderIndex = index
+        case .none:
+            break
         }
         
         // no complete match: search the dynamic table now


### PR DESCRIPTION
### Motivation

While investigating performance of HTTP/2 I noticed a substantial number
of allocations occuring in a hot loop in header compression. Specifically
I set up a simple harness that encoded headers 100 times, and then ran
that harness 10k times. This harness ended up performing 17 million
allocations, which is frankly a bit too high!

The fact that the number of allocations was in the millions suggested that
we were allocating some resources per header encode. That's not good:
assuming the target `ByteBuffer` is big enough we should not need to
perform new allocations to encode headers.

The allocations came from two places. Firstly, we were allocating in the
`HeaderTableStorage.indices(matching:)` function. This was because that
operation was returning a lazy collection, which required multiple heap
allocations for the closure contexts. Those needed to be eliminated.

Secondly, we were triggering a CoW of the `ByteBuffer` passed in to
`encode()`. This is the result of a complex bit of control flow that
fundamentally meant that the buffer was held in two places in that
method.

Removing these two sources of allocations dropped the count in my test
from 17 million to 176k, a decrease of 100x. We also saw a speed boost
of nearly 66% in terms of runtime of the microbenchmark.

### Modifications

- Removed `HeaderTableStorage.indices(matching:)`
- Implemented `HeaderTableStorage.closestMatch(name:value:), containing
   the repeated logic of the body of the two loops over the header
   indices.
- Used swap() and an empty byte buffer to ensure that encode does not
   cause a CoW operation.

### Result

Much faster and more memory efficient header encoding.