### PR TITLE
Enforce pseudo-headers must be first in a header block.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -172,6 +172,15 @@ public enum NIOHTTP2Errors {
         }
     }
 
+    /// A header block contained a pseudo-header after a regular header.
+    public struct PseudoHeaderAfterRegularHeader: NIOHTTP2Error {
+        public var name: String
+
+        public init(_ name: String) {
+            self.name = name
+        }
+    }
+
     /// An outbound request was about to be sent, but does not contain a Host header.
     public struct MissingHostHeader: NIOHTTP2Error {
         public init() { }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -85,6 +85,8 @@ extension ConnectionStateMachineTests {
                 ("testServerTrailersMustHaveEndStreamSet", testServerTrailersMustHaveEndStreamSet),
                 ("testRejectHeadersWithUppercaseHeaderFieldName", testRejectHeadersWithUppercaseHeaderFieldName),
                 ("testAllowHeadersWithUppercaseHeaderFieldNameWhenValidationDisabled", testAllowHeadersWithUppercaseHeaderFieldNameWhenValidationDisabled),
+                ("testRejectPseudoHeadersAfterRegularHeaders", testRejectPseudoHeadersAfterRegularHeaders),
+                ("testAllowPseudoHeadersAfterRegularHeaders", testAllowPseudoHeadersAfterRegularHeaders),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

RFC 7540 requires that HTTP/2 pseudo-headers must be first in a HTTP/2
header block, and must occur before any regular headers. We should enforce
that requirement.

Modifications:

- Added checking that pseudo-headers are first in a header block.

Result:

Better RFC 7540 validation.