### PR TITLE
Better manage stream channel activation.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -62,8 +62,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                                              parent: self.channel,
                                              multiplexer: self,
                                              streamID: streamID,
-                                             targetWindowSize: 65535,
-                                             initiatedRemotely: true)
+                                             targetWindowSize: 65535)
             self.streams[streamID] = channel
             channel.configure(initializer: self.inboundStreamStateInitializer, userPromise: nil)
             channel.receiveInboundFrame(frame)
@@ -111,6 +110,10 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             let channels = self.streams.values
             for channel in channels {
                 channel.initialWindowSizeChanged(delta: evt.delta)
+            }
+        case let evt as NIOHTTP2StreamCreatedEvent:
+            if let channel = self.streams[evt.streamID] {
+                channel.networkActivationReceived()
             }
         default:
             break
@@ -180,8 +183,7 @@ extension HTTP2StreamMultiplexer {
                                              parent: self.channel,
                                              multiplexer: self,
                                              streamID: streamID,
-                                             targetWindowSize: 65535,  // TODO: make configurable
-                                             initiatedRemotely: false)
+                                             targetWindowSize: 65535)  // TODO: make configurable
             self.streams[streamID] = channel
             channel.configure(initializer: streamStateInitializer, userPromise: promise)
         }

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -62,6 +62,8 @@ extension HTTP2StreamMultiplexerTests {
                 ("testMultiplexerForwardsActiveToParent", testMultiplexerForwardsActiveToParent),
                 ("testCreatedChildChannelCanBeClosedImmediately", testCreatedChildChannelCanBeClosedImmediately),
                 ("testCreatedChildChannelCanBeClosedBeforeWritingHeaders", testCreatedChildChannelCanBeClosedBeforeWritingHeaders),
+                ("testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive", testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive),
+                ("testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive", testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Our existing model for working out whether a stream channel is active is
a bit too ad-hoc. We "activate" a stream channel once the initializer
has completed so long as the parent channel is active. This approach
is basically reasonable, but it makes it a bit hard to handle stream
closure.

Specifically, in the client case a stream channel may be "active" but
have never sent a frame. In this case we can (and must) close the stream
without sending a frame if the user requests closure. This means we
need to know whether or not the stream is actually open from the
perspective of the parent channel.

Modifications:

- Added new notifications about whether the stream is active on the
    network
- Enhanced the stream channel to be more clear about its state.
- Wrote some new tests.
- Fixed old tests that needed updating.

Result:

HTTP2StreamChannel will be more resilient to weird network behaviour.