### PR TITLE
Allow zero length SETTINGS frames to be parsed.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -730,7 +730,7 @@ struct HTTP2FrameDecoder {
             }
 
             return .settings(.ack)
-        } else if length == 0 || length % 6 != 0 {
+        } else if length % 6 != 0 {
             // A SETTINGS frame with a length other than a multiple of 6 octets MUST be treated
             // as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.
             throw InternalError.codecError(code: .frameSizeError)

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
@@ -56,6 +56,7 @@ extension HTTP2FrameParserTests {
                 ("testResetStreamFrameDecodingFailure", testResetStreamFrameDecodingFailure),
                 ("testResetStreamFrameEncoding", testResetStreamFrameEncoding),
                 ("testSettingsFrameDecoding", testSettingsFrameDecoding),
+                ("testSettingsFrameDecodingWithNoSettings", testSettingsFrameDecodingWithNoSettings),
                 ("testSettingsFrameDecodingWithUnknownItems", testSettingsFrameDecodingWithUnknownItems),
                 ("testSettingsFrameDecodingFailure", testSettingsFrameDecodingFailure),
                 ("testSettingsFrameEncoding", testSettingsFrameEncoding),

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
@@ -869,6 +869,21 @@ class HTTP2FrameParserTests: XCTestCase {
         
         try assertReadsFrame(from: &buf, matching: expectedFrame)
     }
+
+  func testSettingsFrameDecodingWithNoSettings() throws {
+    let settings: [HTTP2Setting] = []
+    let expectedFrame = HTTP2Frame(payload: .settings(.settings(settings)), streamID: .rootStream)
+
+    let frameBytes: [UInt8] = [
+      0x00, 0x00, 0x00,           // 3-byte payload length (0 bytes)
+      0x04,                       // 1-byte frame type (SETTINGS)
+      0x00,                       // 1-byte flags (none)
+      0x00, 0x00, 0x00, 0x00,     // 4-byte stream identifier
+    ]
+    var buf = byteBuffer(withBytes: frameBytes)
+
+    try assertReadsFrame(from: &buf, matching: expectedFrame)
+  }
     
     func testSettingsFrameDecodingWithUnknownItems() throws {
         let settings: [HTTP2Setting] = [


### PR DESCRIPTION
Zero length SETTINGS frames are permitted by RFC 7540 but the frame
parser currently throws a FRAME_SIZE_ERROR.

- Allow zero length SETTINGS frames to be parsed
- Added a test

Parsing zero length SETTINGS frames don't throw an error.