### PR TITLE
Link to CONTRIBUTING.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ The legacy `swift-nio-http` 0.x is part of the SwiftNIO 1 family of repositories
 
 ## Developing SwiftNIO HTTP/2
 
-For the most part, SwiftNIO development is as straightforward as any other SwiftPM project. With that said, we do have a few processes that are worth understanding before you contribute. For details, please see `CONTRIBUTING.md` in this repository.
+For the most part, SwiftNIO development is as straightforward as any other SwiftPM project. With that said, we do have a few processes that are worth understanding before you contribute. For details, please see [`CONTRIBUTING.md`](/CONTRIBUTING.md) in this repository.
 


### PR DESCRIPTION
Motivation:

Linking to `CONTRIBUTING.md` directly would save readers some time if they'd like to navigate to this file while reading `README.md`.

Modifications:

No functional change, only `README.md` is updated.

Result:

The rendered `README.md` will have a direct link to `CONTRIBUTING.md`.