### PR TITLE
Minimise channelReadComplete traffic.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -34,6 +34,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     private var nextOutboundStreamID: HTTP2StreamID
     private var connectionFlowControlManager: InboundWindowManager
     private var flushState: FlushState = .notReading
+    private var didReadChannels: StreamChannelList = StreamChannelList()
 
     public func handlerAdded(context: ChannelHandlerContext) {
         // We now need to check that we're on the same event loop as the one we were originally given.
@@ -44,6 +45,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
 
     public func handlerRemoved(context: ChannelHandlerContext) {
         self.context = nil
+        self.didReadChannels.removeAll()
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -66,6 +68,9 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
 
         if let channel = streams[streamID] {
             channel.receiveInboundFrame(frame)
+            if !channel.inList {
+                self.didReadChannels.append(channel)
+            }
         } else if case .headers = frame.payload {
             let channel = HTTP2StreamChannel(allocator: self.channel.allocator,
                                              parent: self.channel,
@@ -75,6 +80,10 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             self.streams[streamID] = channel
             channel.configure(initializer: self.inboundStreamStateInitializer, userPromise: nil)
             channel.receiveInboundFrame(frame)
+
+            if !channel.inList {
+                self.didReadChannels.append(channel)
+            }
         } else {
             // This frame is for a stream we know nothing about. We can't do much about it, so we
             // are going to fire an error and drop the frame.
@@ -84,6 +93,11 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     }
 
     public func channelReadComplete(context: ChannelHandlerContext) {
+        // Call channelReadComplete on the children until this has been propagated enough.
+        while let channel = self.didReadChannels.removeFirst() {
+            channel.receiveParentChannelReadComplete()
+        }
+
         if case .flushPending = self.flushState {
             self.flushState = .notReading
             context.flush()

--- a/Sources/NIOHTTP2/StreamChannelList.swift
+++ b/Sources/NIOHTTP2/StreamChannelList.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+
+/// A linked list for storing HTTP2StreamChannels.
+///
+/// Note that while this object *could* conform to `Sequence`, there is minimal value in doing
+/// that here, as it's so single-use. If we find ourselves needing to expand on this data type
+/// in future we can revisit that idea.
+struct StreamChannelList {
+    private var head: HTTP2StreamChannel?
+    private var tail: HTTP2StreamChannel?
+}
+
+/// A node for objects stored in an intrusive linked list.
+///
+/// Any object that wishes to be stored in a linked list must embed one of these nodes.
+struct StreamChannelListNode {
+    fileprivate enum ListState {
+        case inList(next: HTTP2StreamChannel?)
+        case notInList
+    }
+
+    fileprivate var state: ListState = .notInList
+
+    internal init() { }
+}
+
+
+extension StreamChannelList {
+    /// Append an element to the linked list.
+    mutating func append(_ element: HTTP2StreamChannel) {
+        precondition(!element.inList)
+
+        guard case .notInList = element.streamChannelListNode.state else {
+            preconditionFailure("Appended an element already in a list")
+        }
+
+        element.streamChannelListNode.state = .inList(next: nil)
+
+        if let tail = self.tail {
+            tail.streamChannelListNode.state = .inList(next: element)
+            self.tail = element
+        } else {
+            assert(self.head == nil)
+            self.head = element
+            self.tail = element
+        }
+    }
+
+    mutating func removeFirst() -> HTTP2StreamChannel? {
+        guard let head = self.head else {
+            assert(self.tail == nil)
+            return nil
+        }
+
+        guard case .inList(let next) = head.streamChannelListNode.state else {
+            preconditionFailure("Popped an element not in a list")
+        }
+
+        self.head = next
+        if self.head == nil {
+            assert(self.tail === head)
+            self.tail = nil
+        }
+
+        head.streamChannelListNode = .init()
+        return head
+    }
+
+    mutating func removeAll() {
+        while self.removeFirst() != nil { }
+    }
+}
+
+
+// MARK:- IntrusiveLinkedListElement helpers.
+extension HTTP2StreamChannel {
+    /// Whether this element is currently in a list.
+    internal var inList: Bool {
+        switch self.streamChannelListNode.state {
+        case .inList:
+            return true
+        case .notInList:
+            return false
+        }
+    }
+}

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -65,6 +65,8 @@ extension HTTP2StreamMultiplexerTests {
                 ("testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive", testCreatedChildChannelCanBeClosedImmediatelyWhenBaseIsActive),
                 ("testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive", testCreatedChildChannelCanBeClosedBeforeWritingHeadersWhenBaseIsActive),
                 ("testMultiplexerCoalescesFlushCallsDuringChannelRead", testMultiplexerCoalescesFlushCallsDuringChannelRead),
+                ("testMultiplexerDoesntFireReadCompleteForEachFrame", testMultiplexerDoesntFireReadCompleteForEachFrame),
+                ("testMultiplexerCorrectlyTellsAllStreamsAboutReadComplete", testMultiplexerCorrectlyTellsAllStreamsAboutReadComplete),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Currently swift-nio-http2 is extremely naive with its use of
channelReadComplete calls in HTTP2StreamChannel, firing one
channelReadComplete call per frame read. In high frame load cases this
leads to a lot of excessive channelReadComplete traffic, which can cause
unnecessary time spent in flush calls.

We should try to minimise the amount of time we spend on this
bookkeeping and save the CPU cost.

Modifications:

- Store a linked-list of HTTP2StreamChannels that need to have
channelReadComplete fired on them.
- Fire channelReadComplete based on this linked list.

Result:

Moderate improvement in performance in high-throughput workloads.