### PR TITLE
Improve debugging output for HTTP2Handler.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -608,3 +608,25 @@ extension HTTP2ConnectionStateMachine.ValidationState {
         }
     }
 }
+
+
+extension NIOHTTP2Handler: CustomStringConvertible {
+    public var description: String {
+        return """
+NIOHTTP2Handler(
+    stateMachine: \(String(describing: self.stateMachine)),
+    frameDecoder: \(String(describing: self.frameDecoder)),
+    frameEncoder: \(String(describing: self.frameEncoder)),
+    writeBuffer: \(String(describing: self.writeBuffer)),
+    inboundEventBuffer: \(String(describing: self.inboundEventBuffer)),
+    outboundBuffer: \(String(describing: self.outboundBuffer)),
+    wroteFrame: \(String(describing: self.wroteFrame)),
+    denialOfServiceValidator: \(String(describing: self.denialOfServiceValidator)),
+    mode: \(String(describing: self.mode)),
+    initialSettings: \(String(describing: self.initialSettings)),
+    channelClosed: \(String(describing: self.channelClosed)),
+    channelWritable: \(String(describing: self.channelWritable))
+)
+"""
+    }
+}


### PR DESCRIPTION
Motivation:

Sometimes it's useful to be able to print out objects and see their
internal state. Somehow, HTTP2Handler can't do this.

Modifications:

Add a conformance to HTTP2Handler.

Result:

Awesome debugging output.

Now renders:

```
NIOHTTP2Handler(
    stateMachine: HTTP2ConnectionStateMachine(state: NIOHTTP2.HTTP2ConnectionStateMachine.(unknown context at $1003b2c94).State.active(NIOHTTP2.HTTP2ConnectionStateMachine.(unknown context at $1003b27bc).ActiveConnectionState(role: NIOHTTP2.HTTP2ConnectionStateMachine.ConnectionRole.server, headerBlockValidation: NIOHTTP2.HTTP2ConnectionStateMachine.ValidationState.enabled, contentLengthValidation: NIOHTTP2.HTTP2ConnectionStateMachine.ValidationState.enabled, localSettings: NIOHTTP2.HTTP2SettingsState(currentSettingsValues: [NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 6): 16384, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 4): 65535, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 1): 4096, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 2): 1, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 5): 16384, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 3): 100], unacknowlegedSettingsFrames: []), remoteSettings: NIOHTTP2.HTTP2SettingsState(currentSettingsValues: [NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 4): 1073741824, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 2): 0, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 1): 4096, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 5): 16384, NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 3): 100], unacknowlegedSettingsFrames: []), streamState: NIOHTTP2.ConnectionStreamState(activeStreams: [HTTP2StreamID(1): NIOHTTP2.HTTP2StreamStateMachine(state: NIOHTTP2.HTTP2StreamStateMachine.(unknown context at $1003b9f90).State.halfClosedRemoteLocalIdle(localWindow: 1073741824), streamID: HTTP2StreamID(1))], recentlyResetStreams: [ <_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ] (bufferCapacity: 32, ringLength: 0), maxResetStreams: 32, clientStreamCount: 1, serverStreamCount: 0, lastClientStreamID: HTTP2StreamID(1), lastServerStreamID: HTTP2StreamID(0), maxClientInitiatedStreams: 100, maxServerInitiatedStreams: 100), inboundFlowControlWindow: 65535, outboundFlowControlWindow: 1073741824))),
    frameDecoder: Optional(NIOHTTP2.HTTP2FrameDecoder(headerDecoder: NIOHPACK.HPACKDecoder(headerTable: NIOHPACK.IndexedHeaderTable(staticTable: [("", ""), (":authority", ""), (":method", "GET"), (":method", "POST"), (":path", "/"), (":path", "/index.html"), (":scheme", "http"), (":scheme", "https"), (":status", "200"), (":status", "204"), (":status", "206"), (":status", "304"), (":status", "400"), (":status", "404"), (":status", "500"), ("accept-charset", ""), ("accept-encoding", "gzip, deflate"), ("accept-language", ""), ("accept-ranges", ""), ("accept", ""), ("access-control-allow-origin", ""), ("age", ""), ("allow", ""), ("authorization", ""), ("cache-control", ""), ("content-disposition", ""), ("content-encoding", ""), ("content-language", ""), ("content-length", ""), ("content-location", ""), ("content-range", ""), ("content-type", ""), ("cookie", ""), ("date", ""), ("etag", ""), ("expect", ""), ("expires", ""), ("from", ""), ("host", ""), ("if-match", ""), ("if-modified-since", ""), ("if-none-match", ""), ("if-range", ""), ("if-unmodified-since", ""), ("last-modified", ""), ("link", ""), ("location", ""), ("max-forwards", ""), ("proxy-authenticate", ""), ("proxy-authorization", ""), ("range", ""), ("referer", ""), ("refresh", ""), ("retry-after", ""), ("server", ""), ("set-cookie", ""), ("strict-transport-security", ""), ("transfer-encoding", ""), ("user-agent", ""), ("vary", ""), ("via", ""), ("www-authenticate", "")], dynamicTable: NIOHPACK.DynamicHeaderTable(storage: [("accept", "*/*"), ("user-agent", "curl/7.64.1"), (":authority", "[::1]:8888")], maximumTableLength: 4096), allocator: NIO.ByteBufferAllocator(malloc: (Function), realloc: (Function), free: (Function), memcpy: (Function))), maxHeaderListSize: 16384), state: NIOHTTP2.HTTP2FrameDecoder.(unknown context at $1003b86b4).ParserState.accumulatingFrameHeader(NIOHTTP2.HTTP2FrameDecoder.(unknown context at $1003b82ec).AccumulatingFrameHeaderParserState(unusedBytes: ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, capacity: 1024, slice: _ByteBufferSlice { 0..<1024 }, storage: 0x0000000103809c00 (1024 bytes) })), allocator: NIO.ByteBufferAllocator(malloc: (Function), realloc: (Function), free: (Function), memcpy: (Function)), maxFrameSize: 16384)),
    frameEncoder: Optional(NIOHTTP2.HTTP2FrameEncoder(allocator: NIO.ByteBufferAllocator(malloc: (Function), realloc: (Function), free: (Function), memcpy: (Function)), headerEncoder: NIOHPACK.HPACKEncoder(headerIndexTable: NIOHPACK.IndexedHeaderTable(staticTable: [("", ""), (":authority", ""), (":method", "GET"), (":method", "POST"), (":path", "/"), (":path", "/index.html"), (":scheme", "http"), (":scheme", "https"), (":status", "200"), (":status", "204"), (":status", "206"), (":status", "304"), (":status", "400"), (":status", "404"), (":status", "500"), ("accept-charset", ""), ("accept-encoding", "gzip, deflate"), ("accept-language", ""), ("accept-ranges", ""), ("accept", ""), ("access-control-allow-origin", ""), ("age", ""), ("allow", ""), ("authorization", ""), ("cache-control", ""), ("content-disposition", ""), ("content-encoding", ""), ("content-language", ""), ("content-length", ""), ("content-location", ""), ("content-range", ""), ("content-type", ""), ("cookie", ""), ("date", ""), ("etag", ""), ("expect", ""), ("expires", ""), ("from", ""), ("host", ""), ("if-match", ""), ("if-modified-since", ""), ("if-none-match", ""), ("if-range", ""), ("if-unmodified-since", ""), ("last-modified", ""), ("link", ""), ("location", ""), ("max-forwards", ""), ("proxy-authenticate", ""), ("proxy-authorization", ""), ("range", ""), ("referer", ""), ("refresh", ""), ("retry-after", ""), ("server", ""), ("set-cookie", ""), ("strict-transport-security", ""), ("transfer-encoding", ""), ("user-agent", ""), ("vary", ""), ("via", ""), ("www-authenticate", "")], dynamicTable: NIOHPACK.DynamicHeaderTable(storage: [], maximumTableLength: 4096), allocator: NIO.ByteBufferAllocator(malloc: (Function), realloc: (Function), free: (Function), memcpy: (Function))), state: NIOHPACK.HPACKEncoder.(unknown context at $1003b0b80).EncoderState.idle, buffer: ByteBuffer { readerIndex: 0, writerIndex: 0, readableBytes: 0, capacity: 128, slice: _ByteBufferSlice { 0..<128 }, storage: 0x000000010309b580 (128 bytes) }, useHuffmanEncoding: true), maxFrameSize: 16384)),
    writeBuffer: Optional(ByteBuffer { readerIndex: 0, writerIndex: 9, readableBytes: 9, capacity: 128, slice: _ByteBufferSlice { 0..<128 }, storage: 0x000000010309b6b0 (128 bytes) }),
    inboundEventBuffer: InboundEventBuffer { [ _ _ <_ _ _ _ _ _ ] (bufferCapacity: 8, ringLength: 0) },
    outboundBuffer: CompoundOutboundBuffer(concurrentStreamsBuffer: NIOHTTP2.ConcurrentStreamBuffer(mode: NIOHTTP2.NIOHTTP2Handler.ParserMode.server, currentOutboundStreams: 0, maxOutboundStreams: 100, lastOutboundStream: HTTP2StreamID(0), bufferedFrames: NIOHTTP2.(unknown context at $1003b45c8).SortedCircularBuffer(_base: [ <_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ] (bufferCapacity: 16, ringLength: 0))), flowControlBuffer: NIOHTTP2.OutboundFlowControlBuffer(streamDataBuffers: [HTTP2StreamID(1): NIOHTTP2.(unknown context at $1003b491c).StreamFlowControlState(streamID: HTTP2StreamID(1), currentWindowSize: 1073741824, dataBuffer: NIOHTTP2.(unknown context at $1003b49b0).DataBuffer(bufferedChunks: [ <_ _ _ _ _ _ _ _ ] (bufferCapacity: 8, ringLength: 0), flushedBufferedBytes: 0))], flushableStreams: Set([]), connectionWindowSize: 1073741824, maxFrameSize: 16384), controlFrameBuffer: NIOHTTP2.ControlFrameBuffer(pendingControlFrames: [ <_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ] (bufferCapacity: 16, ringLength: 0), maximumBufferSize: 10000)),
    wroteFrame: true,
    denialOfServiceValidator: DOSHeuristics(receivedEmptyDataFrames: 0, maximumSequentialEmptyDataFrames: 1),
    mode: server,
    initialSettings: [NIOHTTP2.HTTP2Setting(parameter: NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 3), _value: 100), NIOHTTP2.HTTP2Setting(parameter: NIOHTTP2.HTTP2SettingsParameter(networkRepresentation: 6), _value: 16384)],
    channelClosed: false,
    channelWritable: true
)
```