### PR TITLE
tolerate multiple RST_STREAMs for same stream

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -168,7 +168,7 @@ struct ConnectionStreamState {
     /// - parameters:
     ///     - streamID: The ID of the stream to modify.
     ///     - ignoreRecentlyReset: Whether a recently reset stream should be ignored. Should be set to `true` when receiving frames.
-    ///     - ignoreClosed: Whether a closed stream should be ignored. Should be set to `true` when receiving window update frames.
+    ///     - ignoreClosed: Whether a closed stream should be ignored. Should be set to `true` when receiving window update or reset stream frames.
     ///     - modifier: A block that will be invoked to modify the stream state, if present.
     /// - returns: The result of the state modification, as well as any state change that occurred to the stream.
     @inline(__always)

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingRstStreamState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingRstStreamState.swift
@@ -23,7 +23,9 @@ protocol ReceivingRstStreamState: HasFlowControlWindows {
 extension ReceivingRstStreamState {
     /// Called to receive a RST_STREAM frame.
     mutating func receiveRstStream(streamID: HTTP2StreamID, reason: HTTP2ErrorCode) -> StateMachineResultWithEffect {
-        let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true) {
+        // RFC 7540 § 6.4 <https://httpwg.org/specs/rfc7540.html#RST_STREAM> does not explicitly forbid a peer sending
+        // multiple RST_STREAMs for the same stream which means we should ignore subsequent RST_STREAMs.
+        let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true, ignoreClosed: true) {
             $0.receiveRstStream(reason: reason)
         }
         return StateMachineResultWithEffect(result, connectionState: self)

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -139,6 +139,7 @@ extension ConnectionStateMachineTests {
                 ("testNoPolicingMissingContentLengthForResponsesWhenValidationDisabled", testNoPolicingMissingContentLengthForResponsesWhenValidationDisabled),
                 ("testNoPolicingInvalidContentLengthForRequestsWithEndStreamWhenValidationDisabled", testNoPolicingInvalidContentLengthForRequestsWithEndStreamWhenValidationDisabled),
                 ("testNoPolicingInvalidContentLengthForResponsesWithEndStreamWhenValidationDisabled", testNoPolicingInvalidContentLengthForResponsesWithEndStreamWhenValidationDisabled),
+                ("testWeTolerateOneStreamBeingResetTwice", testWeTolerateOneStreamBeingResetTwice),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The HTTP/2 RFC does not explicitly forbid sending more than one
RST_STREAM for the same stream. Given that we have seen this behaviour
in the wild we are going to ignore any additional RST_STREAMs.

A further indicative that this is the right call is that the RFC
explicitly mentions that sending RST_STREAMs in the idle state is not
acceptable.

Modifications:

Ignore RST_STREAM frames for streams in the closed state.

Result:

More compatibility.