### PR TITLE
ignore frames that don't have a HTTP/1 equivalent

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -79,12 +79,9 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
             if content.endStream {
                 context.fireChannelRead(self.wrapInboundOut(.end(nil)))
             }
-        case .alternativeService, .rstStream, .priority, .windowUpdate:
-            // All these frames may be sent on a stream, but are ignored by the multiplexer and will be
-            // handled elsewhere.
+        case .alternativeService, .rstStream, .priority, .windowUpdate, .settings, .pushPromise, .ping, .goAway, .origin:
+            // These don't have an HTTP/1 equivalent, so let's drop them.
             return
-        default:
-            fatalError("unimplemented frame \(frame)")
         }
     }
 

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
@@ -53,6 +53,7 @@ extension HTTP2ToHTTP1CodecTests {
                 ("testReceiveResponseWithNonNumericalStatus", testReceiveResponseWithNonNumericalStatus),
                 ("testSendRequestWithoutHost", testSendRequestWithoutHost),
                 ("testSendRequestWithDuplicateHost", testSendRequestWithDuplicateHost),
+                ("testFramesWithoutHTTP1EquivalentAreIgnored", testFramesWithoutHTTP1EquivalentAreIgnored),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Previously, the H2to1 codec would crash if for example a push promise
came by.

Modifications:

Instead of crashing, ignore the frames without equivalent.

Result:

Fewer crashes.