### PR TITLE
Explicitly test we tolerate GREASE.

### DIFF
--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
@@ -94,6 +94,7 @@ extension HTTP2FrameParserTests {
                 ("testPushPromiseAndContinuationsInOneBuffer", testPushPromiseAndContinuationsInOneBuffer),
                 ("testMultipleFramesInOneBuffer", testMultipleFramesInOneBuffer),
                 ("testCorrectlyAccountForFlowControlledLength", testCorrectlyAccountForFlowControlledLength),
+                ("testIgnoreGreaseFrames", testIgnoreGreaseFrames),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -71,6 +71,7 @@ extension SimpleClientServerTests {
                 ("testForbidsExceedingMaxHeaderListSizeBeforeDecodingSingleFrame", testForbidsExceedingMaxHeaderListSizeBeforeDecodingSingleFrame),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromServer", testNoStreamWindowUpdateOnEndStreamFrameFromServer),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
+                ("testGreasedSettingsAreTolerated", testGreasedSettingsAreTolerated),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
@@ -1888,4 +1888,9 @@ class SimpleClientServerTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertTrue(try self.clientChannel.finish().isClean))
         XCTAssertNoThrow(XCTAssertTrue(try self.serverChannel.finish().isClean))
     }
+
+    func testGreasedSettingsAreTolerated() throws {
+        let settings = nioDefaultSettings + [HTTP2Setting(parameter: .init(extensionSetting: 0xfafa), value: 0xf0f0f0f0)]
+        XCTAssertNoThrow(try self.basicHTTP2Connection(clientSettings: settings))
+    }
 }


### PR DESCRIPTION
Motivation:

As Chrome has started GREASEing HTTP/2 settings and frames, we should
ensure that we have tests that explicitly validate that we tolerate
GREASEing these parameters.

A future version of swift-nio-http2 should start emitting GREASE as
well, but for now we'll satisfy ourselves with this.

Two relevant citations:

https://tools.ietf.org/html/draft-bishop-httpbis-grease-00

https://bugs.chromium.org/p/chromium/issues/detail?id=1083706

Modifications:

- Added a frame parser test
- Added a end-to-end settings test.

Result:

Validated that GREASE is tolerated.