### PR TITLE
namespace ChannelOptions & fix deprecations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.3.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
     ],
     targets: [
         .target(name: "NIOHTTP2Server",
@@ -35,7 +35,7 @@ let package = Package(
         .target(name: "NIOHPACK",
             dependencies: ["NIO", "NIOConcurrencyHelpers", "NIOHTTP1"]),
         .testTarget(name: "NIOHTTP2Tests",
-            dependencies: ["NIO", "NIOHTTP1", "NIOHTTP2"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOHTTP2", "NIOFoundationCompat"]),
         .testTarget(name: "NIOHPACKTests",
             dependencies: ["NIOHPACK"])
     ]

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -15,26 +15,35 @@
 import NIO
 import NIOConcurrencyHelpers
 
-/// `StreamIDOption` allows users to query the stream ID for a given `HTTP2StreamChannel`.
-///
-/// On active `HTTP2StreamChannel`s, it is possible that a channel handler or user may need to know which
-/// stream ID the channel owns. This channel option allows that query. Please note that this channel option
-/// is *get-only*: that is, it cannot be used with `setOption`. The stream ID for a given `HTTP2StreamChannel`
-/// is immutable.
-public struct StreamIDOption: ChannelOption {
-    public typealias Value = HTTP2StreamID
-
-    public init() { }
-}
 
 /// The various channel options specific to `HTTP2StreamChannel`s.
 ///
 /// Please note that some of NIO's regular `ChannelOptions` are valid on `HTTP2StreamChannel`s.
 public struct HTTP2StreamChannelOptions {
     /// - seealso: `StreamIDOption`.
-    public static let streamID: StreamIDOption = StreamIDOption()
+    public static let streamID: HTTP2StreamChannelOptions.Types.StreamIDOption = .init()
 }
 
+extension HTTP2StreamChannelOptions {
+    public enum Types {}
+}
+
+@available(*, deprecated, renamed: "HTTP2StreamChannelOptions.Types.StreamIDOption")
+public typealias StreamIDOption = HTTP2StreamChannelOptions.Types.StreamIDOption
+
+extension HTTP2StreamChannelOptions.Types {
+    /// `StreamIDOption` allows users to query the stream ID for a given `HTTP2StreamChannel`.
+    ///
+    /// On active `HTTP2StreamChannel`s, it is possible that a channel handler or user may need to know which
+    /// stream ID the channel owns. This channel option allows that query. Please note that this channel option
+    /// is *get-only*: that is, it cannot be used with `setOption`. The stream ID for a given `HTTP2StreamChannel`
+    /// is immutable.
+    public struct StreamIDOption: ChannelOption {
+        public typealias Value = HTTP2StreamID
+
+        public init() { }
+    }
+}
 
 /// The current state of a stream channel.
 private enum StreamChannelState {
@@ -269,7 +278,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         assert(eventLoop.inEventLoop)
 
         switch option {
-        case _ as AutoReadOption:
+        case _ as ChannelOptions.Types.AutoReadOption:
             self.autoRead = value as! Bool
         default:
             fatalError("setting option \(option) on HTTP2StreamChannel not supported")
@@ -280,9 +289,9 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         assert(eventLoop.inEventLoop)
 
         switch option {
-        case _ as StreamIDOption:
+        case _ as HTTP2StreamChannelOptions.Types.StreamIDOption:
             return self.streamID as! Option.Value
-        case _ as AutoReadOption:
+        case _ as ChannelOptions.Types.AutoReadOption:
             return self.autoRead as! Option.Value
         default:
             fatalError("option \(option) not supported on HTTP2StreamChannel")

--- a/Tests/NIOHPACKTests/HuffmanCodingTests.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests.swift
@@ -14,6 +14,7 @@
 
 import XCTest
 import NIO
+import NIOFoundationCompat
 import Foundation
 @testable import NIOHPACK
 
@@ -136,13 +137,10 @@ class HuffmanCodingTests: XCTestCase {
         }
         
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-        buffer.writeWithUnsafeMutableBytes { ptr in
-            let bytePtr = ptr.bindMemory(to: UInt8.self)
-            return data.copyBytes(to: bytePtr)
-        }
-        
+        buffer.writeBytes(data)
+
         // warm up the decoder
-        _ = try! buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes)
+        XCTAssertNoThrow(try buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes))
         
         self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
             startMeasuring()
@@ -183,13 +181,10 @@ class HuffmanCodingTests: XCTestCase {
         }
         
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-        buffer.writeWithUnsafeMutableBytes { ptr in
-            let bytePtr = ptr.bindMemory(to: UInt8.self)
-            return data.copyBytes(to: bytePtr)
-        }
+        buffer.writeBytes(data)
         
         // ensure the decoder table has been loaded
-        _ = try! buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes)
+        XCTAssertNoThrow(try buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes))
         
         self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
             startMeasuring()

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -588,7 +588,7 @@ func openTemporaryFile() -> (CInt, String) {
 extension FileRegion {
     func asByteBuffer(allocator: ByteBufferAllocator) -> ByteBuffer {
         var fileBuffer = allocator.buffer(capacity: self.readableBytes)
-        fileBuffer.writeWithUnsafeMutableBytes { ptr in
+        fileBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: self.readableBytes) { ptr in
             let rc = try! self.fileHandle.withUnsafeFileDescriptor { fd -> Int in
                 lseek(fd, off_t(self.readerIndex), SEEK_SET)
                 return read(fd, ptr.baseAddress!, self.readableBytes)

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,7 +18,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=384810
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -31,7 +31,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=72010
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=378000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=384810
 
   shell:
     image: swift-nio-http2:18.04-5.0


### PR DESCRIPTION
Motivation:

All other NIO repositories now have namespaced ChannelOptions.

Modifications:

Namespace the ChannelOptions and fix the deprecations resulting from namespacing swift-nio's ChannelOptions (and other 2.9.0 changes).

Results:

Fewer warnings.