### PR TITLE
[nghttp2] Forward `channelInactive` events to the child channels.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -85,6 +85,12 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             }
         }
     }
+    
+    public func channelInactive(ctx: ChannelHandlerContext) {
+        for channel in self.streams.values {
+            channel.receiveStreamClosed(nil)
+        }
+    }
 
     public func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any) {
         // The only event we care about right now is StreamClosedEvent, and in particular

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -35,6 +35,7 @@ extension HTTP2StreamMultiplexerTests {
                 ("testFramesForClosedStreamsAreReported", testFramesForClosedStreamsAreReported),
                 ("testClosingIdleChannels", testClosingIdleChannels),
                 ("testClosingActiveChannels", testClosingActiveChannels),
+                ("testClosingChannelAlsoClosesChildChannels", testClosingChannelAlsoClosesChildChannels),
                 ("testClosePromiseIsSatisfiedWithTheEvent", testClosePromiseIsSatisfiedWithTheEvent),
                 ("testMultipleClosePromisesAreSatisfied", testMultipleClosePromisesAreSatisfied),
                 ("testClosePromiseFailsWithError", testClosePromiseFailsWithError),


### PR DESCRIPTION
Not sure if you are still interested in patches for the nghttp2 support branch. Some people might be brave enough to be still using it... ;)

I noticed that stale/disconnected connections never fail/disconnect the child channels. The reason seems to be that the multiplexer does not forward `channelIncactive` events. This PR fixes this.

If you _really want_ I can add an test for this...