### PR TITLE
Account for window size of stream closing frames

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -505,7 +505,9 @@ extension NIOHTTP2Handler {
 
         switch stateChange {
         case .streamClosed(let streamClosedData):
+            self.outboundBuffer.connectionWindowSize = streamClosedData.localConnectionWindowSize
             self.inboundEventBuffer.pendingUserEvent(StreamClosedEvent(streamID: streamClosedData.streamID, reason: streamClosedData.reason))
+            self.inboundEventBuffer.pendingUserEvent(NIOHTTP2WindowUpdatedEvent(streamID: .rootStream, inboundWindowSize: streamClosedData.remoteConnectionWindowSize, outboundWindowSize: streamClosedData.localConnectionWindowSize))
 
             let failedWrites = self.outboundBuffer.streamClosed(streamClosedData.streamID)
             let error = NIOHTTP2Errors.StreamClosed(streamID: streamClosedData.streamID, errorCode: streamClosedData.reason ?? .cancel)

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -69,6 +69,8 @@ extension SimpleClientServerTests {
                 ("testEnforcingMaxHeaderListSize", testEnforcingMaxHeaderListSize),
                 ("testForbidsExceedingMaxHeaderListSizeBeforeDecoding", testForbidsExceedingMaxHeaderListSizeBeforeDecoding),
                 ("testForbidsExceedingMaxHeaderListSizeBeforeDecodingSingleFrame", testForbidsExceedingMaxHeaderListSizeBeforeDecodingSingleFrame),
+                ("testNoStreamWindowUpdateOnEndStreamFrameFromServer", testNoStreamWindowUpdateOnEndStreamFrameFromServer),
+                ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Frames that close a stream may consume some of the connection window. We
were not correctly accounting for that in the code, which meant that
frames that carried END_STREAM would not notify the stream multiplexer
that they had consumed connection window space. In the worst cases this
could lead to resource starvation due to consumption of this window
without causing us to emit new WINDOW_UPDATE frames.

Modifications:

StreamClosedEvents should be followed by flow control change events.

Result:

We will correctly update the connection window when a stream is closed.
Resolves #173.