### PR TITLE
Coalesce flushes during the read cycle.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -416,7 +416,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         self.state.beginClosing()
         let resetFrame = HTTP2Frame(streamID: self.streamID, payload: .rstStream(.cancel))
         self.receiveOutboundFrame(resetFrame, promise: nil)
-        self.parent?.flush()
+        self.multiplexer.childChannelFlush()
     }
 
     private func closedCleanly() {
@@ -514,7 +514,7 @@ private extension HTTP2StreamChannel {
             let write = self.pendingWrites.removeFirst()
             self.receiveOutboundFrame(write.0, promise: write.1)
         }
-        self.parent?.flush()
+        self.multiplexer.childChannelFlush()
     }
 
     /// Fails all pending writes with the given error.

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -64,6 +64,7 @@ extension HTTP2StreamMultiplexerTests {
                 ("testCreatedChildChannelCanBeClosedBeforeWritingHeaders", testCreatedChildChannelCanBeClosedBeforeWritingHeaders),
                 ("testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive", testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive),
                 ("testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive", testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive),
+                ("testMultiplexerCoalescesFlushCallsDuringChannelRead", testMultiplexerCoalescesFlushCallsDuringChannelRead),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -164,6 +164,17 @@ extension EmbeddedChannel {
         let content: HTTP2Frame? = try? assertNoThrowWithValue(self.readInbound())
         XCTAssertNil(content, "Received unexpected content: \(content!)", file: file, line: line)
     }
+
+    /// Retrieve all sent frames.
+    func sentFrames(file: StaticString = #file, line: UInt = #line) throws -> [HTTP2Frame] {
+        var receivedFrames: [HTTP2Frame] = Array()
+
+        while let frame = try assertNoThrowWithValue(self.readOutbound(as: HTTP2Frame.self), file: file, line: line) {
+            receivedFrames.append(frame)
+        }
+
+        return receivedFrames
+    }
 }
 
 extension HTTP2Frame {


### PR DESCRIPTION
Motivation:

The HTTP2StreamMultiplexer currently passes frames from child streams
through to the rest of the pipeline, and does the same with flushes.
Because HTTP2 is multiplexed, it is highly likely that in any
channelRead cycle multiple child channels will make sufficient progress
to want to flush their results. This means we can end up with multiple,
redundant, flush calls.

It would be better in general to try to reduce the amount of flushing
necessary to no more than once per channelRead cycle.

Modifications:

- Keep track of the channelRead cycle and where we are in it.
- Avoid flushing when we can expect a channelReadComplete.
- Flush on channelReadComplete if necessary.

Result:

Fewer flushes, better performance under high read load.