### PR TITLE
fix dependencies: require NIO 2.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.3.0"),
     ],
     targets: [
         .target(name: "NIOHTTP2Server",


### PR DESCRIPTION
### Motivation

Having correct dependencies is important but `swift-nio-http2` requires NIO 2.3.0 or better but claimed it could do with NIO 2.0.0.

### Modification

Bump the NIO requirement to 2.3.0.

### Result

Dependencies more correct.