### PR TITLE
Avoid 8 heap allocations on child channel creation

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -64,7 +64,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                                              targetWindowSize: 65535,
                                              initiatedRemotely: true)
             self.streams[streamID] = channel
-            channel.configure(initializer: self.inboundStreamStateInitializer)
+            channel.configure(initializer: self.inboundStreamStateInitializer, userPromise: nil)
             channel.closeFuture.whenComplete { _ in
                 self.childChannelClosed(streamID: streamID)
             }
@@ -184,13 +184,9 @@ extension HTTP2StreamMultiplexer {
                                              targetWindowSize: 65535,  // TODO: make configurable
                                              initiatedRemotely: false)
             self.streams[streamID] = channel
-            let activationFuture = channel.configure(initializer: streamStateInitializer)
+            channel.configure(initializer: streamStateInitializer, userPromise: promise)
             channel.closeFuture.whenComplete { _ in
                 self.childChannelClosed(streamID: streamID)
-            }
-
-            if let promise = promise {
-                activationFuture.map { channel }.cascade(to: promise)
             }
         }
     }


### PR DESCRIPTION
Motivation:

When users create a child channel and want to get hold of it,
they will pass a promise to createStreamChannel. This promise
will force a call to map{} and a call to cascade(), both of
which heap allocate. We don't need to have these heap allocations,
and they're easily removed, so we should.

Modifications:

Manually cascade the result.

Result:

Slightly fewer heap allocations in some workloads.