### PR TITLE
Drop buffered outbound frames when closing.

### DIFF
--- a/Sources/NIOHTTP2/ConcurrentStreamBuffer.swift
+++ b/Sources/NIOHTTP2/ConcurrentStreamBuffer.swift
@@ -81,6 +81,14 @@ struct ConcurrentStreamBuffer {
         return nil
     }
 
+    func invalidateBuffer(reason: ChannelError) {
+        for buffer in self.bufferedFrames {
+            for (_, promise) in buffer.frames {
+                promise?.fail(reason)
+            }
+        }
+    }
+
     mutating func streamCreated(_ streamID: HTTP2StreamID) {
         // We only care about outbound streams.
         guard streamID.mayBeInitiatedBy(self.mode) else {

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -112,6 +112,11 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
         }
     }
 
+    public func handlerRemoved(context: ChannelHandlerContext) {
+        // Any frames we're buffering need to be dropped.
+        self.outboundBuffer.invalidateBuffer()
+    }
+
     public func channelActive(context: ChannelHandlerContext) {
         self.writeAndFlushPreamble(context: context)
         context.fireChannelActive()

--- a/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
+++ b/Sources/NIOHTTP2/OutboundFlowControlBuffer.swift
@@ -110,6 +110,12 @@ internal struct OutboundFlowControlBuffer {
         }
     }
 
+    internal func invalidateBuffer(reason: ChannelError) {
+        for buffer in self.streamDataBuffers.values {
+            buffer.dataBuffer.failAllWrites(error: reason)
+        }
+    }
+
     internal mutating func streamCreated(_ streamID: HTTP2StreamID, initialWindowSize: UInt32) {
         assert(streamID != .rootStream)
 
@@ -303,6 +309,12 @@ private struct DataBuffer {
         var buffer = MarkedCircularBuffer<BufferElement>(initialCapacity: 0)
         swap(&buffer, &self.bufferedChunks)
         return buffer
+    }
+
+    func failAllWrites(error: ChannelError) {
+        for chunk in self.bufferedChunks {
+            chunk.1?.fail(error)
+        }
     }
 }
 

--- a/Sources/NIOHTTP2/OutboundFrameBuffer.swift
+++ b/Sources/NIOHTTP2/OutboundFrameBuffer.swift
@@ -176,6 +176,11 @@ extension CompoundOutboundBuffer {
         return droppedPromises
     }
 
+    func invalidateBuffer() {
+        self.concurrentStreamsBuffer.invalidateBuffer(reason: ChannelError.ioOnClosedChannel)
+        self.flowControlBuffer.invalidateBuffer(reason: ChannelError.ioOnClosedChannel)
+    }
+
     mutating func updateStreamWindow(_ streamID: HTTP2StreamID, newSize: Int32) {
         self.flowControlBuffer.updateWindowOfStream(streamID, newSize: newSize)
     }

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
@@ -35,6 +35,7 @@ extension CompoundOutboundBufferTest {
                 ("testBufferedFrameDrops", testBufferedFrameDrops),
                 ("testRejectsPrioritySelfDependency", testRejectsPrioritySelfDependency),
                 ("testBufferedFlushedFrameBufferingBehindFlowControl", testBufferedFlushedFrameBufferingBehindFlowControl),
+                ("testFailingAllPromisesOnClose", testFailingAllPromisesOnClose),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -58,6 +58,7 @@ extension SimpleClientServerTests {
                 ("testInvalidRequestHeaderBlockAllowsRstStream", testInvalidRequestHeaderBlockAllowsRstStream),
                 ("testClientConnectionErrorCorrectlyReported", testClientConnectionErrorCorrectlyReported),
                 ("testChangingMaxConcurrentStreams", testChangingMaxConcurrentStreams),
+                ("testFailsPromisesForBufferedWrites", testFailsPromisesForBufferedWrites),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

While having outbound buffers is necessary, it's pretty important to
clear then when the connection is closed, or the promise will get
leaked. In this case, leaking the promise is usually pretty dang bad,
and tends to cause awkward things like crashes.

Modifications:

- Added hooks to invalidate the CompoundOutboundBuffer.
- Called those hooks in handlerRemoved, where there is no reentrancy
    risk.

Result:

Less risk of runtime crash.