### PR TITLE
Forbid empty :path headers.

### DIFF
--- a/Sources/NIOHTTP2/HPACKHeaders+Validation.swift
+++ b/Sources/NIOHTTP2/HPACKHeaders+Validation.swift
@@ -142,13 +142,23 @@ extension RequestBlockValidator: HeaderBlockValidator {
         // This is a bit awkward.
         //
         // For now we don't support extended-CONNECT, but when we do we'll need to update the logic here.
-        guard let pseudoHeaderType = pseudoHeaderType, pseudoHeaderType == .method else {
+        guard let pseudoHeaderType = pseudoHeaderType else {
             // Nothing to do here.
             return
         }
 
-        // This is a method pseudo-header. Check if the value is CONNECT.
-        self.isConnectRequest = value == "CONNECT"
+        switch pseudoHeaderType {
+        case .method:
+            // This is a method pseudo-header. Check if the value is CONNECT.
+            self.isConnectRequest = value == "CONNECT"
+        case .path:
+            // This is a path pseudo-header. It must not be empty.
+            if value.utf8.count == 0 {
+                throw NIOHTTP2Errors.EmptyPathHeader()
+            }
+        default:
+            break
+        }
     }
 
     var allowedPseudoHeaderFields: PseudoHeaders {

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -210,6 +210,11 @@ public enum NIOHTTP2Errors {
         public init() { }
     }
 
+    /// A HTTP/2 header block was received with an empty :path header.
+    public struct EmptyPathHeader: NIOHTTP2Error {
+        public init() { }
+    }
+
     /// A :status header was received with an invalid value.
     public struct InvalidStatusValue: NIOHTTP2Error {
         public var value: String

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -91,6 +91,8 @@ extension ConnectionStateMachineTests {
                 ("testAllowRequestHeadersWithMissingMethodFieldWhenValidationDisabled", testAllowRequestHeadersWithMissingMethodFieldWhenValidationDisabled),
                 ("testRejectRequestHeadersWithMissingPathField", testRejectRequestHeadersWithMissingPathField),
                 ("testAllowRequestHeadersWithMissingPathFieldWhenValidationDisabled", testAllowRequestHeadersWithMissingPathFieldWhenValidationDisabled),
+                ("testRejectRequestHeadersWithEmptyPathField", testRejectRequestHeadersWithEmptyPathField),
+                ("testAllowRequestHeadersWithEmptyPathFieldWhenValidationDisabled", testAllowRequestHeadersWithEmptyPathFieldWhenValidationDisabled),
                 ("testRejectRequestHeadersWithMissingSchemeField", testRejectRequestHeadersWithMissingSchemeField),
                 ("testAllowRequestHeadersWithMissingSchemeFieldWhenValidationDisabled", testAllowRequestHeadersWithMissingSchemeFieldWhenValidationDisabled),
                 ("testRejectRequestHeadersWithDuplicateMethodField", testRejectRequestHeadersWithDuplicateMethodField),


### PR DESCRIPTION
Motivation:

RFC 7540 does not allow empty :path pseudo-headers. We should police this.

Modifications:

- Added a check that :path isn't empty.

Result:

Better RFC 7540 validation.