### PR TITLE
Allow closing idle StreamChannels.

### DIFF
--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -60,6 +60,8 @@ extension HTTP2StreamMultiplexerTests {
                 ("testInitiatedChildChannelActivates", testInitiatedChildChannelActivates),
                 ("testMultiplexerIgnoresPriorityFrames", testMultiplexerIgnoresPriorityFrames),
                 ("testMultiplexerForwardsActiveToParent", testMultiplexerForwardsActiveToParent),
+                ("testCreatedChildChannelCanBeClosedImmediately", testCreatedChildChannelCanBeClosedImmediately),
+                ("testCreatedChildChannelCanBeClosedBeforeWritingHeaders", testCreatedChildChannelCanBeClosedBeforeWritingHeaders),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -1332,7 +1332,7 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
         }
         self.channel.embeddedEventLoop.run()
         XCTAssertTrue(closed)
-        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean()))
+        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean))
     }
 
     func testCreatedChildChannelCanBeClosedBeforeWritingHeaders() throws {
@@ -1357,6 +1357,6 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
         child.close(promise: nil)
         self.channel.embeddedEventLoop.run()
         XCTAssertTrue(closed)
-        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean()))
+        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean))
     }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -1330,9 +1330,9 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
             channel.close().whenComplete { _ in closed = true }
             return channel.eventLoop.makeSucceededFuture(())
         }
-        (self.channel.eventLoop as! EmbeddedEventLoop).run()
+        self.channel.embeddedEventLoop.run()
         XCTAssertTrue(closed)
-        XCTAssertNoThrow(try self.channel.finish())
+        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean()))
     }
 
     func testCreatedChildChannelCanBeClosedBeforeWritingHeaders() throws {
@@ -1348,15 +1348,15 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
         multiplexer.createStreamChannel(promise: channelPromise) { (channel, streamID) in
             return channel.eventLoop.makeSucceededFuture(())
         }
-        (self.channel.eventLoop as! EmbeddedEventLoop).run()
+        self.channel.embeddedEventLoop.run()
 
         let child = try assertNoThrowWithValue(channelPromise.futureResult.wait())
         child.closeFuture.whenComplete { _ in closed = true }
 
         XCTAssertFalse(closed)
         child.close(promise: nil)
-        (self.channel.eventLoop as! EmbeddedEventLoop).run()
+        self.channel.embeddedEventLoop.run()
         XCTAssertTrue(closed)
-        XCTAssertNoThrow(try self.channel.finish())
+        XCTAssertNoThrow(XCTAssertTrue(try self.channel.finish().isClean()))
     }
 }


### PR DESCRIPTION
Motivation:

Users who create stream channels may end up deciding not to use them
and throw them away. We should tolerate this, instead of hanging.

Modifications:

- Rewrote the state management to properly isolate states.
- Allow instant-close when the network hasn't seen the stream.

Result:

Close is faster and works better.