### PR TITLE
swift 5.1 docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,11 +23,18 @@ RUN gem install jazzy --no-ri --no-rdoc
 RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
+# script to allow mapping framepointers on linux (until part of the toolchain)
+RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
+RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal
+
+# swiftformat (until part of the toolchain)
+
+ARG swiftformat_version=0.40.12
+RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
+RUN cd $HOME/.tools/swift-format && swift build -c release
+RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat
+
 # h2spec
 ARG h2spec_version
 RUN [ -z $h2spec_version ] || wget -q https://github.com/summerwind/h2spec/releases/download/v$h2spec_version/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz
 RUN [ -z $h2spec_version ] || tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools
-
-# script to allow mapping framepointers on linux
-RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
-RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -3,35 +3,35 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
     build:
       args:
-        ubuntu_version: "bionic"
+        ubuntu_version: "xenial"
         swift_version: "5.1"
         h2spec_version: "2.2.1"
 
   unit-tests:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
 
   integration-tests:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
 
   performance-test:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
 
   h2spec:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
 
   test:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
 
   shell:
-    image: swift-nio-http2:18.04-5.1
+    image: swift-nio-http2:16.04-5.1

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-http2:18.04-5.1
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.1"
+        h2spec_version: "2.2.1"
+
+  unit-tests:
+    image: swift-nio-http2:18.04-5.1
+
+  integration-tests:
+    image: swift-nio-http2:18.04-5.1
+    environment:
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
+      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+
+  performance-test:
+    image: swift-nio-http2:18.04-5.1
+
+  h2spec:
+    image: swift-nio-http2:18.04-5.1
+
+  test:
+    image: swift-nio-http2:18.04-5.1
+    environment:
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
+      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+
+  shell:
+    image: swift-nio-http2:18.04-5.1


### PR DESCRIPTION
motivation: support swift 5.1

changes:
* add docker compose file for swift 5.1, will add CI job once merged
* update swiftformat version to 0.40.12
* use more standard dockerfile setup