### PR TITLE
Add debugging info to HTTP2StreamChannel too.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -612,6 +612,13 @@ extension HTTP2ConnectionStateMachine.ValidationState {
 
 extension NIOHTTP2Handler: CustomStringConvertible {
     public var description: String {
+        return "NIOHTTP2Handler(mode: \(String(describing: self.mode)))"
+    }
+}
+
+
+extension NIOHTTP2Handler: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return """
 NIOHTTP2Handler(
     stateMachine: \(String(describing: self.stateMachine)),

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -722,6 +722,13 @@ extension HTTP2StreamChannel {
     }
 }
 
+// MARK: Custom String Convertible
+extension HTTP2StreamChannel {
+    public var description: String {
+        return "HTTP2StreamChannel(streamID: \(self.streamID), isActive: \(self.isActive), isWritable: \(self.isWritable))"
+    }
+}
+
 extension HTTP2Frame {
     /// A shorthand heuristic for how many bytes we assume a frame consumes on the wire.
     ///


### PR DESCRIPTION
Motivation:

Sometimes folks will want to print things about the HTTP2StreamChannel,
and we should give them the things we can safely get. We also may want a
shorter log for NIOHTTP2Handler as the standard description, with the
wall of text available in the debug description.

Modifications:

- Conform HTTP2StreamChannel to CustomStringConvertible
- Conform NIOHTTP2Handler to CustomDebugStringConvertible.

Result:

Even better debug info.