### PR TITLE
Pass changes in SETTINGS_MAX_CONCURRENT_STREAMS to outbound buffer.

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
@@ -48,6 +48,7 @@ extension HasRemoteSettings {
                     } else {
                         self.streamState.maxServerInitiatedStreams = newValue
                     }
+                    effect.newMaxConcurrentStreams = newValue
                 case .headerTableSize:
                     frameDecoder.headerDecoder.maxDynamicTableLength = Int(newValue)
                 case .initialWindowSize:

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -486,13 +486,15 @@ extension NIOHTTP2Handler {
                 promise?.fail(error)
             }
         case .remoteSettingsChanged(let settingsChange):
-            // TODO(cory): also max concurrent streams.
             if settingsChange.streamWindowSizeChange != 0 {
                 self.outboundBuffer.initialWindowSizeChanged(settingsChange.streamWindowSizeChange)
             }
             if let newMaxFrameSize = settingsChange.newMaxFrameSize {
                 self.frameEncoder.maxFrameSize = newMaxFrameSize
                 self.outboundBuffer.maxFrameSize = Int(newMaxFrameSize)
+            }
+            if let newMaxConcurrentStreams = settingsChange.newMaxConcurrentStreams {
+                self.outboundBuffer.maxOutboundStreams = Int(newMaxConcurrentStreams)
             }
         case .localSettingsChanged(let settingsChange):
             if settingsChange.streamWindowSizeChange != 0 {

--- a/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
+++ b/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
@@ -148,6 +148,8 @@ internal enum NIOHTTP2ConnectionStateChange: Hashable {
         internal var streamWindowSizeChange: Int = 0
 
         internal var newMaxFrameSize: UInt32?
+
+        internal var newMaxConcurrentStreams: UInt32?
     }
 
     /// The local peer's settings have changed in a way that is not trivial to decode.

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -57,6 +57,7 @@ extension SimpleClientServerTests {
                 ("testStreamErrorOnSelfDependentHeadersFrames", testStreamErrorOnSelfDependentHeadersFrames),
                 ("testInvalidRequestHeaderBlockAllowsRstStream", testInvalidRequestHeaderBlockAllowsRstStream),
                 ("testClientConnectionErrorCorrectlyReported", testClientConnectionErrorCorrectlyReported),
+                ("testChangingMaxConcurrentStreams", testChangingMaxConcurrentStreams),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

If the remote peer changes SETTINGS_MAX_CONCURRENT_STREAMS we should ensure that we don't
subsequently violate those bounds.

Modifications:

- Plumb in the SETTINGS_MAX_CONCURRENT_STREAMS change.

Result:

SETTINGS_MAX_CONCURRENT_STREAMS works better