### PR TITLE
Close stream channels when the parent channel becomes inactive

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -97,6 +97,13 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
         context.fireChannelActive()
     }
 
+    public func channelInactive(context: ChannelHandlerContext) {
+        for channel in self.streams.values {
+            channel.receiveStreamClosed(nil)
+        }
+        context.fireChannelInactive()
+    }
+
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         switch event {
         case let evt as StreamClosedEvent:

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
@@ -29,6 +29,7 @@ extension ConfiguringPipelineTests {
                 ("testBasicPipelineCommunicates", testBasicPipelineCommunicates),
                 ("testPipelineRespectsPositionRequest", testPipelineRespectsPositionRequest),
                 ("testPreambleGetsWrittenOnce", testPreambleGetsWrittenOnce),
+                ("testClosingParentChannelClosesStreamChannel", testClosingParentChannelClosesStreamChannel),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Stream channels don't get closed when the parent channel closes. This
can lead to some unexpected behaviour for users.

Modifications:

Call receiveStreamClosed on stream channels in the multiplexer when
reciving channelInactive. Added a test to verify the stream is closed.

Result:

Stream channels will be closed when the parent channel is closed.