### PR TITLE
fix new warnings in very new Swift compilers

### DIFF
--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
@@ -70,11 +70,11 @@ final class CompoundOutboundBufferTest: XCTestCase {
         var newFrames: [HTTP2Frame] = Array()
         XCTAssertEqual(buffer.streamClosed(1).count, 0)
 
-        while case .frame(let write) = buffer.nextFlushedWritableFrame(channelWritable: true) {
-            newFrames.append(write.0)
-            XCTAssertNil(write.1)
-            buffer.streamCreated(write.0.streamID, initialWindowSize: 65535)
-            XCTAssertEqual(buffer.streamClosed(write.0.streamID).count, 0)
+        while case .frame(let frame, let promise) = buffer.nextFlushedWritableFrame(channelWritable: true) {
+            newFrames.append(frame)
+            XCTAssertNil(promise)
+            buffer.streamCreated(frame.streamID, initialWindowSize: 65535)
+            XCTAssertEqual(buffer.streamClosed(frame.streamID).count, 0)
         }
 
         subsequentFrames.assertFramesMatch(newFrames)
@@ -349,17 +349,17 @@ final class CompoundOutboundBufferTest: XCTestCase {
         buffer.flushReceived()
 
         // Now attempt to unbuffer the frames.
-        guard case .frame(let firstFrame) = buffer.nextFlushedWritableFrame(channelWritable: true) else {
+        guard case .frame(let firstFrame, _) = buffer.nextFlushedWritableFrame(channelWritable: true) else {
             XCTFail("Didn't get expected frame")
             return
         }
-        firstFrame.0.assertFrameMatches(this: pingFrame)
+        firstFrame.assertFrameMatches(this: pingFrame)
 
-        guard case .frame(let secondFrame) = buffer.nextFlushedWritableFrame(channelWritable: true) else {
+        guard case .frame(let secondFrame, _) = buffer.nextFlushedWritableFrame(channelWritable: true) else {
             XCTFail("Didn't get expected frame")
             return
         }
-        secondFrame.0.assertFrameMatches(this: dataFrame)
+        secondFrame.assertFrameMatches(this: dataFrame)
     }
 }
 

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -491,26 +491,26 @@ extension HTTP2Frame {
     }
 
     func assertAlternativeServiceFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
-        guard case .alternativeService(let payload) = frame.payload else {
+        guard case .alternativeService(let origin, let field) = frame.payload else {
             preconditionFailure("AltSvc frames can never match non-AltSvc frames.")
         }
-        self.assertAlternativeServiceFrame(origin: payload.origin, field: payload.field, file: file, line: line)
+        self.assertAlternativeServiceFrame(origin: origin, field: field, file: file, line: line)
     }
 
     func assertAlternativeServiceFrame(origin: String?, field: ByteBuffer?, file: StaticString = #file, line: UInt = #line) {
-        guard case .alternativeService(let actualPayload) = self.payload else {
+        guard case .alternativeService(let actualOrigin, let actualField) = self.payload else {
             XCTFail("Expected ALTSVC frame, got \(self.payload) instead", file: file, line: line)
             return
         }
 
         XCTAssertEqual(.rootStream, self.streamID, "ALTSVC frame must be on the root stream!, got \(self.streamID)!", file: file, line: line)
         XCTAssertEqual(origin,
-                       actualPayload.origin,
-                       "Non matching origins: expected \(String(describing: origin)), got \(String(describing: actualPayload.origin))",
+                       actualOrigin,
+                       "Non matching origins: expected \(String(describing: origin)), got \(String(describing: actualOrigin))",
                        file: file, line: line)
         XCTAssertEqual(field,
-                       actualPayload.field,
-                       "Non matching field: expected \(String(describing: field)), got \(String(describing: actualPayload.field))",
+                       actualField,
+                       "Non matching field: expected \(String(describing: field)), got \(String(describing: actualField))",
                        file: file, line: line)
     }
 


### PR DESCRIPTION
Motivation:

Newer Swift compilers warn about implicitly tupling the payload of an
enum case whilst pattern matching.

Modification:

Stop using implicit tupling.

Result:

No warnings on newer Swift compilers.