### PR TITLE
Allow maxStreamID to be used in GOAWAY by either peer.

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingGoAwayState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingGoAwayState.swift
@@ -24,7 +24,7 @@ protocol ReceivingGoawayState {
 
 extension ReceivingGoawayState {
     mutating func receiveGoAwayFrame(lastStreamID: HTTP2StreamID) -> StateMachineResultWithEffect {
-        guard lastStreamID.mayBeInitiatedBy(self.role) || lastStreamID == .rootStream else {
+        guard lastStreamID.mayBeInitiatedBy(self.role) || lastStreamID == .rootStream || lastStreamID == .maxID else {
             // The remote peer has sent a GOAWAY with an invalid stream ID.
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.InvalidStreamIDForPeer(), type: .protocolError), effect: nil)
         }
@@ -37,7 +37,7 @@ extension ReceivingGoawayState {
 
 extension ReceivingGoawayState where Self: RemotelyQuiescingState {
     mutating func receiveGoAwayFrame(lastStreamID: HTTP2StreamID) -> StateMachineResultWithEffect {
-        guard lastStreamID.mayBeInitiatedBy(self.role) || lastStreamID == .rootStream else {
+        guard lastStreamID.mayBeInitiatedBy(self.role) || lastStreamID == .rootStream || lastStreamID == .maxID else {
             // The remote peer has sent a GOAWAY with an invalid stream ID.
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.InvalidStreamIDForPeer(), type: .protocolError), effect: nil)
         }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingGoawayState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingGoawayState.swift
@@ -24,7 +24,7 @@ protocol SendingGoawayState {
 
 extension SendingGoawayState {
     mutating func sendGoAwayFrame(lastStreamID: HTTP2StreamID) -> StateMachineResultWithEffect {
-        guard lastStreamID.mayBeInitiatedBy(self.peerRole) || lastStreamID == .rootStream else {
+        guard lastStreamID.mayBeInitiatedBy(self.peerRole) || lastStreamID == .rootStream || lastStreamID == .maxID else {
             // The user has sent a GOAWAY with an invalid stream ID.
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.InvalidStreamIDForPeer(), type: .protocolError), effect: nil)
         }
@@ -37,7 +37,7 @@ extension SendingGoawayState {
 
 extension SendingGoawayState where Self: LocallyQuiescingState {
     mutating func sendGoAwayFrame(lastStreamID: HTTP2StreamID) -> StateMachineResultWithEffect {
-        guard lastStreamID.mayBeInitiatedBy(self.peerRole) || lastStreamID == .rootStream else {
+        guard lastStreamID.mayBeInitiatedBy(self.peerRole) || lastStreamID == .rootStream || lastStreamID == .maxID else {
             // The user has sent a GOAWAY with an invalid stream ID.
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.InvalidStreamIDForPeer(), type: .protocolError), effect: nil)
         }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -56,6 +56,7 @@ extension SimpleClientServerTests {
                 ("testStreamErrorOnSelfDependentPriorityFrames", testStreamErrorOnSelfDependentPriorityFrames),
                 ("testStreamErrorOnSelfDependentHeadersFrames", testStreamErrorOnSelfDependentHeadersFrames),
                 ("testInvalidRequestHeaderBlockAllowsRstStream", testInvalidRequestHeaderBlockAllowsRstStream),
+                ("testClientConnectionErrorCorrectlyReported", testClientConnectionErrorCorrectlyReported),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We would previously error if clients emitted a GOAWAY frame that had
a last stream ID set to the max value. This is a bit unnecessary, not
least given that we emitted those frames ourselves! In fact, this error
would mask real server protocol errors if we hit them.

Modifications:

- Allowed max stream ID as the last stream ID.
- Wrote a test to verify this.

Result:

Fewer unnecessary protocol errors.
Resolves #101.