### PR TITLE
fix allocation counter limits

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,7 +18,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=374000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -31,7 +31,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=374000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
 
   shell:
     image: swift-nio-http2:18.04-5.0


### PR DESCRIPTION
Motivation:

We regressed 4 allocations in the security update
https://github.com/apple/swift-nio-http2/security/advisories/GHSA-jchv-x857-q8fq
. Four allocations are a great tradeoff for a number of security
vulnerabilities fixed but we need to raise the limits accordingly.

Modifications:

Raise the limits to the new limit so tests can pass again.

Result:

PRs can pass again and master should build again.