### PR TITLE
Make multiplexer's targetWindowSize configurable

### DIFF
--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
@@ -27,10 +27,15 @@ extension ConfiguringPipelineTests {
    static var allTests : [(String, (ConfiguringPipelineTests) -> () throws -> Void)] {
       return [
                 ("testBasicPipelineCommunicates", testBasicPipelineCommunicates),
+                ("testBasicPipelineCommunicatesWithTargetWindowSize", testBasicPipelineCommunicatesWithTargetWindowSize),
                 ("testPipelineRespectsPositionRequest", testPipelineRespectsPositionRequest),
+                ("testPipelineRespectsPositionRequestWithTargetWindowSize", testPipelineRespectsPositionRequestWithTargetWindowSize),
                 ("testPreambleGetsWrittenOnce", testPreambleGetsWrittenOnce),
+                ("testPreambleGetsWrittenOnceWithTargetWindowSize", testPreambleGetsWrittenOnceWithTargetWindowSize),
                 ("testClosingParentChannelClosesStreamChannel", testClosingParentChannelClosesStreamChannel),
+                ("testClosingParentChannelClosesStreamChannelWithTargetWindowSize", testClosingParentChannelClosesStreamChannelWithTargetWindowSize),
                 ("testNegotiatedHTTP2BasicPipelineCommunicates", testNegotiatedHTTP2BasicPipelineCommunicates),
+                ("testNegotiatedHTTP2BasicPipelineCommunicatesWithTargetWindowSize", testNegotiatedHTTP2BasicPipelineCommunicatesWithTargetWindowSize),
                 ("testNegotiatedHTTP1BasicPipelineCommunicates", testNegotiatedHTTP1BasicPipelineCommunicates),
            ]
    }


### PR DESCRIPTION
Make multiplexer's `targetWindowSize` configurable and use configurability when creating stream channels.
    
Motivation:
`targetWindowSize` constrains throughput. The default hardcoded `65535` is an unecessarily low limit that should be otherwise configrable. A `TODO` in the code stated as such.
    
Modifications:    
- In `HTTP2StreamMultiplexer`, responding to a `TODO` where stream multiplexer creates a stream channel, created a multiplexr stored property to be used which is set in the default initilaizer.
- In `HTTP2PipelineHelpers`, added versions of `configureHTTP2Pipeline(..)` and `configureCommonHTTP2ServerPipeline(..)` that require an `activeTargetWindow` arg.
    
Result:    
Clients, such as `GRPCClient`, can configure pipelines with targetWindowSizes to their liking.