### PR TITLE
Update build_podspec script & added SwiftNIOHPACK Pod

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .target(name: "NIOHTTP2PerformanceTester",
                 dependencies: ["NIOHTTP2"]),
         .target(name: "NIOHTTP2",
-            dependencies: ["NIO", "NIOHTTP1", "NIOTLS", "NIOHPACK"]),
+            dependencies: ["NIO", "NIOHTTP1", "NIOTLS", "NIOHPACK", "NIOConcurrencyHelpers"]),
         .target(name: "NIOHPACK",
             dependencies: ["NIO", "NIOConcurrencyHelpers", "NIOHTTP1"]),
         .testTarget(name: "NIOHTTP2Tests",

--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -16,17 +16,22 @@
 set -eu
 
 function usage() {
-  echo "$0 [-u] version"
+  echo "$0 [-u] version nio_version"
   echo
   echo "OPTIONS:"
   echo "  -u: Additionally upload the podspec"
+  echo "  -f: Skip over all targets before the specified target"
 }
 
 upload=false
+skip_until=""
 while getopts ":u" opt; do
   case $opt in
     u)
       upload=true
+      ;;
+    f)
+      skip_until="$OPTARG"
       ;;
     \?)
       usage
@@ -42,15 +47,43 @@ if [[ $# -eq 0 ]]; then
 fi
 
 version=$1
-name="SwiftNIOHTTP2"
+
+# Current SwiftNIO Version to add as dependency in the .podspec
+nio_version=$2
+newline=$'\n'
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmpdir=$(mktemp -d /tmp/.build_podspecsXXXXXX)
+
 echo "Building podspec in $tmpdir"
 
-cat > "${tmpdir}/${name}.podspec" <<- EOF
+# We only want to generate Podspec files for the two targets
+targets=( "SwiftNIOHPACK" "SwiftNIOHTTP2" )
+
+for target in "${targets[@]}"; do
+
+  if [[ -n "$skip_until" && "$target" != "$skip_until" ]]; then
+    echo "Skipping $target"
+    continue
+  elif [[ "$skip_until" == "$target" ]]; then
+    skip_until=""
+  fi
+
+  echo "Building podspec for $target"
+
+  dependencies=()
+
+  while read -r raw_dependency; do
+    if [ "$raw_dependency" == "SwiftNIOHPACK" ]; then
+      dependencies+=( "${newline}  s.dependency '$raw_dependency', s.version.to_s" )
+    else
+      dependencies+=( "${newline}  s.dependency '$raw_dependency', '$nio_version'" )
+    fi
+  done < <("${here}/list_topsorted_dependencies.sh" -d "${target#Swift}" | sed 's/^NIO/SwiftNIO/')
+
+  cat > "${tmpdir}/${target}.podspec" <<- EOF
 Pod::Spec.new do |s|
-  s.name = '$name'
+  s.name = '$target'
   s.version = '$version'
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
   s.summary = 'Useful code around SwiftNIO.'
@@ -58,22 +91,23 @@ Pod::Spec.new do |s|
   s.author = 'Apple Inc.'
   s.source = { :git => 'https://github.com/apple/swift-nio-http2.git', :tag => s.version.to_s }
   s.documentation_url = 'https://apple.github.io/swift-nio-http2/'
-  s.module_name = 'NIOHTTP2'
+  s.module_name = '${target#Swift}'
 
   s.swift_version = '5.0'
   s.cocoapods_version = '>=1.6.0'
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
-  s.dependency 'SwiftNIO', '~> 2.0.0'
 
-  s.source_files = 'Sources/NIOHTTP2/**/*.swift'
+  s.source_files = 'Sources/${target#Swift}/**/*.{swift,c,h}'
+  ${dependencies[*]-}
 end
 EOF
 
-if $upload; then
-  echo "Uploading ${tmpdir}/${name}.podspec"
-  pod trunk push "${tmpdir}/${name}.podspec"
-else
-  echo "Generated podspec available at ${tmpdir}/${name}.podspec"
-fi
+  pod repo update # last chance of getting the latest versions of previous pushed pods
+  if $upload; then
+    echo "Uploading ${tmpdir}/${target}.podspec"
+    pod trunk push "${tmpdir}/${target}.podspec"
+  fi
+
+done

--- a/scripts/list_topsorted_dependencies.sh
+++ b/scripts/list_topsorted_dependencies.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage() {
+    echo "$0 -l"
+    echo
+    echo "OPTIONS:"
+    echo "  -l: Only dependencies of library targets"
+    echo "  -r: Reverse the output"
+    echo "  -d <PACKAGE>: Prints the dependencies of the given package"
+}
+
+function tac_compat() {
+    sed '1!G;h;$!d'
+}
+
+tmpfile=$(mktemp /tmp/.list_topsorted_dependencies_XXXXXX)
+
+only_libs=false
+do_reversed=false
+package_dependency=""
+while getopts "lrd:" opt; do
+    case $opt in
+        l)
+            only_libs=true
+            ;;
+        r)
+            do_reversed=true
+            ;;
+        d)
+            package_dependency="$OPTARG"
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+transform=cat
+if $do_reversed; then
+    transform=tac_compat
+fi
+
+if [[ ! -z "$package_dependency" ]]; then
+  swift package dump-package | jq -r ".targets |
+                                      map(select(.name == \"$package_dependency\" and .type == \"regular\") | .dependencies | map(.byName | first)) | .[] | .[]"
+  exit 0
+fi
+
+(
+cd "$here/.."
+if $only_libs; then
+    swift package dump-package | jq '.products |
+                                     map(select(.type | has("library") | not)) |
+                                     map(.name) | .[]' | tr -d '"' \
+                                     >> "$tmpfile"
+fi
+swift package dump-package | jq '.targets |
+                                 map(.name as $name |
+                                 select(.name == $name and .type == "regular") |
+                                 { "\($name)": .dependencies | map(.byName | first) } ) |
+                                 map(to_entries[]) |
+                                 map("\(.key) \(.value | .[])") |
+                                 .[]' | \
+                                     tr -d '"' | \
+                                     tsort | "$transform" | while read -r line; do
+    if ! grep -q "^$line\$" "$tmpfile"; then
+        echo "$line"
+    fi
+done
+)
+
+rm "$tmpfile"


### PR DESCRIPTION
- `SwiftNIOHTTP2` has a dependency on internal target `SwiftNIOHPACK` so validating the podspec was failing
- Updated the script to allow for the generation of both `SwiftNIOHTTP2.podspec` & `SwiftNIOHPACK .podspec`
- In `NIOHTTP2StreamChannel.swift`, it imports `NIOConcurrencyHelpers` which was not added as a dependency explicitly. Added the dependency which allowed the successful validation of the `SwiftNIOHTTP2` Pod. 

### Cocoapods
[SwiftNIOHTTP2](http://cocoapods.org/pods/SwiftNIOHTTP2)
[SwiftNIOHPACK](http://cocoapods.org/pods/SwiftNIOHPACK)

Newly created Pods from Release 1.9.1 - still need to add the other maintainers as Pod owners! 