### PR TITLE
Issue #151 Update BadStreamStateTransition to have stream state

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -61,7 +61,11 @@ public enum NIOHTTP2Errors {
 
     /// A stream state transition was attempted that was not valid.
     public struct BadStreamStateTransition: NIOHTTP2Error {
-        public init() { }
+        let fromState: NIOHTTP2StreamState
+
+        init(from state: NIOHTTP2StreamState) {
+            fromState = state
+        }
     }
 
     /// An attempt was made to change the flow control window size, either via

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -60,8 +60,12 @@ public enum NIOHTTP2Errors {
     }
 
     /// A stream state transition was attempted that was not valid.
-    public struct BadStreamStateTransition: NIOHTTP2Error {
+    public struct BadStreamStateTransition: NIOHTTP2Error, CustomStringConvertible {
         let fromState: NIOHTTP2StreamState
+        
+        public var description: String {
+            return "BadStreamStateTransition in state \(fromState)"
+        }
 
         init(from state: NIOHTTP2StreamState) {
             fromState = state

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -61,14 +61,19 @@ public enum NIOHTTP2Errors {
 
     /// A stream state transition was attempted that was not valid.
     public struct BadStreamStateTransition: NIOHTTP2Error, CustomStringConvertible {
-        let fromState: NIOHTTP2StreamState
-        
+        public let fromState: NIOHTTP2StreamState?
+
         public var description: String {
-            return "BadStreamStateTransition in state \(fromState)"
+            let stateName = fromState != nil ? "\(fromState!)" : "unknown state"
+            return "BadStreamStateTransition in state \(stateName)"
         }
 
         init(from state: NIOHTTP2StreamState) {
             fromState = state
+        }
+
+        public init() {
+            self.fromState = nil
         }
     }
 

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -1023,8 +1023,7 @@ private extension HPACKHeaders {
     }
 }
 
-
-/// State of a HTTP2 Stream.
+/// A public state of a `HTTP2StreamStateMachine`. This copy mirrors `HTTP2StreamStateMachine.state` but without associated values.
 public enum NIOHTTP2StreamState {
     case idle
     case reservedRemote

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -1024,7 +1024,7 @@ private extension HPACKHeaders {
 }
 
 /// A state of a `HTTP2StreamStateMachine`. This copy mirrors `HTTP2StreamStateMachine.state` but without associated values.
-enum NIOHTTP2StreamState {
+public enum NIOHTTP2StreamState {
     case idle
     case reservedRemote
     case reservedLocal

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -383,9 +383,9 @@ extension HTTP2StreamStateMachine {
             // seems reasonable to me: specifically, if we have a stream to fail, fail it, otherwise treat
             // the error as connection scoped.)
             case .idle(.server, _, _), .closed:
-                return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             case .reservedRemote, .halfClosedLocalPeerIdle, .halfClosedLocalPeerActive:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.ContentLengthViolated {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .protocolError), effect: nil)
@@ -514,9 +514,9 @@ extension HTTP2StreamStateMachine {
             // seems reasonable to me: specifically, if we have a stream to fail, fail it, otherwise treat
             // the error as connection scoped.)
             case .idle(.client, _, _), .closed:
-                return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             case .reservedLocal, .halfClosedRemoteLocalIdle, .halfClosedRemoteLocalActive:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.ContentLengthViolated {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .protocolError), effect: nil)
@@ -586,7 +586,7 @@ extension HTTP2StreamStateMachine {
             // Sending a DATA frame outside any of these states is a stream error of type STREAM_CLOSED (RFC7540 § 6.1)
             case .idle, .halfOpenRemoteLocalIdle, .reservedLocal, .reservedRemote, .halfClosedLocalPeerIdle,
                  .halfClosedLocalPeerActive, .halfClosedRemoteLocalIdle, .closed:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .streamClosed), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .streamClosed), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.FlowControlViolation {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .flowControlError), effect: nil)
@@ -657,7 +657,7 @@ extension HTTP2StreamStateMachine {
             // Receiving a DATA frame outside any of these states is a stream error of type STREAM_CLOSED (RFC7540 § 6.1)
             case .idle, .halfOpenLocalPeerIdle, .reservedLocal, .reservedRemote, .halfClosedLocalPeerIdle,
                  .halfClosedRemoteLocalActive, .halfClosedRemoteLocalIdle, .closed:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .streamClosed), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .streamClosed), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.FlowControlViolation {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .flowControlError), effect: nil)
@@ -693,7 +693,7 @@ extension HTTP2StreamStateMachine {
              .fullyOpen(localRole: .client, localContentLength: _, remoteContentLength: _, localWindow: _, remoteWindow: _),
              .halfClosedRemoteLocalActive(localRole: .client, initiatedBy: _, localContentLength: _, localWindow: _),
              .halfClosedRemoteLocalActive(localRole: .server, initiatedBy: .server, localContentLength: _, localWindow: _):
-            return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+            return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
         }
     }
 
@@ -720,7 +720,7 @@ extension HTTP2StreamStateMachine {
              .fullyOpen(localRole: .server, localContentLength: _, remoteContentLength: _, localWindow: _, remoteWindow: _),
              .halfClosedLocalPeerActive(localRole: .server, initiatedBy: _, remoteContentLength: _, remoteWindow: _),
              .halfClosedLocalPeerActive(localRole: .client, initiatedBy: .server, remoteContentLength: _, remoteWindow: _):
-            return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+            return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
         }
     }
 
@@ -769,7 +769,7 @@ extension HTTP2StreamStateMachine {
                 windowEffect = .windowSizeChange(.init(streamID: self.streamID, localStreamWindowSize: nil, remoteStreamWindowSize: Int(remoteWindow)))
 
             case .idle, .reservedLocal, .halfClosedRemoteLocalIdle, .halfClosedRemoteLocalActive, .closed:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.InvalidFlowControlWindowSize {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .flowControlError), effect: nil)
@@ -833,7 +833,7 @@ extension HTTP2StreamStateMachine {
                 windowEffect = nil
 
             case .idle, .reservedRemote, .closed:
-                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+                return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
         } catch let error where error is NIOHTTP2Errors.InvalidFlowControlWindowSize {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .flowControlError), effect: nil)
@@ -856,7 +856,7 @@ extension HTTP2StreamStateMachine {
     mutating func receiveRstStream(reason: HTTP2ErrorCode) -> StateMachineResultWithStreamEffect {
         // We can receive RST_STREAM frames in any state but idle.
         if case .idle = self.state {
-            return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState(self.state)), type: .protocolError), effect: nil)
+            return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.BadStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
         }
 
         self.state = .closed(reason: reason)
@@ -1023,33 +1023,57 @@ private extension HPACKHeaders {
     }
 }
 
-/// A state of a `HTTP2StreamStateMachine`. This copy mirrors `HTTP2StreamStateMachine.state` but without associated values.
-public enum NIOHTTP2StreamState {
-    case idle
-    case reservedRemote
-    case reservedLocal
-    case halfOpenLocalPeerIdle
-    case halfOpenRemoteLocalIdle
-    case fullyOpen
-    case halfClosedLocalPeerIdle
-    case halfClosedLocalPeerActive
-    case halfClosedRemoteLocalIdle
-    case halfClosedRemoteLocalActive
-    case closed
+/// A state of a `HTTP2StreamStateMachine`. This copy in effect mirrors `HTTP2StreamStateMachine.state` but without associated values.
+public struct NIOHTTP2StreamState: Hashable, CustomStringConvertible {
+    private enum State {
+        case idle
+        case reservedRemote
+        case reservedLocal
+        case halfOpenLocalPeerIdle
+        case halfOpenRemoteLocalIdle
+        case fullyOpen
+        case halfClosedLocalPeerIdle
+        case halfClosedLocalPeerActive
+        case halfClosedRemoteLocalIdle
+        case halfClosedRemoteLocalActive
+        case closed
+    }
 
-    fileprivate init(_ state: HTTP2StreamStateMachine.State) {
+    private var state: State
+
+    private init(state: State) {
+        self.state = state
+    }
+
+    public var description: String {
+        return "\(state)"
+    }
+
+    public static let idle = NIOHTTP2StreamState(state: .idle)
+    public static let reservedRemote = NIOHTTP2StreamState(state: .reservedRemote)
+    public static let reservedLocal = NIOHTTP2StreamState(state: .reservedLocal)
+    public static let halfOpenLocalPeerIdle = NIOHTTP2StreamState(state: .halfOpenLocalPeerIdle)
+    public static let halfOpenRemoteLocalIdle = NIOHTTP2StreamState(state: .halfOpenRemoteLocalIdle)
+    public static let fullyOpen = NIOHTTP2StreamState(state: .fullyOpen)
+    public static let halfClosedLocalPeerIdle = NIOHTTP2StreamState(state: .halfClosedLocalPeerIdle)
+    public static let halfClosedLocalPeerActive = NIOHTTP2StreamState(state: .halfClosedLocalPeerActive)
+    public static let halfClosedRemoteLocalIdle = NIOHTTP2StreamState(state: .halfClosedRemoteLocalIdle)
+    public static let halfClosedRemoteLocalActive = NIOHTTP2StreamState(state: .halfClosedRemoteLocalActive)
+    public static let closed = NIOHTTP2StreamState(state: .closed)
+    
+    fileprivate static func get(_ state: HTTP2StreamStateMachine.State) -> NIOHTTP2StreamState {
         switch state {
-        case .idle: self = .idle
-        case .reservedRemote: self = .reservedRemote
-        case .reservedLocal: self = .reservedLocal
-        case .halfOpenLocalPeerIdle: self = .halfOpenLocalPeerIdle
-        case .halfOpenRemoteLocalIdle: self = .halfOpenRemoteLocalIdle
-        case .fullyOpen: self = .fullyOpen
-        case .halfClosedLocalPeerIdle: self = .halfClosedLocalPeerIdle
-        case .halfClosedLocalPeerActive: self = .halfClosedLocalPeerActive
-        case .halfClosedRemoteLocalIdle: self = .halfClosedRemoteLocalIdle
-        case .halfClosedRemoteLocalActive: self = .halfClosedRemoteLocalActive
-        case .closed: self = .closed
+        case .idle: return idle
+        case .reservedRemote: return reservedRemote
+        case .reservedLocal: return reservedLocal
+        case .halfOpenLocalPeerIdle: return halfOpenLocalPeerIdle
+        case .halfOpenRemoteLocalIdle: return halfOpenRemoteLocalIdle
+        case .fullyOpen: return fullyOpen
+        case .halfClosedLocalPeerIdle: return halfClosedLocalPeerIdle
+        case .halfClosedLocalPeerActive: return halfClosedLocalPeerActive
+        case .halfClosedRemoteLocalIdle: return halfClosedRemoteLocalIdle
+        case .halfClosedRemoteLocalActive: return halfClosedRemoteLocalActive
+        case .closed: return closed
         }
     }
 }

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -1023,8 +1023,8 @@ private extension HPACKHeaders {
     }
 }
 
-/// A public state of a `HTTP2StreamStateMachine`. This copy mirrors `HTTP2StreamStateMachine.state` but without associated values.
-public enum NIOHTTP2StreamState {
+/// A state of a `HTTP2StreamStateMachine`. This copy mirrors `HTTP2StreamStateMachine.state` but without associated values.
+enum NIOHTTP2StreamState {
     case idle
     case reservedRemote
     case reservedLocal

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -27,6 +27,7 @@ extension ConnectionStateMachineTests {
    static var allTests : [(String, (ConnectionStateMachineTests) -> () throws -> Void)] {
       return [
                 ("testSimpleRequestResponseFlow", testSimpleRequestResponseFlow),
+                ("testSimpleRequestResponseErrorFlow", testSimpleRequestResponseErrorFlow),
                 ("testOpeningConnectionWhileServerPreambleMissing", testOpeningConnectionWhileServerPreambleMissing),
                 ("testServerSendsItsPreambleFirst", testServerSendsItsPreambleFirst),
                 ("testMoreComplexStreamLifecycle", testMoreComplexStreamLifecycle),


### PR DESCRIPTION
swift-nio-http2 commit hash: 85d5cea3f9134a242ad4baaa3a4af1ff080a3f81

Context:
Address the issue #151. Update BadStreamStateTransition to have a property with the stream state when the error happened. This public steam state is a enum without any associated values.
Also update some unit test functions to return an optional error. 

% swift --version
Apple Swift version 5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)
Target: x86_64-apple-darwin19.0.0
