### PR TITLE
Swift 5.1 support for CI

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-http2:16.04-5.1
+    build:
+      args:
+        ubuntu_version: "xenial"
+        swift_version: "5.1"
+        h2spec_version: "2.2.1"
+
+  unit-tests:
+    image: swift-nio-http2:16.04-5.1
+
+  integration-tests:
+    image: swift-nio-http2:16.04-5.1
+    environment:
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
+      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+
+  performance-test:
+    image: swift-nio-http2:16.04-5.1
+
+  h2spec:
+    image: swift-nio-http2:16.04-5.1
+
+  test:
+    image: swift-nio-http2:16.04-5.1
+    environment:
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
+      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+
+  shell:
+    image: swift-nio-http2:16.04-5.1


### PR DESCRIPTION
```
[...]
Step 19/20 : RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
 ---> Running in 5fe358f141e2
Removing intermediate container 5fe358f141e2
 ---> 6af14966355c
Step 20/20 : RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal
 ---> Running in 3d18d06a7d43
Removing intermediate container 3d18d06a7d43
 ---> b909c721ec38
Successfully built b909c721ec38
Successfully tagged swift-nio-http2:16.04-5.1
```