### PR TITLE
use official docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,12 @@ FROM swift:$swift_version-$ubuntu_version
 ARG swift_version
 ARG ubuntu_version
 
+# set as UTF-8
+RUN apt-get update && apt-get install -y locales locales-all
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
 # dependencies
 RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools # used by integration tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,79 +1,27 @@
-ARG ubuntu_version=16.04
-FROM ubuntu:$ubuntu_version
+ARG swift_version=5.0
+ARG ubuntu_version=bionic
+FROM swift:$swift_version-$ubuntu_version
 # needed to do again after FROM due to docker limitation
+ARG swift_version
 ARG ubuntu_version
 
-ARG DEBIAN_FRONTEND=noninteractive
-# do not start services during installation as this will fail and log a warning / error.
-RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
-
-# basic dependencies
-RUN apt-get update
-RUN apt-get install -y wget git build-essential software-properties-common pkg-config locales
-RUN apt-get install -y libicu-dev libblocksruntime0
-RUN apt-get install -y lsof dnsutils netcat-openbsd # used by integration tests
-
-# local
-RUN locale-gen en_US.UTF-8
-RUN locale-gen en_US en_US.UTF-8
-RUN dpkg-reconfigure locales
-RUN echo 'export LANG=en_US.UTF-8' >> $HOME/.profile
-RUN echo 'export LANGUAGE=en_US:en' >> $HOME/.profile
-RUN echo 'export LC_ALL=en_US.UTF-8' >> $HOME/.profile
-
-# known_hosts
-RUN mkdir -p $HOME/.ssh
-RUN touch $HOME/.ssh/known_hosts
-RUN ssh-keyscan github.com 2> /dev/null >> $HOME/.ssh/known_hosts
-
-# clang
-RUN apt-get install -y clang-3.9
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 100
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100
-
-# modern curl, if needed
-ARG install_curl_from_source
-RUN [ ! -z $install_curl_from_source ] || { apt-get update && apt-get install -y curl libcurl4-openssl-dev libz-dev; }
-RUN [ -z $install_curl_from_source ] || { apt-get update && apt-get install -y libssl-dev; }
-RUN [ -z $install_curl_from_source ] || mkdir $HOME/.curl
-RUN [ -z $install_curl_from_source ] || wget -q https://curl.haxx.se/download/curl-7.50.3.tar.gz -O $HOME/curl.tar.gz
-RUN [ -z $install_curl_from_source ] || tar xzf $HOME/curl.tar.gz --directory $HOME/.curl --strip-components=1
-RUN [ -z $install_curl_from_source ] || ( cd $HOME/.curl && ./configure --with-ssl && make && make install && cd - )
-RUN [ -z $install_curl_from_source ] || ldconfig
+# dependencies
+RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools # used by integration tests
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
 RUN gem install jazzy --no-ri --no-rdoc
 
-# nghttp2
-ARG install_nghttp2_from_source
-RUN [ ! -z $install_nghttp2_from_source ] || apt-get install -y nghttp2 libnghttp2-dev
-RUN [ -z $install_nghttp2_from_source ] || mkdir $HOME/.nghttp2
-RUN [ -z $install_nghttp2_from_source ] || wget -q https://github.com/nghttp2/nghttp2/releases/download/v1.32.0/nghttp2-1.32.0.tar.gz -O $HOME/nghttp2.tar.gz
-RUN [ -z $install_nghttp2_from_source ] || tar xzf $HOME/nghttp2.tar.gz --directory $HOME/.nghttp2 --strip-components=1
-RUN [ -z $install_nghttp2_from_source ] || ( cd $HOME/.nghttp2 && ./configure && make && make install && cd - )
-RUN [ -z $install_nghttp2_from_source ] || ldconfig
+# tools
+RUN mkdir -p $HOME/.tools
+RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # h2spec
 ARG h2spec_version
-RUN [ -z $h2spec_version ] || mkdir $HOME/.h2spec
-RUN [ -z $h2spec_version ] || wget -q https://github.com/summerwind/h2spec/releases/download/v$h2spec_version/h2spec_linux_amd64.tar.gz -O $HOME/h2spec.tar.gz
-RUN [ -z $h2spec_version ] || tar xzf $HOME/h2spec.tar.gz --directory $HOME/.h2spec
-RUN [ -z $h2spec_version ] || mv $HOME/.h2spec/h2spec /usr/local/bin/h2spec
-
-# swift
-ARG swift_version=4.0.3
-ARG swift_flavour=RELEASE
-ARG swift_builds_suffix=release
-
-RUN mkdir $HOME/.swift
-RUN wget -q "https://swift.org/builds/swift-${swift_version}-${swift_builds_suffix}/ubuntu$(echo $ubuntu_version | sed 's/\.//g')/swift-${swift_version}-${swift_flavour}/swift-${swift_version}-${swift_flavour}-ubuntu${ubuntu_version}.tar.gz" -O $HOME/swift.tar.gz
-RUN tar xzf $HOME/swift.tar.gz --directory $HOME/.swift --strip-components=1
-RUN echo 'export PATH="$HOME/.swift/usr/bin:$PATH"' >> $HOME/.profile
-RUN echo 'export LINUX_SOURCEKIT_LIB_PATH="$HOME/.swift/usr/lib"' >> $HOME/.profile
+RUN [ -z $h2spec_version ] || wget -q https://github.com/summerwind/h2spec/releases/download/v$h2spec_version/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz
+RUN [ -z $h2spec_version ] || tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools
 
 # script to allow mapping framepointers on linux
-RUN mkdir -p $HOME/.scripts
-RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.scripts/symbolicate-linux-fatal
-RUN chmod 755 $HOME/.scripts/symbolicate-linux-fatal
-RUN echo 'export PATH="$HOME/.scripts:$PATH"' >> $HOME/.profile
+RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
+RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -6,7 +6,7 @@ services:
     image: swift-nio-http2:18.04-5.0
     build:
       args:
-        ubuntu_version: "18.04"
+        ubuntu_version: "bionic"
         swift_version: "5.0"
         h2spec_version: "2.2.1"
 


### PR DESCRIPTION
motivation: now that swift has official docker images, use them instead of the homebrewed one

changes: refactor docker file to use swift:version instead of ubuntu:version