### PR TITLE
Fix partial table lookups.

### DIFF
--- a/Sources/NIOHPACK/HPACKEncoder.swift
+++ b/Sources/NIOHPACK/HPACKEncoder.swift
@@ -295,7 +295,7 @@ public struct HPACKEncoder {
     }
     
     private mutating func _appendNonIndexed(header: String, value: String) {
-        if let (index, _) = self.headerIndexTable.firstHeaderMatch(for: header, value: value) {
+        if let (index, _) = self.headerIndexTable.firstHeaderMatch(for: header, value: nil) {
             // we actually don't care if it has a value in this instance; we're only indexing the
             // name.
             self.buffer.write(encodedInteger: UInt(index), prefix: 4, prefixBits: 0)

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -40,6 +40,7 @@ extension HPACKCodingTests {
                 ("testHPACKHeadersWithZeroIndex", testHPACKHeadersWithZeroIndex),
                 ("testHPACKDecoderRespectsMaxHeaderListSize", testHPACKDecoderRespectsMaxHeaderListSize),
                 ("testDifferentlyCasedHPACKHeadersAreNotEqual", testDifferentlyCasedHPACKHeadersAreNotEqual),
+                ("testHPACKHeadersDontSearchForFullMatchesForNonIndexedHeaders", testHPACKHeadersDontSearchForFullMatchesForNonIndexedHeaders),
            ]
    }
 }

--- a/Tests/NIOHPACKTests/HeaderTableTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HeaderTableTests+XCTest.swift
@@ -30,6 +30,7 @@ extension HeaderTableTests {
                 ("testDynamicTableInsertion", testDynamicTableInsertion),
                 ("testHeaderDump", testHeaderDump),
                 ("testHeaderDescription", testHeaderDescription),
+                ("testDynamicTableEntryCanBeFoundAsPartialMatch", testDynamicTableEntryCanBeFoundAsPartialMatch),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In many cases it's necessary to be able to do HPACK table lookups to
find only a matching header field name, when it isn't going to be
possible to use a fully indexed header. For example, when using
nonIndexable header fields you cannot use an indexed field value, so
there is no point looking at all the header field values anyway.

While we technically supported this, there were two wrinkles. The first
was that if you attempted to search for a header field without any care
for its name, we'd actually only search the static table, missing
anything added into the dynamic table, which is pretty stupid.

The second issue was that nonIndexable header fields did extra
unnecessary work. This is because we asked the header table to search
for an exact match, but then disregarded whether or not one was found.
That meant a bunch of wasted computation.

Modifications:

- Fixed the table lookup to correctly search both dynamic and static
    tables for partial matches.
- Correctly indicated that nonIndexable headers shouldn't care about
    matching the header value.

Result:

Better handling of non-indexable headers.