### PR TITLE
Add HPACK and Huffman benchmarks.

### DIFF
--- a/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
@@ -13,14 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 protocol Benchmark: class {
-    init()
     func setUp() throws
     func tearDown()
     func run() throws -> Int
 }
 
-func measureAndPrint<B: Benchmark>(desc: String, benchmark: B.Type) throws {
-    let bench = B()
+func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
     try bench.setUp()
     defer {
         bench.tearDown()

--- a/Sources/NIOHTTP2PerformanceTester/HPACKHeaderDecodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HPACKHeaderDecodingBenchmark.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHPACK
+
+
+final class HPACKHeaderDecodingBenchmark {
+    private var headers: ByteBuffer
+    private let loopCount: Int
+    private var decoder: HPACKDecoder
+
+    init(headers: HPACKHeaders, loopCount: Int) {
+        self.headers = headers.encoded
+        self.loopCount = loopCount
+        self.decoder = HPACKDecoder(allocator: .init())
+    }
+}
+
+
+extension HPACKHeaderDecodingBenchmark: Benchmark {
+    func setUp() throws { }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        for _ in 0..<self.loopCount {
+            _ = try self.decoder.decodeHeaders(from: &self.headers)
+            self.headers.moveReaderIndex(to: 0)
+        }
+
+        return self.loopCount
+    }
+}
+
+
+extension HPACKHeaders {
+    fileprivate var encoded: ByteBuffer {
+        var encoder = HPACKEncoder(allocator: .init())
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        try! encoder.encode(headers: self, to: &buffer)
+        return buffer
+    }
+}

--- a/Sources/NIOHTTP2PerformanceTester/HPACKHeaderEncodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HPACKHeaderEncodingBenchmark.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHPACK
+
+
+final class HPACKHeaderEncodingBenchmark {
+    private let headers: HPACKHeaders
+    private let loopCount: Int
+    private var encoder: HPACKEncoder
+    private var buffer: ByteBuffer
+
+    init(headers: HPACKHeaders, loopCount: Int) {
+        self.headers = headers
+        self.loopCount = loopCount
+        self.encoder = HPACKEncoder(allocator: ByteBufferAllocator())
+        self.buffer = ByteBufferAllocator().buffer(capacity: 1024)
+    }
+}
+
+
+extension HPACKHeaderEncodingBenchmark: Benchmark {
+    func setUp() throws { }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        for _ in 0..<self.loopCount {
+            try self.encoder.encode(headers: headers, to: &self.buffer)
+            self.buffer.clear()
+        }
+
+        return self.loopCount
+    }
+}
+
+
+extension HPACKHeaders {
+    static let indexable: HPACKHeaders = {
+        var headers = HPACKHeaders()
+        headers.add(contentsOf: [(":method", "GET"), (":path", "/"), (":scheme", "https"), (":authority", "localhost"), ("foo", "bar")],
+                    indexing: .indexable)
+        return headers
+    }()
+
+    static let nonIndexable: HPACKHeaders = {
+        var headers = HPACKHeaders()
+        headers.add(contentsOf: [(":method", "GET"), (":path", "/"), (":scheme", "https"), (":authority", "localhost"), ("foo", "bar")],
+                    indexing: .nonIndexable)
+        return headers
+    }()
+
+    static let neverIndexed: HPACKHeaders = {
+        var headers = HPACKHeaders()
+        headers.add(contentsOf: [(":method", "GET"), (":path", "/"), (":scheme", "https"), (":authority", "localhost"), ("foo", "bar")],
+                    indexing: .neverIndexed)
+        return headers
+    }()
+}

--- a/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIO
+import NIOHPACK
+
+
+/// This benchmark is mostly attempting to stress the Huffman Decoding implementation by
+/// way of using larger or more complex strings.
+final class HuffmanDecodingBenchmark {
+    private let loopCount: Int
+    private var decoder: HPACKDecoder
+    private var buffer: ByteBuffer
+
+    init(huffmanBytes: [UInt8], loopCount: Int) {
+        self.loopCount = loopCount
+        self.decoder = HPACKDecoder(allocator: .init(), maxDynamicTableSize: HPACKDecoder.maxDynamicTableSize, maxHeaderListSize: .max)
+        self.buffer = ByteBufferAllocator().buffer(capacity: 1024)
+
+        // We encode this header with both the name and value as a huffman string, never indexed.
+        self.buffer.writeInteger(UInt8(0x10))  // Never indexed, non-indexed name
+        self.buffer.encodeInteger(1, prefix: 7, prefixBits: 0x80)  // Name length, huffman encoded, 7-bit integer
+        self.buffer.writeInteger(UInt8(0x97))  // Huffman encoded "f"
+        self.buffer.encodeInteger(UInt(huffmanBytes.count), prefix: 7, prefixBits: 0x80)  // Value length, huffman encoded, 7-bit integer
+        self.buffer.writeBytes(huffmanBytes)
+    }
+}
+
+
+extension HuffmanDecodingBenchmark: Benchmark {
+    func setUp() throws {
+        // Run a single iteration of the loop. This warms up the encoder and decoder and ensures all the pages are mapped.
+        try self.loopIteration()
+    }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        for _ in 0..<self.loopCount {
+            try self.loopIteration()
+        }
+
+        return self.loopCount
+    }
+
+    private func loopIteration() throws {
+        _ = try self.decoder.decodeHeaders(from: &self.buffer)
+        self.buffer.moveReaderIndex(to: 0)
+    }
+}
+
+
+extension Array where Element == UInt8 {
+    static let basicHuffmanBytes: [UInt8] = {
+        // This is hilariously slow (TWO intermediate Data objects!) but it's only invoked in setup so who cares?
+        let url = fixtureDirectoryURL.appendingPathComponent("large_huffman_b64.txt")
+        let base64Data = try! Data(contentsOf: url)
+        let data = Data(base64Encoded: base64Data)!
+        return Array(data)
+    }()
+
+    static let complexHuffmanBytes: [UInt8] = {
+        let url = fixtureDirectoryURL.appendingPathComponent("large_complex_huffman_b64.txt")
+        let base64Data = try! Data(contentsOf: url)
+        let data = Data(base64Encoded: base64Data)!
+        return Array(data)
+    }()
+
+    // The location of the test fixtures.
+    private static let fixtureDirectoryURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Tests").appendingPathComponent("NIOHPACKTests").appendingPathComponent("Fixtures").absoluteURL
+}
+
+
+extension ByteBuffer {
+    // Copied directly from our internal implementation.
+    fileprivate mutating func encodeInteger(_ value: UInt, prefix: Int, prefixBits: UInt8 = 0) {
+        assert(prefix <= 8)
+        assert(prefix >= 1)
+
+        let k = (1 << prefix) - 1
+        var initialByte = prefixBits
+
+        if value < k {
+            // it fits already!
+            initialByte |= UInt8(truncatingIfNeeded: value)
+            self.writeInteger(initialByte)
+            return
+        }
+
+        // if it won't fit in this byte altogether, fill in all the remaining bits and move
+        // to the next byte.
+        initialByte |= UInt8(truncatingIfNeeded: k)
+        self.writeInteger(initialByte)
+
+        // deduct the initial [prefix] bits from the value, then encode it seven bits at a time into
+        // the remaining bytes.
+        var n = value - UInt(k)
+        while n >= 128 {
+            let nextByte = (1 << 7) | UInt8(n & 0x7f)
+            self.writeInteger(nextByte)
+            n >>= 7
+        }
+
+        self.writeInteger(UInt8(n))
+    }
+}

--- a/Sources/NIOHTTP2PerformanceTester/HuffmanEncodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HuffmanEncodingBenchmark.swift
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHPACK
+
+
+/// This benchmark is mostly attempting to stress the Huffman Encoding implementation by
+/// way of using larger or more complex strings.
+final class HuffmanEncodingBenchmark {
+    private var headers: HPACKHeaders
+    private let loopCount: Int
+    private var encoder: HPACKEncoder
+    private var buffer: ByteBuffer
+
+    init(huffmanString: String, loopCount: Int) {
+        self.headers = HPACKHeaders()
+        self.headers.add(name: "f", value: huffmanString, indexing: .neverIndexed)
+
+        self.loopCount = loopCount
+        self.encoder = HPACKEncoder(allocator: .init())
+        self.buffer = ByteBufferAllocator().buffer(capacity: 1024)
+    }
+}
+
+
+extension HuffmanEncodingBenchmark: Benchmark {
+    func setUp() throws {
+        // Run a single iteration of the loop. This warms up the encoder and decoder and ensures all the pages are mapped.
+        try self.loopIteration()
+    }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        for _ in 0..<self.loopCount {
+            try self.loopIteration()
+        }
+
+        return self.loopCount
+    }
+
+    private func loopIteration() throws {
+        try self.encoder.encode(headers: self.headers, to: &self.buffer)
+        self.buffer.clear()
+    }
+}
+
+
+extension String {
+    static let basicHuffmanString: String = {
+        var text = "Hello, world. I am a header value; I have Teh Texts. I am going on for quite a long time because I want to ensure that the encoded data buffer needs to be expanded to test out that code. I'll try some meta-characters too: \r\t\n ought to do it, no?"
+        while text.count < 1024 * 128 {
+            text += text
+        }
+        return text
+    }()
+
+    static let complexHuffmanString: String = {
+        var text = "午セイ谷高ぐふあト食71入ツエヘナ津県を類及オモ曜一購ごきわ致掲ぎぐず敗文輪へけり鯖審ヘ塊米卸呪おぴ。"
+        while text.utf8.count < 128 * 1024 {
+            text += text
+        }
+        return text
+    }()
+}

--- a/Sources/NIOHTTP2PerformanceTester/main.swift
+++ b/Sources/NIOHTTP2PerformanceTester/main.swift
@@ -59,4 +59,14 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void
 
 // MARK: Utilities
 
-try measureAndPrint(desc: "1_conn_10k_reqs", benchmark: Bench1Conn10kRequests.self)
+try measureAndPrint(desc: "1_conn_10k_reqs", benchmark: Bench1Conn10kRequests())
+try measureAndPrint(desc: "encode_100k_header_blocks_indexable", benchmark: HPACKHeaderEncodingBenchmark(headers: .indexable, loopCount: 100_000))
+try measureAndPrint(desc: "encode_100k_header_blocks_nonindexable", benchmark: HPACKHeaderEncodingBenchmark(headers: .nonIndexable, loopCount: 100_000))
+try measureAndPrint(desc: "encode_100k_header_blocks_neverIndexed", benchmark: HPACKHeaderEncodingBenchmark(headers: .neverIndexed, loopCount: 100_000))
+try measureAndPrint(desc: "decode_100k_header_blocks_indexable", benchmark: HPACKHeaderDecodingBenchmark(headers: .indexable, loopCount: 100_000))
+try measureAndPrint(desc: "decode_100k_header_blocks_nonindexable", benchmark: HPACKHeaderDecodingBenchmark(headers: .nonIndexable, loopCount: 100_000))
+try measureAndPrint(desc: "decode_100k_header_blocks_neverIndexed", benchmark: HPACKHeaderDecodingBenchmark(headers: .neverIndexed, loopCount: 100_000))
+try measureAndPrint(desc: "huffman_encode_basic", benchmark: HuffmanEncodingBenchmark(huffmanString: .basicHuffmanString, loopCount: 100))
+try measureAndPrint(desc: "huffman_encode_complex", benchmark: HuffmanEncodingBenchmark(huffmanString: .complexHuffmanString, loopCount: 100))
+try measureAndPrint(desc: "huffman_decode_basic", benchmark: HuffmanDecodingBenchmark(huffmanBytes: .basicHuffmanBytes, loopCount: 25))
+try measureAndPrint(desc: "huffman_decode_complex", benchmark: HuffmanDecodingBenchmark(huffmanBytes: .complexHuffmanBytes, loopCount: 10))

--- a/Tests/NIOHPACKTests/HuffmanCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests+XCTest.swift
@@ -28,10 +28,6 @@ extension HuffmanCodingTests {
       return [
                 ("testBasicCoding", testBasicCoding),
                 ("testComplexCoding", testComplexCoding),
-                ("testBasicEncodingPerformance", testBasicEncodingPerformance),
-                ("testBasicDecodingPerformance", testBasicDecodingPerformance),
-                ("testComplexEncodingPerformance", testComplexEncodingPerformance),
-                ("testComplexDecodingPerformance", testComplexDecodingPerformance),
            ]
    }
 }

--- a/Tests/NIOHPACKTests/HuffmanCodingTests.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests.swift
@@ -19,24 +19,7 @@ import Foundation
 @testable import NIOHPACK
 
 class HuffmanCodingTests: XCTestCase {
-    /// Control timing-sensitive tests from command-line in run-time:
-    ///     ENABLE_TIMING_TESTS=false swift test
-    ///     ENABLED_SANITIZERS=true swift test -fsanitize=thread
-    /// or during compile time:
-    ///     swift test -fsanitize=thread -DENABLED_SANITIZERS
-    let timeSensitiveTestEnabled: Bool = {
-        #if ENABLED_SANITIZERS
-        return false
-        #else
-        let env = ProcessInfo.processInfo.environment
-        return ((env["ENABLED_SANITIZERS"] ?? "false") == "false")
-            && ((env["ENABLE_TIMING_TESTS"] ?? "true") == "true")
-        #endif
-    }()
-
     var scratchBuffer: ByteBuffer = ByteBufferAllocator().buffer(capacity: 4096)
-    
-    let fixtureDirURL = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Fixtures").absoluteURL
     
     // MARK: - Helper Methods
     
@@ -103,93 +86,4 @@ class HuffmanCodingTests: XCTestCase {
         
         try verifyHuffmanCoding(text2, Array(encoded2Data))
     }
-
-    func testBasicEncodingPerformance() {
-        guard self.timeSensitiveTestEnabled else { return }
-
-        var text = "Hello, world. I am a header value; I have Teh Texts. I am going on for quite a long time because I want to ensure that the encoded data buffer needs to be expanded to test out that code. I'll try some meta-characters too: \r\t\n ought to do it, no?"
-        while text.count < 1024 * 128 {
-            text += text
-        }
-        
-        // warm up the encoder
-        self.scratchBuffer.setHuffmanEncoded(bytes: text.utf8)
-        
-        self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
-            self.scratchBuffer.clear()
-            startMeasuring()
-            self.scratchBuffer.setHuffmanEncoded(bytes: text.utf8)
-            stopMeasuring()
-        }
-    }
-    
-    func testBasicDecodingPerformance() {
-        guard self.timeSensitiveTestEnabled else { return }
-
-        let url = fixtureDirURL.appendingPathComponent("large_huffman_b64.txt")
-        guard let base64Data = try? Data(contentsOf: url) else {
-            XCTFail("Couldn't load fixture data")
-            return
-        }
-        guard let data = Data(base64Encoded: base64Data) else {
-            XCTFail("Couldn't decode base64 fixture data")
-            return
-        }
-        
-        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-        buffer.writeBytes(data)
-
-        // warm up the decoder
-        XCTAssertNoThrow(try buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes))
-        
-        self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
-            startMeasuring()
-            _ = try! buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes)
-        }
-    }
-    
-    func testComplexEncodingPerformance() {
-        guard self.timeSensitiveTestEnabled else { return }
-
-        var text = "午セイ谷高ぐふあト食71入ツエヘナ津県を類及オモ曜一購ごきわ致掲ぎぐず敗文輪へけり鯖審ヘ塊米卸呪おぴ。"
-        while text.utf8.count < 128 * 1024 {
-            text += text
-        }
-        
-        // warm up the encoder
-        self.scratchBuffer.setHuffmanEncoded(bytes: text.utf8)
-        
-        self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
-            self.scratchBuffer.clear()
-            startMeasuring()
-            self.scratchBuffer.setHuffmanEncoded(bytes: text.utf8)
-            stopMeasuring()
-        }
-    }
-    
-    func testComplexDecodingPerformance() {
-        guard self.timeSensitiveTestEnabled else { return }
-
-        let url = fixtureDirURL.appendingPathComponent("large_complex_huffman_b64.txt")
-        guard let base64Data = try? Data(contentsOf: url) else {
-            XCTFail("Couldn't load fixture data")
-            return
-        }
-        guard let data = Data(base64Encoded: base64Data) else {
-            XCTFail("Couldn't decode base64 fixture data")
-            return
-        }
-        
-        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-        buffer.writeBytes(data)
-        
-        // ensure the decoder table has been loaded
-        XCTAssertNoThrow(try buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes))
-        
-        self.measureMetrics(HuffmanCodingTests.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
-            startMeasuring()
-            _ = try! buffer.getHuffmanEncodedString(at: buffer.readerIndex, length: buffer.readableBytes)
-        }
-    }
-
 }


### PR DESCRIPTION
Motivation:
    
Having benchmarks for the HPACK encoder and decoder gives us betterinsight into their performance.
    
While we're here, we can move the Huffman benchmarks out of the unit tests and into the benchmark suite.
    
Modifications:
    
Added encoder, decoder, and huffman benchmarks.
    
Result:
    
Better performance numbers.
