### PR TITLE
Add a subscript to HPACKHeaders to return the first value with a matc…

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -161,8 +161,27 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral {
         
         return array
     }
-    
-    /// Checks if a header is present
+
+    /// Retrieves the first value for a given header field name from the block.
+    ///
+    /// This method uses case-insensitive comparisons for the header field name. It
+    /// does not return the first value from a maximally-decomposed list of the header fields,
+    /// but instead returns the first value from the original representation: that means
+    /// that a comma-separated header field list may contain more than one entry, some of
+    /// which contain commas and some do not. If you want a representation of the header fields
+    /// suitable for performing computation on, consider `getCanonicalForm`.
+    ///
+    /// - Parameter name: The header field name whose first value should be retrieved.
+    /// - Returns: The first value for the header field name.
+    public func first(name: String) -> String? {
+        guard !self.headers.isEmpty else {
+            return nil
+        }
+
+        return self.headers.first { $0.name.isEqualCaseInsensitiveASCIIBytes(to: name) }?.value
+    }
+
+    /// Checks if a header is present.
     ///
     /// - parameters:
     ///     - name: The name of the header

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -34,6 +34,7 @@ extension HPACKCodingTests {
                 ("testInlineDynamicTableResize", testInlineDynamicTableResize),
                 ("testHPACKHeadersDescription", testHPACKHeadersDescription),
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
+                ("testHPACKHeadersFirstSubscript", testHPACKHeadersFirstSubscript),
                 ("testHPACKHeadersExpressedByDictionaryLiteral", testHPACKHeadersExpressedByDictionaryLiteral),
                 ("testHPACKHeadersAddingSequenceOfPairs", testHPACKHeadersAddingSequenceOfPairs),
                 ("testHPACKHeadersAddingOtherHPACKHeaders", testHPACKHeadersAddingOtherHPACKHeaders),

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -34,7 +34,7 @@ extension HPACKCodingTests {
                 ("testInlineDynamicTableResize", testInlineDynamicTableResize),
                 ("testHPACKHeadersDescription", testHPACKHeadersDescription),
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
-                ("testHPACKHeadersFirstSubscript", testHPACKHeadersFirstSubscript),
+                ("testHPACKHeadersFirst", testHPACKHeadersFirst),
                 ("testHPACKHeadersExpressedByDictionaryLiteral", testHPACKHeadersExpressedByDictionaryLiteral),
                 ("testHPACKHeadersAddingSequenceOfPairs", testHPACKHeadersAddingSequenceOfPairs),
                 ("testHPACKHeadersAddingOtherHPACKHeaders", testHPACKHeadersAddingOtherHPACKHeaders),

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -581,6 +581,20 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["abcdefg,hijklmn,opqrst"])
     }
 
+    func testHPACKHeadersFirstSubscript() throws {
+        let headers = HPACKHeaders([
+            (":method", "GET"),
+            ("foo", "bar"),
+            ("foo", "baz"),
+            ("custom-key", "value-1,value-2")
+        ])
+
+        XCTAssertEqual(headers.first(name: ":method"), "GET")
+        XCTAssertEqual(headers.first(name: "Foo"), "bar")
+        XCTAssertEqual(headers.first(name: "custom-key"), "value-1,value-2")
+        XCTAssertNil(headers.first(name: "not-present"))
+    }
+
     func testHPACKHeadersExpressedByDictionaryLiteral() throws {
         let headers: HPACKHeaders = [
             ":method": "GET",

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -581,7 +581,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["abcdefg,hijklmn,opqrst"])
     }
 
-    func testHPACKHeadersFirstSubscript() throws {
+    func testHPACKHeadersFirst() throws {
         let headers = HPACKHeaders([
             (":method", "GET"),
             ("foo", "bar"),


### PR DESCRIPTION
…hing name

Motivation:

In some cases you only expect (or care about) a single value for a
header. However, getting this value without allocating an array or
traversing the whole array requres using first(where:) provided by
Sequence. This is not very ergonomic as it requires users to do the
case-insensitive comparison and then exctact the value from the
HPACKHeader. Additionally, users cannot use NIO HTTP/2s case insensitive
ASCII comparison.

Modifications:

- Provide a subscript on HPACKHeaders which returns the value from the
  first header whose name is a case insentive match of the subscript
  parameter.

Result:

- It's easier to get only the first header matching a given name