### PR TITLE
fix warnings with newer Swift compilers

### DIFF
--- a/Tests/NIOHPACKTests/HeaderTableTests.swift
+++ b/Tests/NIOHPACKTests/HeaderTableTests.swift
@@ -19,7 +19,7 @@ import NIO
 func XCTAssertEqualTuple<T1: Equatable, T2: Equatable>(_ expression1: @autoclosure () throws -> (T1, T2)?,
                                                        _ expression2: @autoclosure () throws -> (T1, T2)?,
                                                        _ message: @autoclosure () -> String = "",
-                                                       file: StaticString = #file, line: UInt = #line) {
+                                                       file: StaticString = (#file), line: UInt = #line) {
     let ex1: (T1, T2)?
     let ex2: (T1, T2)?
     do {

--- a/Tests/NIOHPACKTests/HuffmanCodingTests.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests.swift
@@ -23,7 +23,7 @@ class HuffmanCodingTests: XCTestCase {
     
     // MARK: - Helper Methods
     
-    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = #file, line: UInt = #line) {
+    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = (#file), line: UInt = #line) {
         XCTAssertEqual(buffer.readableBytes, array.count, "Buffer and array are different sizes", file: file, line: line)
         buffer.withUnsafeReadableBytes { bufPtr in
             array.withUnsafeBytes { arrayPtr in
@@ -32,7 +32,7 @@ class HuffmanCodingTests: XCTestCase {
         }
     }
     
-    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = #file, line: UInt = #line) throws {
+    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = (#file), line: UInt = #line) throws {
         self.scratchBuffer.clear()
         
         let utf8 = string.utf8

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
@@ -367,7 +367,7 @@ extension CompoundOutboundBufferTest {
 }
 
 extension CompoundOutboundBuffer {
-    fileprivate mutating func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
+    fileprivate mutating func receivedFrames(file: StaticString = (#file), line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         loop: while true {
@@ -388,14 +388,14 @@ extension CompoundOutboundBuffer {
 }
 
 extension CompoundOutboundBuffer.FlushedWritableFrameResult {
-    internal func assertNoFrame(file: StaticString = #file, line: UInt = #line) {
+    internal func assertNoFrame(file: StaticString = (#file), line: UInt = #line) {
         guard case .noFrame = self else {
             XCTFail("Expected .noFrame, got \(self)", file: file, line: line)
             return
         }
     }
 
-    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = #file, line: UInt = #line) {
+    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = (#file), line: UInt = #line) {
         guard case .error(let promise, let thrownError) = self else {
             XCTFail("Expected .error, got \(self)", file: file, line: line)
             return

--- a/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
@@ -24,21 +24,21 @@ struct TestCaseError: Error { }
 // We need these to work around the fact that neither EventLoopPromise or MarkedCircularBuffer have equatable
 // conformances.
 extension OutboundFrameAction {
-    internal func assertForward(file: StaticString = #file, line: UInt = #line) {
+    internal func assertForward(file: StaticString = (#file), line: UInt = #line) {
         guard case .forward = self else {
             XCTFail("Expected .forward, got \(self)", file: file, line: line)
             return
         }
     }
 
-    internal func assertNothing(file: StaticString = #file, line: UInt = #line) {
+    internal func assertNothing(file: StaticString = (#file), line: UInt = #line) {
         guard case .nothing = self else {
             XCTFail("Expected .nothing, got \(self)", file: file, line: line)
             return
         }
     }
 
-    internal func assertForwardAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertForwardAndDrop(file: StaticString = (#file), line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .forwardAndDrop(let promises, let error) = self else {
             XCTFail("Expected .forwardAndDrop, got \(self)", file: file, line: line)
             throw TestCaseError()
@@ -47,7 +47,7 @@ extension OutboundFrameAction {
         return (promises, error)
     }
 
-    internal func assertSucceedAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertSucceedAndDrop(file: StaticString = (#file), line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .succeedAndDrop(let promises, let error) = self else {
             XCTFail("Expected .succeedAndDrop, got \(self)", file: file, line: line)
             throw TestCaseError()

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -18,7 +18,7 @@ import NIO
 import NIOHPACK
 @testable import NIOHTTP2
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) {
     switch body() {
     case .succeed:
         return
@@ -28,7 +28,7 @@ func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticS
 }
 
 @discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) -> Error? {
     switch body() {
     case .connectionError(underlyingError: let error, type: type):
         return error
@@ -39,7 +39,7 @@ func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> Stat
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) -> Error? {
     switch body() {
     case .streamError(streamID: _, underlyingError: let error, type: type):
         return error
@@ -50,7 +50,7 @@ func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMac
 }
 
 @discardableResult
-func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
+func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
     let error: NIOHTTP2Errors.BadStreamStateTransition
 
     switch body().result {
@@ -68,7 +68,7 @@ func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclos
     return error
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
+func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) {
     switch body() {
     case .ignoreFrame:
         return
@@ -77,39 +77,39 @@ func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticSt
     }
 }
 
-func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = (#file), line: UInt = #line) {
     return assertSucceeds(body().0, file: file, line: line)
 }
 
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = (#file), line: UInt = #line) {
     assertConnectionError(type: type, body().0, file: file, line: line)
 }
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) {
     return assertSucceeds(body().result, file: file, line: line)
 }
 
 @discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> Error? {
     // Errors must always lead to noChange.
     let result = body()
     return assertConnectionError(type: type, result.result, file: file, line: line)
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> Error? {
     // Errors must always lead to noChange.
     let result = body()
     return assertStreamError(type: type, result.result, file: file, line: line)
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
+func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) {
     // Ignored frames must always lead to noChange.
     let result = body()
     assertIgnored(result.result, file: file, line: line)
 }
 
-func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
     let result = body()
 
     if case .some(.bulkStreamClosure(let closedStreamsEvent)) = result.effect {
@@ -166,7 +166,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.server.receiveSettings(.ack, frameEncoder: &self.serverEncoder, frameDecoder: &self.serverDecoder))
     }
 
-    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens streams.
@@ -180,7 +180,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertGoawaySucceeds(self.client.receiveGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: file, line: line)
     }
 
-    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens its stream, server sends response.
@@ -1323,7 +1323,7 @@ class ConnectionStateMachineTests: XCTestCase {
         self.exchangePreamble()
 
         // WindowUpdate frames are valid in a wide range of states. This test validates them in all of them, including proving that errors are correctly reported.
-        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = #file, line: UInt = #line) {
+        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = (#file), line: UInt = #line) {
             var client = client
             var server = server
 

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
@@ -44,7 +44,7 @@ class HTTP2FrameParserTests: XCTestCase {
     }
     
     private func assertEqualFrames(_ frame1: HTTP2Frame, _ frame2: HTTP2Frame,
-                                   file: StaticString = #file, line: UInt = #line) {
+                                   file: StaticString = (#file), line: UInt = #line) {
         XCTAssertEqual(frame1.streamID, frame2.streamID, "StreamID mismatch: \(frame1.streamID) != \(frame2.streamID)",
             file: file, line: line)
         
@@ -113,7 +113,7 @@ class HTTP2FrameParserTests: XCTestCase {
     
     private func assertReadsFrame(from bytes: inout ByteBuffer, matching expectedFrame: HTTP2Frame,
                                   expectedFlowControlledLength: Int = 0,
-                                  file: StaticString = #file, line: UInt = #line) throws {
+                                  file: StaticString = (#file), line: UInt = #line) throws {
         let initialByteIndex = bytes.readerIndex
         let totalFrameSize = bytes.readableBytes
         

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
@@ -21,7 +21,7 @@ import NIOHTTP1
 
 extension EmbeddedChannel {
     /// Assert that we received a request head.
-    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = #file, line: UInt = #line) {
+    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = (#file), line: UInt = #line) {
         guard let actualPart: HTTPServerRequestPart = try? assertNoThrowWithValue(self.readInbound()) else {
             XCTFail("No data received", file: file, line: line)
             return
@@ -30,7 +30,7 @@ extension EmbeddedChannel {
         XCTAssertEqual(actualPart, part, file: file, line: line)
     }
 
-    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = #file, line: UInt = #line) {
+    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = (#file), line: UInt = #line) {
         guard let actualPart: HTTPClientResponsePart = try? assertNoThrowWithValue(self.readInbound()) else {
             XCTFail("No data received", file: file, line: line)
             return

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
@@ -38,7 +38,7 @@ class OutboundFlowControlBufferTests: XCTestCase {
         return self.loop.makePromise()
     }
 
-    private func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
+    private func receivedFrames(file: StaticString = (#file), line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         while let (bufferedFrame, promise) = self.buffer.nextFlushedWritableFrame() {


### PR DESCRIPTION
Motiviation:

A few `#file` parameters have been forwarded to (now) `#filePath` ones.

Modification:

- silence the `#file`/`#filePath` warning by adding `(#file)` because we
  can't forward them properly right now
  (https://bugs.swift.org/browse/SR-12934). That's okay because even on
  the Swift master branch, `#file` == `#filePath`.

Result:

No warnings in newer Swift compilers.