### PR TITLE
accept more valid-in-HTTP/1 but invalid-in-H2 messages

### DIFF
--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -36,6 +36,7 @@ extension HPACKCodingTests {
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
                 ("testHPACKHeadersWithZeroIndex", testHPACKHeadersWithZeroIndex),
                 ("testHPACKDecoderRespectsMaxHeaderListSize", testHPACKDecoderRespectsMaxHeaderListSize),
+                ("testDifferentlyCasedHPACKHeadersAreNotEqual", testDifferentlyCasedHPACKHeadersAreNotEqual),
            ]
    }
 }

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -608,4 +608,18 @@ class HPACKCodingTests: XCTestCase {
         let decoded = try decoder.decodeHeaders(from: &request)
         XCTAssertEqual(decoded, HPACKHeaders(Array(repeatElement((":method", "GET"), count: 1000))))
     }
+
+    func testDifferentlyCasedHPACKHeadersAreNotEqual() {
+        let variants: [HPACKHeaders] = [HPACKHeaders([("foo", "foox")]), HPACKHeaders([("Foo", "foo")]),
+                                        HPACKHeaders([("foo", "Foo")]), HPACKHeaders([("Foo", "Foo")])]
+
+        for v1 in variants.indices {
+            for v2 in variants.indices {
+                guard v1 != v2 else {
+                    continue
+                }
+                XCTAssertNotEqual(variants[v1], variants[v2], "indices \(v1) and \(v2)")
+            }
+        }
+    }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
@@ -54,6 +54,12 @@ extension HTTP2ToHTTP1CodecTests {
                 ("testSendRequestWithoutHost", testSendRequestWithoutHost),
                 ("testSendRequestWithDuplicateHost", testSendRequestWithDuplicateHost),
                 ("testFramesWithoutHTTP1EquivalentAreIgnored", testFramesWithoutHTTP1EquivalentAreIgnored),
+                ("testWeTolerateUpperCasedHTTP1HeadersForRequests", testWeTolerateUpperCasedHTTP1HeadersForRequests),
+                ("testWeTolerateUpperCasedHTTP1HeadersForResponses", testWeTolerateUpperCasedHTTP1HeadersForResponses),
+                ("testWeDoNotNormalizeHeadersIfUserAskedUsNotToForRequests", testWeDoNotNormalizeHeadersIfUserAskedUsNotToForRequests),
+                ("testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses", testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses),
+                ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests),
+                ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

HTTP/2 is mostly just HTTP(/1) semantics with streams on a new wire
protocol. However, there are certain things that are legal in HTTP/1 but
which are illegal in HTTP/2.

Modification:

Accept more of those messages and transform them into their HTTP/2
equivalent.

Result:

- Easier to write HTTP/2 clients & servers in NIO.
- fixes #152