### PR TITLE
Ignore WINDOW_UPDATE on closed streams.

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
@@ -55,7 +55,7 @@ extension ReceivingPushPromiseState {
             try self.streamState.createRemotelyPushedStream(streamID: childStreamID,
                                                             remoteInitialWindowSize: self.remoteInitialWindowSize)
 
-           let result = self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: true) {
+            let result = self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: true) {
                 $0.receivePushPromise(headers: headers, validateHeaderBlock: validateHeaderBlock)
             }
             return StateMachineResultWithEffect(result, connectionState: self)

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingWindowUpdateState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingWindowUpdateState.swift
@@ -41,7 +41,7 @@ extension ReceivingWindowUpdateState {
             }
         } else {
             // This is an update for a specific stream: it's responsible for policing any errors.
-            let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true) {
+            let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true, ignoreClosed: true) {
                 $0.receiveWindowUpdate(windowIncrement: increment)
             }
             return StateMachineResultWithEffect(result, connectionState: self)

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -68,6 +68,7 @@ extension ConnectionStateMachineTests {
                 ("testDataFramesWithoutEndStream", testDataFramesWithoutEndStream),
                 ("testSendingCompleteRequestBeforeResponse", testSendingCompleteRequestBeforeResponse),
                 ("testWindowUpdateValidity", testWindowUpdateValidity),
+                ("testWindowUpdateOnClosedStream", testWindowUpdateOnClosedStream),
                 ("testWindowIncrementsOfSizeZeroArentOk", testWindowIncrementsOfSizeZeroArentOk),
                 ("testCannotSendDataFrames", testCannotSendDataFrames),
                 ("testChangingInitialWindowSizeLotsOfStreams", testChangingInitialWindowSizeLotsOfStreams),


### PR DESCRIPTION
Motivation:

RFC 7540 Section 6.9: "WINDOW_UPDATE can be sent by a peer that has sent
a frame bearing the END_STREAM flag.  This means that a receiver could
receive a WINDOW_UPDATE frame on a "half-closed (remote)" or "closed"
stream. A receiver MUST NOT treat this as an error (see Section 5.1)."

Previously WINDOW_UPDATE frames received in this state would be treated
as an error.

Modifications:

- Allow frames to be ignored if they are for a stream which has been
  closed.
- Add a test to verify WINDOW_UPDATE on a closed stream.
- Update tests which relied on a stream error in this case.

Result:

More compliant code.