### PR TITLE
Added helper to configure HTTP1 or H2 accordingly to the negotiated protocol

### DIFF
--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -151,13 +151,13 @@ extension Channel {
         return self.pipeline.addHandler(alpnHandler)
     }
 
-    /// Configures a `ChannelPipeline` to speak either HTTP or HTTP/2 accordingly to what can be negotiated with the client.
+    /// Configures a `ChannelPipeline` to speak either HTTP or HTTP/2 according to what can be negotiated with the client.
     ///
     /// This helper takes care of configuring the server pipeline such that it negotiates whether to
-    /// use HTTP/1.1 or HTTP/2. Once the protocol to use for the channel has been negotitated, the
+    /// use HTTP/1.1 or HTTP/2. Once the protocol to use for the channel has been negotiated, the
     /// provided callback will configure the application-specific handlers in a protocol-agnostic way.
     ///
-    /// This function does't configure the TLS handler. Callers of this function need to add a TLS
+    /// This function doesn't configure the TLS handler. Callers of this function need to add a TLS
     /// handler appropriately configured to perform protocol negotiation.
     ///
     /// - parameters:

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -56,7 +56,7 @@ public extension ChannelPipeline {
     ///         negotiated, or if no protocol was negotiated. Must return a future that completes when the
     ///         pipeline has been fully mutated.
     /// - returns: An `EventLoopFuture<Void>` that completes when the pipeline is ready to negotiate.
-    @available(*, deprecated, message: "Please use Channel.configureHTTP2SecureUpgrade(h2ChannelConfigurator, http1ChannelConfigurator)")
+    @available(*, deprecated, renamed: "Channel.configureHTTP2SecureUpgrade(h2ChannelConfigurator:http1ChannelConfigurator:)")
     func configureHTTP2SecureUpgrade(h2PipelineConfigurator: @escaping (ChannelPipeline) -> EventLoopFuture<Void>,
                                      http1PipelineConfigurator: @escaping (ChannelPipeline) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         let alpnHandler = ApplicationProtocolNegotiationHandler { result in

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
@@ -30,6 +30,8 @@ extension ConfiguringPipelineTests {
                 ("testPipelineRespectsPositionRequest", testPipelineRespectsPositionRequest),
                 ("testPreambleGetsWrittenOnce", testPreambleGetsWrittenOnce),
                 ("testClosingParentChannelClosesStreamChannel", testClosingParentChannelClosesStreamChannel),
+                ("testNegotiatedHTTP2BasicPipelineCommunicates", testNegotiatedHTTP2BasicPipelineCommunicates),
+                ("testNegotiatedHTTP1BasicPipelineCommunicates", testNegotiatedHTTP1BasicPipelineCommunicates),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
@@ -233,7 +233,7 @@ class ConfiguringPipelineTests: XCTestCase {
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent
         XCTAssertEqual(2, serverRecorder.receivedParts.count)
-        if case .head(let head) = serverRecorder.receivedParts.first {
+        if case .some(.head(let head)) = serverRecorder.receivedParts.first {
             XCTAssertEqual(1, head.headers["host"].count)
             XCTAssertEqual("localhost", head.headers["host"].first)
             XCTAssertEqual(.GET, head.method)
@@ -241,7 +241,7 @@ class ConfiguringPipelineTests: XCTestCase {
         } else {
             XCTFail("Expected head")
         }
-        if case .end(_) = serverRecorder.receivedParts.last {
+        if case .some(.end(_)) = serverRecorder.receivedParts.last {
         } else {
             XCTFail("Expected end")
         }
@@ -283,13 +283,13 @@ class ConfiguringPipelineTests: XCTestCase {
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent
         XCTAssertEqual(2, serverRecorder.receivedParts.count)
-        if case .head(let head) = serverRecorder.receivedParts.first {
+        if case .some(.head(let head)) = serverRecorder.receivedParts.first {
             XCTAssertEqual(.GET, head.method)
             XCTAssertEqual("/testHTTP1", head.uri)
         } else {
             XCTFail("Expected head")
         }
-        if case .end(_) = serverRecorder.receivedParts.last {
+        if case .some(.end(_)) = serverRecorder.receivedParts.last {
         } else {
             XCTFail("Expected end")
         }


### PR DESCRIPTION
Motivation:

Applications might want to support H2 (when available) and HTTP1 (as a fallback).
The application logic should not change between the two versions of the protocol and the code to configure support for both the protocols is boilerplate and can be provided as an helper function.

Modifications:

This PR adds an helper function to configure HTTP1 or H2 pipelines according to the protocol negotiated by the TLS handler.

Result:

Applications that need to support clients using both HTTP1 and H2 can configure their channels by calling `configureCommonHTTPServerPipeline`, which should reduce the boilerplate they have to write.