### PR TITLE
Allow servers to send PUSH_PROMISE before HEADERS.

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -59,6 +59,8 @@ extension SimpleClientServerTests {
                 ("testClientConnectionErrorCorrectlyReported", testClientConnectionErrorCorrectlyReported),
                 ("testChangingMaxConcurrentStreams", testChangingMaxConcurrentStreams),
                 ("testFailsPromisesForBufferedWrites", testFailsPromisesForBufferedWrites),
+                ("testAllowPushPromiseBeforeReceivingHeadersNoBody", testAllowPushPromiseBeforeReceivingHeadersNoBody),
+                ("testAllowPushPromiseBeforeReceivingHeadersWithPossibleBody", testAllowPushPromiseBeforeReceivingHeadersWithPossibleBody),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

RFC 7540 is not particularly clear on whether the server is required to
send PUSH_PROMISE frames before or after the HEADERS frame, or whether
both are acceptable. We took a somewhat hard-line approach by asserting
that PUSH_PROMISE could only be sent after the server sent HEADERS, but
we've now caught at least one notable implementation in the wild doing
something different (nghttp2).

Given that there's no clear normative language pointing in either
direction, we should consider being a bit more lenient and allowing
both.

Modifications:

- Updated the stream state machine to allow pushes on a locally-idle
stream.

Result:

Servers can send PUSH_PROMISE before they have sent HEADERS.
Resolves #144.