### PR TITLE
Reserve capacity when decoding HPACK headers

### DIFF
--- a/Sources/NIOHPACK/HPACKDecoder.swift
+++ b/Sources/NIOHPACK/HPACKDecoder.swift
@@ -89,6 +89,7 @@ public struct HPACKDecoder {
         // take a local copy to mutate
         var bufCopy = buffer
         var headers: [HPACKHeader] = []
+        headers.reserveCapacity(16)
 
         while bufCopy.readableBytes > 0 {
             switch try self.decodeHeader(from: &bufCopy) {


### PR DESCRIPTION
Motivation:

I was seeing frequent reallocations of the headers array as it
resized during decoding.

Modifications:

Reserve capacity for at least 16 HPACK headers during decoding.

Result:

Fewer reallocations at the cost of allocating more than we might need.