### PR TITLE
forward #file to #filePath differently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ Package.pins
 Package.resolved
 *.pem
 DerivedData
+.swiftpm
+Tests/hpack-test-case
 

--- a/Tests/NIOHPACKTests/HeaderTableTests.swift
+++ b/Tests/NIOHPACKTests/HeaderTableTests.swift
@@ -19,14 +19,14 @@ import NIO
 func XCTAssertEqualTuple<T1: Equatable, T2: Equatable>(_ expression1: @autoclosure () throws -> (T1, T2)?,
                                                        _ expression2: @autoclosure () throws -> (T1, T2)?,
                                                        _ message: @autoclosure () -> String = "",
-                                                       file: StaticString = (#file), line: UInt = #line) {
+                                                       file: StaticString = #file, line: UInt = #line) {
     let ex1: (T1, T2)?
     let ex2: (T1, T2)?
     do {
         ex1 = try expression1()
         ex2 = try expression2()
     } catch {
-        XCTFail("Unexpected exception: \(error) \(message())", file: file, line: line)
+        XCTFail("Unexpected exception: \(error) \(message())", file: (file), line: line)
         return
     }
     
@@ -35,8 +35,8 @@ func XCTAssertEqualTuple<T1: Equatable, T2: Equatable>(_ expression1: @autoclosu
     let left2 = ex1?.1
     let right2 = ex2?.1
 
-    XCTAssertEqual(left1, right1, message(), file: file, line: line)
-    XCTAssertEqual(left2, right2, message(), file: file, line: line)
+    XCTAssertEqual(left1, right1, message(), file: (file), line: line)
+    XCTAssertEqual(left2, right2, message(), file: (file), line: line)
 }
 
 class HeaderTableTests: XCTestCase {

--- a/Tests/NIOHPACKTests/HuffmanCodingTests.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests.swift
@@ -23,26 +23,26 @@ class HuffmanCodingTests: XCTestCase {
     
     // MARK: - Helper Methods
     
-    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = (#file), line: UInt = #line) {
-        XCTAssertEqual(buffer.readableBytes, array.count, "Buffer and array are different sizes", file: file, line: line)
+    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(buffer.readableBytes, array.count, "Buffer and array are different sizes", file: (file), line: line)
         buffer.withUnsafeReadableBytes { bufPtr in
             array.withUnsafeBytes { arrayPtr in
-                XCTAssertEqual(memcmp(bufPtr.baseAddress!, arrayPtr.baseAddress!, arrayPtr.count), 0, "Buffer contents don't match", file: file, line: line)
+                XCTAssertEqual(memcmp(bufPtr.baseAddress!, arrayPtr.baseAddress!, arrayPtr.count), 0, "Buffer contents don't match", file: (file), line: line)
             }
         }
     }
     
-    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = (#file), line: UInt = #line) throws {
+    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = #file, line: UInt = #line) throws {
         self.scratchBuffer.clear()
         
         let utf8 = string.utf8
         let numBytes = self.scratchBuffer.writeHuffmanEncoded(bytes: utf8)
-        XCTAssertEqual(numBytes, bytes.count, "Wrong length encoding '\(string)'", file: file, line: line)
+        XCTAssertEqual(numBytes, bytes.count, "Wrong length encoding '\(string)'", file: (file), line: line)
         
-        assertEqualContents(self.scratchBuffer, bytes, file: file, line: line)
+        assertEqualContents(self.scratchBuffer, bytes, file: (file), line: line)
 
         let decoded = try scratchBuffer.getHuffmanEncodedString(at: self.scratchBuffer.readerIndex, length: self.scratchBuffer.readableBytes)
-        XCTAssertEqual(decoded, string, "Failed to decode '\(string)'", file: file, line: line)
+        XCTAssertEqual(decoded, string, "Failed to decode '\(string)'", file: (file), line: line)
     }
 
     func testBasicCoding() throws {

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
@@ -367,7 +367,7 @@ extension CompoundOutboundBufferTest {
 }
 
 extension CompoundOutboundBuffer {
-    fileprivate mutating func receivedFrames(file: StaticString = (#file), line: UInt = #line) -> [HTTP2Frame] {
+    fileprivate mutating func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         loop: while true {
@@ -379,7 +379,7 @@ extension CompoundOutboundBuffer {
                 promise?.succeed(())
             case .error(let promise, let error):
                 promise?.fail(error)
-                XCTFail("Caught error: \(error)", file: file, line: line)
+                XCTFail("Caught error: \(error)", file: (file), line: line)
             }
         }
 
@@ -388,21 +388,21 @@ extension CompoundOutboundBuffer {
 }
 
 extension CompoundOutboundBuffer.FlushedWritableFrameResult {
-    internal func assertNoFrame(file: StaticString = (#file), line: UInt = #line) {
+    internal func assertNoFrame(file: StaticString = #file, line: UInt = #line) {
         guard case .noFrame = self else {
-            XCTFail("Expected .noFrame, got \(self)", file: file, line: line)
+            XCTFail("Expected .noFrame, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = (#file), line: UInt = #line) {
+    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = #file, line: UInt = #line) {
         guard case .error(let promise, let thrownError) = self else {
-            XCTFail("Expected .error, got \(self)", file: file, line: line)
+            XCTFail("Expected .error, got \(self)", file: (file), line: line)
             return
         }
 
         guard let castError = thrownError as? ErrorType, castError == error else {
-            XCTFail("Expected \(error), got \(thrownError)", file: file, line: line)
+            XCTFail("Expected \(error), got \(thrownError)", file: (file), line: line)
             return
         }
 

--- a/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
@@ -24,32 +24,32 @@ struct TestCaseError: Error { }
 // We need these to work around the fact that neither EventLoopPromise or MarkedCircularBuffer have equatable
 // conformances.
 extension OutboundFrameAction {
-    internal func assertForward(file: StaticString = (#file), line: UInt = #line) {
+    internal func assertForward(file: StaticString = #file, line: UInt = #line) {
         guard case .forward = self else {
-            XCTFail("Expected .forward, got \(self)", file: file, line: line)
+            XCTFail("Expected .forward, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertNothing(file: StaticString = (#file), line: UInt = #line) {
+    internal func assertNothing(file: StaticString = #file, line: UInt = #line) {
         guard case .nothing = self else {
-            XCTFail("Expected .nothing, got \(self)", file: file, line: line)
+            XCTFail("Expected .nothing, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertForwardAndDrop(file: StaticString = (#file), line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertForwardAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .forwardAndDrop(let promises, let error) = self else {
-            XCTFail("Expected .forwardAndDrop, got \(self)", file: file, line: line)
+            XCTFail("Expected .forwardAndDrop, got \(self)", file: (file), line: line)
             throw TestCaseError()
         }
 
         return (promises, error)
     }
 
-    internal func assertSucceedAndDrop(file: StaticString = (#file), line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertSucceedAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .succeedAndDrop(let promises, let error) = self else {
-            XCTFail("Expected .succeedAndDrop, got \(self)", file: file, line: line)
+            XCTFail("Expected .succeedAndDrop, got \(self)", file: (file), line: line)
             throw TestCaseError()
         }
 

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -18,39 +18,39 @@ import NIO
 import NIOHPACK
 @testable import NIOHTTP2
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
     switch body() {
     case .succeed:
         return
     case let result:
-        XCTFail("Result \(result)", file: file, line: line)
+        XCTFail("Result \(result)", file: (file), line: line)
     }
 }
 
 @discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
     switch body() {
     case .connectionError(underlyingError: let error, type: type):
         return error
     case let result:
-        XCTFail("Expected connection error type \(type), got \(result)", file: file, line: line)
+        XCTFail("Expected connection error type \(type), got \(result)", file: (file), line: line)
         return nil
     }
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) -> Error? {
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
     switch body() {
     case .streamError(streamID: _, underlyingError: let error, type: type):
         return error
     case let result:
-        XCTFail("Expected stream error type \(type), got \(result)", file: file, line: line)
+        XCTFail("Expected stream error type \(type), got \(result)", file: (file), line: line)
         return nil
     }
 }
 
 @discardableResult
-func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
+func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
     let error: NIOHTTP2Errors.BadStreamStateTransition
 
     switch body().result {
@@ -59,67 +59,67 @@ func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclos
     case .connectionError(let underlyingError as NIOHTTP2Errors.BadStreamStateTransition, _):
         error = underlyingError
     default:
-        XCTFail("Unexpected result \(body().result)", file: file, line: line)
+        XCTFail("Unexpected result \(body().result)", file: (file), line: line)
         return nil
     }
 
-    XCTAssertEqual(error.fromState, type, file: file, line: line)
+    XCTAssertEqual(error.fromState, type, file: (file), line: line)
     
     return error
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = (#file), line: UInt = #line) {
+func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
     switch body() {
     case .ignoreFrame:
         return
     case let result:
-        XCTFail("Expected to ignore frame, got \(result)", file: file, line: line)
+        XCTFail("Expected to ignore frame, got \(result)", file: (file), line: line)
     }
 }
 
-func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = (#file), line: UInt = #line) {
-    return assertSucceeds(body().0, file: file, line: line)
+func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+    return assertSucceeds(body().0, file: (file), line: line)
 }
 
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = (#file), line: UInt = #line) {
-    assertConnectionError(type: type, body().0, file: file, line: line)
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+    assertConnectionError(type: type, body().0, file: (file), line: line)
 }
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) {
-    return assertSucceeds(body().result, file: file, line: line)
-}
-
-@discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> Error? {
-    // Errors must always lead to noChange.
-    let result = body()
-    return assertConnectionError(type: type, result.result, file: file, line: line)
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
+    return assertSucceeds(body().result, file: (file), line: line)
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
     // Errors must always lead to noChange.
     let result = body()
-    return assertStreamError(type: type, result.result, file: file, line: line)
+    return assertConnectionError(type: type, result.result, file: (file), line: line)
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = (#file), line: UInt = #line) {
+@discardableResult
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
+    // Errors must always lead to noChange.
+    let result = body()
+    return assertStreamError(type: type, result.result, file: (file), line: line)
+}
+
+func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
     // Ignored frames must always lead to noChange.
     let result = body()
-    assertIgnored(result.result, file: file, line: line)
+    assertIgnored(result.result, file: (file), line: line)
 }
 
-func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
+func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
     let result = body()
 
     if case .some(.bulkStreamClosure(let closedStreamsEvent)) = result.effect {
         XCTAssertEqual(closedStreamsEvent.closedStreams.sorted(), droppingStreams?.sorted(),
-                       "GOAWAY closed unexpected streams: expected \(String(describing: droppingStreams)), got \(closedStreamsEvent.closedStreams)", file: file, line: line)
+                       "GOAWAY closed unexpected streams: expected \(String(describing: droppingStreams)), got \(closedStreamsEvent.closedStreams)", file: (file), line: line)
     } else {
-        XCTAssertNil(droppingStreams, "GOAWAY did not close streams, but expected \(String(describing: droppingStreams))", file: file, line: line)
+        XCTAssertNil(droppingStreams, "GOAWAY did not close streams, but expected \(String(describing: droppingStreams))", file: (file), line: line)
     }
 
-    assertSucceeds(result.result, file: file, line: line)
+    assertSucceeds(result.result, file: (file), line: line)
 }
 
 
@@ -166,7 +166,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.server.receiveSettings(.ack, frameEncoder: &self.serverEncoder, frameDecoder: &self.serverDecoder))
     }
 
-    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
+    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens streams.
@@ -176,11 +176,11 @@ class ConnectionStateMachineTests: XCTestCase {
         }
 
         // Server sends a reset.
-        assertGoawaySucceeds(self.server.sendGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: file, line: line)
-        assertGoawaySucceeds(self.client.receiveGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: file, line: line)
+        assertGoawaySucceeds(self.server.sendGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: (file), line: line)
+        assertGoawaySucceeds(self.client.receiveGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: (file), line: line)
     }
 
-    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = (#file), line: UInt = #line) {
+    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens its stream, server sends response.
@@ -1323,19 +1323,19 @@ class ConnectionStateMachineTests: XCTestCase {
         self.exchangePreamble()
 
         // WindowUpdate frames are valid in a wide range of states. This test validates them in all of them, including proving that errors are correctly reported.
-        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = (#file), line: UInt = #line) {
+        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = #file, line: UInt = #line) {
             var client = client
             var server = server
 
-            assertSucceeds(client.sendWindowUpdate(streamID: streamOne, windowIncrement: 10), file: file, line: line)
-            assertSucceeds(server.receiveWindowUpdate(streamID: streamOne, windowIncrement: 10), file: file, line: line)
-            assertStreamError(type: .flowControlError, client.sendWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: file, line: line)
-            assertStreamError(type: .flowControlError, server.receiveWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: file, line: line)
+            assertSucceeds(client.sendWindowUpdate(streamID: streamOne, windowIncrement: 10), file: (file), line: line)
+            assertSucceeds(server.receiveWindowUpdate(streamID: streamOne, windowIncrement: 10), file: (file), line: line)
+            assertStreamError(type: .flowControlError, client.sendWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: (file), line: line)
+            assertStreamError(type: .flowControlError, server.receiveWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: (file), line: line)
 
-            assertSucceeds(server.sendWindowUpdate(streamID: streamOne, windowIncrement: 10), file: file, line: line)
-            assertSucceeds(client.receiveWindowUpdate(streamID: streamOne, windowIncrement: 10), file: file, line: line)
-            assertStreamError(type: .flowControlError, server.sendWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: file, line: line)
-            assertStreamError(type: .flowControlError, client.receiveWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: file, line: line)
+            assertSucceeds(server.sendWindowUpdate(streamID: streamOne, windowIncrement: 10), file: (file), line: line)
+            assertSucceeds(client.receiveWindowUpdate(streamID: streamOne, windowIncrement: 10), file: (file), line: line)
+            assertStreamError(type: .flowControlError, server.sendWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: (file), line: line)
+            assertStreamError(type: .flowControlError, client.receiveWindowUpdate(streamID: streamOne, windowIncrement: UInt32(Int32.max)), file: (file), line: line)
         }
 
         assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: false))

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
@@ -44,76 +44,76 @@ class HTTP2FrameParserTests: XCTestCase {
     }
     
     private func assertEqualFrames(_ frame1: HTTP2Frame, _ frame2: HTTP2Frame,
-                                   file: StaticString = (#file), line: UInt = #line) {
+                                   file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(frame1.streamID, frame2.streamID, "StreamID mismatch: \(frame1.streamID) != \(frame2.streamID)",
-            file: file, line: line)
+            file: (file), line: line)
         
         switch (frame1.payload, frame2.payload) {
         case let (.data(l), .data(r)):
             switch (l.data, r.data) {
             case let (.byteBuffer(lb), .byteBuffer(rb)):
-                XCTAssertEqual(lb, rb, "Data bytes mismatch: \(lb) != \(rb)", file: file, line: line)
+                XCTAssertEqual(lb, rb, "Data bytes mismatch: \(lb) != \(rb)", file: (file), line: line)
             default:
-                XCTFail("We're not testing with file regions!", file: file, line: line)
+                XCTFail("We're not testing with file regions!", file: (file), line: line)
             }
-            XCTAssertEqual(l.endStream, r.endStream, "endStream mismatch: \(l.endStream) != \(r.endStream)", file: file, line: line)
-            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: file, line: line)
+            XCTAssertEqual(l.endStream, r.endStream, "endStream mismatch: \(l.endStream) != \(r.endStream)", file: (file), line: line)
+            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: (file), line: line)
             
         case let (.headers(l), .headers(r)):
-            XCTAssertEqual(l.headers, r.headers, "Headers mismatch: \(l.headers) != \(r.headers)", file: file, line: line)
+            XCTAssertEqual(l.headers, r.headers, "Headers mismatch: \(l.headers) != \(r.headers)", file: (file), line: line)
             XCTAssertEqual(l.priorityData, r.priorityData, "Priority mismatch: \(String(describing: l.priorityData)) != \(String(describing: r.priorityData))",
-                file: file, line: line)
-            XCTAssertEqual(l.endStream, r.endStream, "endStream mismatch: \(l.endStream) != \(r.endStream)", file: file, line: line)
-            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: file, line: line)
+                file: (file), line: line)
+            XCTAssertEqual(l.endStream, r.endStream, "endStream mismatch: \(l.endStream) != \(r.endStream)", file: (file), line: line)
+            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: (file), line: line)
             
         case let (.priority(lp), .priority(rp)):
-            XCTAssertEqual(lp, rp, "Priority mismatch: \(lp) != \(rp)", file: file, line: line)
+            XCTAssertEqual(lp, rp, "Priority mismatch: \(lp) != \(rp)", file: (file), line: line)
             
         case let (.rstStream(le), .rstStream(re)):
-            XCTAssertEqual(le, re, "Error mismatch: \(le) != \(re)", file: file, line: line)
+            XCTAssertEqual(le, re, "Error mismatch: \(le) != \(re)", file: (file), line: line)
             
         case let (.settings(.settings(ls)), .settings(.settings(rs))):
-            XCTAssertEqual(ls, rs, "Settings mismatch: \(ls) != \(rs)", file: file, line: line)
+            XCTAssertEqual(ls, rs, "Settings mismatch: \(ls) != \(rs)", file: (file), line: line)
 
         case (.settings(.ack), .settings(.ack)):
             // Nothing specific to compare here.
             break
             
         case let (.pushPromise(l), .pushPromise(r)):
-            XCTAssertEqual(l.pushedStreamID, r.pushedStreamID, "Stream ID mismatch: \(l.pushedStreamID) != \(r.pushedStreamID)", file: file, line: line)
-            XCTAssertEqual(l.headers, r.headers, "Headers mismatch: \(l.headers) != \(r.headers)", file: file, line: line)
-            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: file, line: line)
+            XCTAssertEqual(l.pushedStreamID, r.pushedStreamID, "Stream ID mismatch: \(l.pushedStreamID) != \(r.pushedStreamID)", file: (file), line: line)
+            XCTAssertEqual(l.headers, r.headers, "Headers mismatch: \(l.headers) != \(r.headers)", file: (file), line: line)
+            XCTAssertEqual(l.paddingBytes, r.paddingBytes, "paddingBytes mismatch: \(String(describing: l.paddingBytes)) != \(String(describing: r.paddingBytes))", file: (file), line: line)
             
         case let (.ping(lp, la), .ping(rp, ra)):
-            XCTAssertEqual(lp, rp, "Ping data mismatch: \(lp) != \(rp)", file: file, line: line)
-            XCTAssertEqual(la, ra, "Ping ack flag mismatch: \(la) != \(ra)", file: file, line: line)
+            XCTAssertEqual(lp, rp, "Ping data mismatch: \(lp) != \(rp)", file: (file), line: line)
+            XCTAssertEqual(la, ra, "Ping ack flag mismatch: \(la) != \(ra)", file: (file), line: line)
             
         case let (.goAway(ls, le, lo), .goAway(rs, re, ro)):
-            XCTAssertEqual(ls, rs, "Stream ID mismatch: \(ls) != \(rs)", file: file, line: line)
-            XCTAssertEqual(le, re, "Error mismatch: \(le) != \(re)", file: file, line: line)
+            XCTAssertEqual(ls, rs, "Stream ID mismatch: \(ls) != \(rs)", file: (file), line: line)
+            XCTAssertEqual(le, re, "Error mismatch: \(le) != \(re)", file: (file), line: line)
             XCTAssertEqual(lo, ro, "Opaque data mismatch: \(String(describing: lo)) != \(String(describing: ro))",
-                file: file, line: line)
+                file: (file), line: line)
             
         case let (.windowUpdate(ls), .windowUpdate(rs)):
-            XCTAssertEqual(ls, rs, "Window size mismatch: \(ls) != \(rs)", file: file, line: line)
+            XCTAssertEqual(ls, rs, "Window size mismatch: \(ls) != \(rs)", file: (file), line: line)
             
         case let (.alternativeService(lo, lf), .alternativeService(ro, rf)):
             XCTAssertEqual(lo, ro, "Origin mismatch: \(String(describing: lo)), \(String(describing: ro))",
-                file: file, line: line)
+                file: (file), line: line)
             XCTAssertEqual(lf, rf, "ALTSVC field mismatch: \(String(describing: lf)), \(String(describing: rf))",
-                file: file, line: line)
+                file: (file), line: line)
             
         case let (.origin(lo), .origin(ro)):
-            XCTAssertEqual(lo, ro, "Origins mismatch: \(lo) != \(ro)", file: file, line: line)
+            XCTAssertEqual(lo, ro, "Origins mismatch: \(lo) != \(ro)", file: (file), line: line)
             
         default:
-            XCTFail("Payload mismatch: \(frame1.payload) / \(frame2.payload)", file: file, line: line)
+            XCTFail("Payload mismatch: \(frame1.payload) / \(frame2.payload)", file: (file), line: line)
         }
     }
     
     private func assertReadsFrame(from bytes: inout ByteBuffer, matching expectedFrame: HTTP2Frame,
                                   expectedFlowControlledLength: Int = 0,
-                                  file: StaticString = (#file), line: UInt = #line) throws {
+                                  file: StaticString = #file, line: UInt = #line) throws {
         let initialByteIndex = bytes.readerIndex
         let totalFrameSize = bytes.readableBytes
         
@@ -126,8 +126,8 @@ class HTTP2FrameParserTests: XCTestCase {
         // should consume all the bytes
         XCTAssertEqual(bytes.readableBytes, 0)
 
-        self.assertEqualFrames(frame, expectedFrame, file: file, line: line)
-        XCTAssertEqual(actualLength, expectedFlowControlledLength, "Non-matching flow controlled length", file: file, line: line)
+        self.assertEqualFrames(frame, expectedFrame, file: (file), line: line)
+        XCTAssertEqual(actualLength, expectedFlowControlledLength, "Non-matching flow controlled length", file: (file), line: line)
 
         if totalFrameSize > 9 {
             // Now try again with the frame arriving in two separate chunks.
@@ -144,9 +144,9 @@ class HTTP2FrameParserTests: XCTestCase {
             let (realFrame, length) = try decoder.nextFrame()!
             XCTAssertNotNil(realFrame)
 
-            self.assertEqualFrames(realFrame, expectedFrame, file: file, line: line)
+            self.assertEqualFrames(realFrame, expectedFrame, file: (file), line: line)
             XCTAssertEqual(length, expectedFlowControlledLength, "Non-matching flow controlled length in parts",
-                           file: file, line: line)
+                           file: (file), line: line)
         }
     }
     

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
@@ -21,22 +21,22 @@ import NIOHTTP1
 
 extension EmbeddedChannel {
     /// Assert that we received a request head.
-    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = (#file), line: UInt = #line) {
+    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = #file, line: UInt = #line) {
         guard let actualPart: HTTPServerRequestPart = try? assertNoThrowWithValue(self.readInbound()) else {
-            XCTFail("No data received", file: file, line: line)
+            XCTFail("No data received", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(actualPart, part, file: file, line: line)
+        XCTAssertEqual(actualPart, part, file: (file), line: line)
     }
 
-    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = (#file), line: UInt = #line) {
+    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = #file, line: UInt = #line) {
         guard let actualPart: HTTPClientResponsePart = try? assertNoThrowWithValue(self.readInbound()) else {
-            XCTFail("No data received", file: file, line: line)
+            XCTFail("No data received", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(actualPart, part, file: file, line: line)
+        XCTAssertEqual(actualPart, part, file: (file), line: line)
     }
 }
 

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
@@ -38,7 +38,7 @@ class OutboundFlowControlBufferTests: XCTestCase {
         return self.loop.makePromise()
     }
 
-    private func receivedFrames(file: StaticString = (#file), line: UInt = #line) -> [HTTP2Frame] {
+    private func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         while let (bufferedFrame, promise) = self.buffer.nextFlushedWritableFrame() {

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -32,7 +32,7 @@ struct NoFrameReceived: Error { }
 extension XCTestCase {
     /// Have two `EmbeddedChannel` objects send and receive data from each other until
     /// they make no forward progress.
-    func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel, file: StaticString = (#file), line: UInt = #line) {
+    func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel, file: StaticString = #file, line: UInt = #line) {
         var operated: Bool
 
         func readBytesFromChannel(_ channel: EmbeddedChannel) -> ByteBuffer? {
@@ -52,24 +52,24 @@ extension XCTestCase {
 
             if let data = readBytesFromChannel(first) {
                 operated = true
-                XCTAssertNoThrow(try second.writeInbound(data), file: file, line: line)
+                XCTAssertNoThrow(try second.writeInbound(data), file: (file), line: line)
             }
             if let data = readBytesFromChannel(second) {
                 operated = true
-                XCTAssertNoThrow(try first.writeInbound(data), file: file, line: line)
+                XCTAssertNoThrow(try first.writeInbound(data), file: (file), line: line)
             }
         } while operated
     }
 
     /// Deliver all the bytes currently flushed on `sourceChannel` to `targetChannel`.
-    func deliverAllBytes(from sourceChannel: EmbeddedChannel, to targetChannel: EmbeddedChannel, file: StaticString = (#file), line: UInt = #line) {
+    func deliverAllBytes(from sourceChannel: EmbeddedChannel, to targetChannel: EmbeddedChannel, file: StaticString = #file, line: UInt = #line) {
         // Collect the serialized data.
         var frameBuffer = sourceChannel.allocator.buffer(capacity: 1024)
         while case .some(.byteBuffer(var buf)) = try? assertNoThrowWithValue(sourceChannel.readOutbound(as: IOData.self)) {
             frameBuffer.writeBuffer(&buf)
         }
 
-        XCTAssertNoThrow(try targetChannel.writeInbound(frameBuffer), file: file, line: line)
+        XCTAssertNoThrow(try targetChannel.writeInbound(frameBuffer), file: (file), line: line)
     }
 
     /// Given two `EmbeddedChannel` objects, verify that each one performs the handshake: specifically,
@@ -79,7 +79,7 @@ extension XCTestCase {
     /// channel is now in an indeterminate state.
     func assertDoHandshake(client: EmbeddedChannel, server: EmbeddedChannel,
                            clientSettings: [HTTP2Setting] = nioDefaultSettings, serverSettings: [HTTP2Setting] = nioDefaultSettings,
-                           file: StaticString = (#file), line: UInt = #line) throws {
+                           file: StaticString = #file, line: UInt = #line) throws {
         // This connects are not semantically right, but are required in order to activate the
         // channels.
         //! FIXME: Replace with registerAlreadyConfigured0 once EmbeddedChannel propagates this
@@ -89,24 +89,24 @@ extension XCTestCase {
         _ = try server.connect(to: socket).wait()
 
         // First the channels need to interact.
-        self.interactInMemory(client, server, file: file, line: line)
+        self.interactInMemory(client, server, file: (file), line: line)
 
         // Now keep an eye on things. Each channel should first have been sent a SETTINGS frame.
-        let clientReceivedSettings = try client.assertReceivedFrame(file: file, line: line)
-        let serverReceivedSettings = try server.assertReceivedFrame(file: file, line: line)
+        let clientReceivedSettings = try client.assertReceivedFrame(file: (file), line: line)
+        let serverReceivedSettings = try server.assertReceivedFrame(file: (file), line: line)
 
         // Each channel should also have a settings ACK.
-        let clientReceivedSettingsAck = try client.assertReceivedFrame(file: file, line: line)
-        let serverReceivedSettingsAck = try server.assertReceivedFrame(file: file, line: line)
+        let clientReceivedSettingsAck = try client.assertReceivedFrame(file: (file), line: line)
+        let serverReceivedSettingsAck = try server.assertReceivedFrame(file: (file), line: line)
 
         // Check that these SETTINGS frames are ok.
-        clientReceivedSettings.assertSettingsFrame(expectedSettings: serverSettings, ack: false, file: file, line: line)
-        serverReceivedSettings.assertSettingsFrame(expectedSettings: clientSettings, ack: false, file: file, line: line)
-        clientReceivedSettingsAck.assertSettingsFrame(expectedSettings: [], ack: true, file: file, line: line)
-        serverReceivedSettingsAck.assertSettingsFrame(expectedSettings: [], ack: true, file: file, line: line)
+        clientReceivedSettings.assertSettingsFrame(expectedSettings: serverSettings, ack: false, file: (file), line: line)
+        serverReceivedSettings.assertSettingsFrame(expectedSettings: clientSettings, ack: false, file: (file), line: line)
+        clientReceivedSettingsAck.assertSettingsFrame(expectedSettings: [], ack: true, file: (file), line: line)
+        serverReceivedSettingsAck.assertSettingsFrame(expectedSettings: [], ack: true, file: (file), line: line)
 
-        client.assertNoFramesReceived(file: file, line: line)
-        server.assertNoFramesReceived(file: file, line: line)
+        client.assertNoFramesReceived(file: (file), line: line)
+        server.assertNoFramesReceived(file: (file), line: line)
     }
 
     /// Assert that sending the given `frames` into `sender` causes them all to pop back out again at `receiver`,
@@ -114,19 +114,19 @@ extension XCTestCase {
     ///
     /// Optionally returns the frames received.
     @discardableResult
-    func assertFramesRoundTrip(frames: [HTTP2Frame], sender: EmbeddedChannel, receiver: EmbeddedChannel, file: StaticString = (#file), line: UInt = #line) throws -> [HTTP2Frame] {
+    func assertFramesRoundTrip(frames: [HTTP2Frame], sender: EmbeddedChannel, receiver: EmbeddedChannel, file: StaticString = #file, line: UInt = #line) throws -> [HTTP2Frame] {
         for frame in frames {
             sender.write(frame, promise: nil)
         }
         sender.flush()
-        self.interactInMemory(sender, receiver, file: file, line: line)
-        sender.assertNoFramesReceived(file: file, line: line)
+        self.interactInMemory(sender, receiver, file: (file), line: line)
+        sender.assertNoFramesReceived(file: (file), line: line)
 
         var receivedFrames = [HTTP2Frame]()
 
         for frame in frames {
-            let receivedFrame = try receiver.assertReceivedFrame(file: file, line: line)
-            receivedFrame.assertFrameMatches(this: frame, file: file, line: line)
+            let receivedFrame = try receiver.assertReceivedFrame(file: (file), line: line)
+            receivedFrame.assertFrameMatches(this: frame, file: (file), line: line)
             receivedFrames.append(receivedFrame)
         }
 
@@ -135,13 +135,13 @@ extension XCTestCase {
 
     /// Asserts that sending new settings from `sender` to `receiver` leads to an appropriate settings ACK. Does not assert that no other frames have been
     /// received.
-    func assertSettingsUpdateWithAck(_ newSettings: HTTP2Settings, sender: EmbeddedChannel, receiver: EmbeddedChannel, file: StaticString = (#file), line: UInt = #line) throws {
+    func assertSettingsUpdateWithAck(_ newSettings: HTTP2Settings, sender: EmbeddedChannel, receiver: EmbeddedChannel, file: StaticString = #file, line: UInt = #line) throws {
         let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings(newSettings)))
         sender.writeAndFlush(frame, promise: nil)
-        self.interactInMemory(sender, receiver, file: file, line: line)
+        self.interactInMemory(sender, receiver, file: (file), line: line)
 
-        try receiver.assertReceivedFrame(file: file, line: line).assertFrameMatches(this: frame)
-        try sender.assertReceivedFrame(file: file, line: line).assertFrameMatches(this: HTTP2Frame(streamID: .rootStream, payload: .settings(.ack)))
+        try receiver.assertReceivedFrame(file: (file), line: line).assertFrameMatches(this: frame)
+        try sender.assertReceivedFrame(file: (file), line: line).assertFrameMatches(this: HTTP2Frame(streamID: .rootStream, payload: .settings(.ack)))
     }
 }
 
@@ -150,9 +150,9 @@ extension EmbeddedChannel {
     /// sent, as this function does not call `interactInMemory`. If no frame has been received, this
     /// will call `XCTFail` and then throw: this will ensure that the test will not proceed past
     /// this point if no frame was received.
-    func assertReceivedFrame(file: StaticString = (#file), line: UInt = #line) throws -> HTTP2Frame {
+    func assertReceivedFrame(file: StaticString = #file, line: UInt = #line) throws -> HTTP2Frame {
         guard let frame: HTTP2Frame = try assertNoThrowWithValue(self.readInbound()) else {
-            XCTFail("Did not receive frame", file: file, line: line)
+            XCTFail("Did not receive frame", file: (file), line: line)
             throw NoFrameReceived()
         }
 
@@ -160,16 +160,16 @@ extension EmbeddedChannel {
     }
 
     /// Asserts that the connection has not received a HTTP/2 frame at this time.
-    func assertNoFramesReceived(file: StaticString = (#file), line: UInt = #line) {
+    func assertNoFramesReceived(file: StaticString = #file, line: UInt = #line) {
         let content: HTTP2Frame? = try? assertNoThrowWithValue(self.readInbound())
-        XCTAssertNil(content, "Received unexpected content: \(content!)", file: file, line: line)
+        XCTAssertNil(content, "Received unexpected content: \(content!)", file: (file), line: line)
     }
 
     /// Retrieve all sent frames.
-    func sentFrames(file: StaticString = (#file), line: UInt = #line) throws -> [HTTP2Frame] {
+    func sentFrames(file: StaticString = #file, line: UInt = #line) throws -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
-        while let frame = try assertNoThrowWithValue(self.readOutbound(as: HTTP2Frame.self), file: file, line: line) {
+        while let frame = try assertNoThrowWithValue(self.readOutbound(as: HTTP2Frame.self), file: (file), line: line) {
             receivedFrames.append(frame)
         }
 
@@ -179,68 +179,68 @@ extension EmbeddedChannel {
 
 extension HTTP2Frame {
     /// Asserts that the given frame is a SETTINGS frame.
-    func assertSettingsFrame(expectedSettings: [HTTP2Setting], ack: Bool, file: StaticString = (#file), line: UInt = #line) {
+    func assertSettingsFrame(expectedSettings: [HTTP2Setting], ack: Bool, file: StaticString = #file, line: UInt = #line) {
         guard case .settings(let payload) = self.payload else {
-            XCTFail("Expected SETTINGS frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected SETTINGS frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
         XCTAssertEqual(self.streamID, .rootStream, "Got unexpected stream ID for SETTINGS: \(self.streamID)",
-                       file: file, line: line)
+                       file: (file), line: line)
 
         switch payload {
         case .ack:
-            XCTAssertEqual(expectedSettings, [], "Got unexpected settings: expected \(expectedSettings), got []", file: file, line: line)
-            XCTAssertTrue(ack, "Got unexpected value for ack: expected \(ack), got true", file: file, line: line)
+            XCTAssertEqual(expectedSettings, [], "Got unexpected settings: expected \(expectedSettings), got []", file: (file), line: line)
+            XCTAssertTrue(ack, "Got unexpected value for ack: expected \(ack), got true", file: (file), line: line)
         case .settings(let actualSettings):
-            XCTAssertEqual(expectedSettings, actualSettings, "Got unexpected settings: expected \(expectedSettings), got \(actualSettings)", file: file, line: line)
-            XCTAssertFalse(false, "Got unexpected value for ack: expected \(ack), got false", file: file, line: line)
+            XCTAssertEqual(expectedSettings, actualSettings, "Got unexpected settings: expected \(expectedSettings), got \(actualSettings)", file: (file), line: line)
+            XCTAssertFalse(false, "Got unexpected value for ack: expected \(ack), got false", file: (file), line: line)
         }
     }
 
-    func assertSettingsFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertSettingsFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .settings(let payload) = frame.payload else {
             preconditionFailure("Settings frames can never match non-settings frames")
         }
 
         switch payload {
         case .ack:
-            self.assertSettingsFrame(expectedSettings: [], ack: true, file: file, line: line)
+            self.assertSettingsFrame(expectedSettings: [], ack: true, file: (file), line: line)
         case .settings(let expectedSettings):
-            self.assertSettingsFrame(expectedSettings: expectedSettings, ack: false, file: file, line: line)
+            self.assertSettingsFrame(expectedSettings: expectedSettings, ack: false, file: (file), line: line)
         }
     }
 
     /// Asserts that this frame matches a give other frame.
-    func assertFrameMatches(this frame: HTTP2Frame, dataFileRegionToByteBuffer: Bool = true, file: StaticString = (#file), line: UInt = #line) {
+    func assertFrameMatches(this frame: HTTP2Frame, dataFileRegionToByteBuffer: Bool = true, file: StaticString = #file, line: UInt = #line) {
         switch frame.payload {
         case .headers:
-            self.assertHeadersFrameMatches(this: frame, file: file, line: line)
+            self.assertHeadersFrameMatches(this: frame, file: (file), line: line)
         case .data:
-            self.assertDataFrameMatches(this: frame, fileRegionToByteBuffer: dataFileRegionToByteBuffer, file: file, line: line)
+            self.assertDataFrameMatches(this: frame, fileRegionToByteBuffer: dataFileRegionToByteBuffer, file: (file), line: line)
         case .goAway:
-            self.assertGoAwayFrameMatches(this: frame, file: file, line: line)
+            self.assertGoAwayFrameMatches(this: frame, file: (file), line: line)
         case .ping:
-            self.assertPingFrameMatches(this: frame, file: file, line: line)
+            self.assertPingFrameMatches(this: frame, file: (file), line: line)
         case .settings:
-            self.assertSettingsFrameMatches(this: frame, file: file, line: line)
+            self.assertSettingsFrameMatches(this: frame, file: (file), line: line)
         case .rstStream:
-            self.assertRstStreamFrameMatches(this: frame, file: file, line: line)
+            self.assertRstStreamFrameMatches(this: frame, file: (file), line: line)
         case .priority:
-            self.assertPriorityFrameMatches(this: frame, file: file, line: line)
+            self.assertPriorityFrameMatches(this: frame, file: (file), line: line)
         case .pushPromise:
-            self.assertPushPromiseFrameMatches(this: frame, file: file, line: line)
+            self.assertPushPromiseFrameMatches(this: frame, file: (file), line: line)
         case .windowUpdate:
-            self.assertWindowUpdateFrameMatches(this: frame, file: file, line: line)
+            self.assertWindowUpdateFrameMatches(this: frame, file: (file), line: line)
         case .alternativeService:
-            self.assertAlternativeServiceFrameMatches(this: frame, file: file, line: line)
+            self.assertAlternativeServiceFrameMatches(this: frame, file: (file), line: line)
         case .origin:
-            self.assertOriginFrameMatches(this: frame, file: file, line: line)
+            self.assertOriginFrameMatches(this: frame, file: (file), line: line)
         }
     }
 
     /// Asserts that a given frame is a HEADERS frame matching this one.
-    func assertHeadersFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertHeadersFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .headers(let payload) = frame.payload else {
             preconditionFailure("Headers frames can never match non-headers frames")
         }
@@ -248,7 +248,7 @@ extension HTTP2Frame {
                                 streamID: frame.streamID,
                                 headers: payload.headers,
                                 priority: payload.priorityData,
-                                file: file,
+                                file: (file),
                                 line: line)
     }
 
@@ -263,29 +263,29 @@ extension HTTP2Frame {
     func assertHeadersFrame(endStream: Bool, streamID: HTTP2StreamID, headers: HPACKHeaders,
                             priority: HTTP2Frame.StreamPriorityData? = nil,
                             type: HeadersType? = nil,
-                            file: StaticString = (#file), line: UInt = #line) {
+                            file: StaticString = #file, line: UInt = #line) {
         guard case .headers(let actualPayload) = self.payload else {
-            XCTFail("Expected HEADERS frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected HEADERS frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
         XCTAssertEqual(actualPayload.endStream, endStream,
-                       "Unexpected endStream: expected \(endStream), got \(actualPayload.endStream)", file: file, line: line)
+                       "Unexpected endStream: expected \(endStream), got \(actualPayload.endStream)", file: (file), line: line)
         XCTAssertEqual(self.streamID, streamID,
-                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: file, line: line)
-        XCTAssertEqual(headers, actualPayload.headers, "Non-equal headers: expected \(headers), got \(actualPayload.headers)", file: file, line: line)
-        XCTAssertEqual(priority, actualPayload.priorityData, "Non-equal priorities: expected \(String(describing: priority)), got \(String(describing: actualPayload.priorityData))", file: file, line: line)
+                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: (file), line: line)
+        XCTAssertEqual(headers, actualPayload.headers, "Non-equal headers: expected \(headers), got \(actualPayload.headers)", file: (file), line: line)
+        XCTAssertEqual(priority, actualPayload.priorityData, "Non-equal priorities: expected \(String(describing: priority)), got \(String(describing: actualPayload.priorityData))", file: (file), line: line)
 
         switch type {
         case .some(.request):
             XCTAssertNoThrow(try actualPayload.headers.validateRequestBlock(),
-                             "\(actualPayload.headers) not a valid \(type!) headers block", file: file, line: line)
+                             "\(actualPayload.headers) not a valid \(type!) headers block", file: (file), line: line)
         case .some(.response):
             XCTAssertNoThrow(try actualPayload.headers.validateResponseBlock(),
-                             "\(actualPayload.headers) not a valid \(type!) headers block", file: file, line: line)
+                             "\(actualPayload.headers) not a valid \(type!) headers block", file: (file), line: line)
         case .some(.trailers):
             XCTAssertNoThrow(try actualPayload.headers.validateTrailersBlock(),
-                             "\(actualPayload.headers) not a valid \(type!) headers block", file: file, line: line)
+                             "\(actualPayload.headers) not a valid \(type!) headers block", file: (file), line: line)
         case .some(.doNotValidate):
             () // alright, let's not validate then
         case .none:
@@ -293,16 +293,16 @@ extension HTTP2Frame {
                 (try? actualPayload.headers.validateResponseBlock()) != nil ||
                 (try? actualPayload.headers.validateTrailersBlock()) != nil,
                           "\(actualPayload.headers) not a valid request/response/trailers header block",
-                file: file, line: line)
+                file: (file), line: line)
         }
     }
 
     /// Asserts that a given frame is a DATA frame matching this one.
     ///
     /// This function always converts the DATA frame to a bytebuffer, for use with round-trip testing.
-    func assertDataFrameMatches(this frame: HTTP2Frame, fileRegionToByteBuffer: Bool = true, file: StaticString = (#file), line: UInt = #line) {
+    func assertDataFrameMatches(this frame: HTTP2Frame, fileRegionToByteBuffer: Bool = true, file: StaticString = #file, line: UInt = #line) {
         guard case .data(let payload) = frame.payload else {
-            XCTFail("Expected DATA frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected DATA frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
@@ -311,7 +311,7 @@ extension HTTP2Frame {
             self.assertDataFrame(endStream: payload.endStream,
                                  streamID: frame.streamID,
                                  payload: bufferPayload,
-                                 file: file,
+                                 file: (file),
                                  line: line)
         case (.fileRegion(let filePayload), true):
             // Sorry about creating an allocator from thin air here!
@@ -319,13 +319,13 @@ extension HTTP2Frame {
             self.assertDataFrame(endStream: payload.endStream,
                                  streamID: frame.streamID,
                                  payload: expectedPayload,
-                                 file: file,
+                                 file: (file),
                                  line: line)
         case (.fileRegion(let filePayload), false):
             self.assertDataFrame(endStream: payload.endStream,
                                  streamID: frame.streamID,
                                  payload: filePayload,
-                                 file: file,
+                                 file: (file),
                                  line: line)
         }
 
@@ -333,214 +333,214 @@ extension HTTP2Frame {
     }
 
     /// Assert the given frame is a DATA frame with the appropriate settings.
-    func assertDataFrame(endStream: Bool, streamID: HTTP2StreamID, payload: ByteBuffer, file: StaticString = (#file), line: UInt = #line) {
+    func assertDataFrame(endStream: Bool, streamID: HTTP2StreamID, payload: ByteBuffer, file: StaticString = #file, line: UInt = #line) {
         guard case .data(let actualFrameBody) = self.payload else {
-            XCTFail("Expected DATA frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected DATA frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
         guard case .byteBuffer(let actualPayload) = actualFrameBody.data else {
-            XCTFail("Expected ByteBuffer DATA frame, got \(actualFrameBody.data) instead", file: file, line: line)
+            XCTFail("Expected ByteBuffer DATA frame, got \(actualFrameBody.data) instead", file: (file), line: line)
             return
         }
 
         XCTAssertEqual(actualFrameBody.endStream, endStream,
-                       "Unexpected endStream: expected \(endStream), got \(actualFrameBody.endStream)", file: file, line: line)
+                       "Unexpected endStream: expected \(endStream), got \(actualFrameBody.endStream)", file: (file), line: line)
         XCTAssertEqual(self.streamID, streamID,
-                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: file, line: line)
+                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: (file), line: line)
         XCTAssertEqual(actualPayload, payload,
-                       "Unexpected body: expected \(payload), got \(actualPayload)", file: file, line: line)
+                       "Unexpected body: expected \(payload), got \(actualPayload)", file: (file), line: line)
 
     }
 
-    func assertDataFrame(endStream: Bool, streamID: HTTP2StreamID, payload: FileRegion, file: StaticString = (#file), line: UInt = #line) {
+    func assertDataFrame(endStream: Bool, streamID: HTTP2StreamID, payload: FileRegion, file: StaticString = #file, line: UInt = #line) {
         guard case .data(let actualFrameBody) = self.payload else {
-            XCTFail("Expected DATA frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected DATA frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
         guard case .fileRegion(let actualPayload) = actualFrameBody.data else {
-            XCTFail("Expected FileRegion DATA frame, got \(actualFrameBody.data) instead", file: file, line: line)
+            XCTFail("Expected FileRegion DATA frame, got \(actualFrameBody.data) instead", file: (file), line: line)
             return
         }
 
         XCTAssertEqual(actualFrameBody.endStream, endStream,
-                       "Unexpected endStream: expected \(endStream), got \(actualFrameBody.endStream)", file: file, line: line)
+                       "Unexpected endStream: expected \(endStream), got \(actualFrameBody.endStream)", file: (file), line: line)
         XCTAssertEqual(self.streamID, streamID,
-                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: file, line: line)
+                       "Unexpected streamID: expected \(streamID), got \(self.streamID)", file: (file), line: line)
         XCTAssertEqual(actualPayload, payload,
-                       "Unexpected body: expected \(payload), got \(actualPayload)", file: file, line: line)
+                       "Unexpected body: expected \(payload), got \(actualPayload)", file: (file), line: line)
 
     }
 
-    func assertGoAwayFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertGoAwayFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .goAway(let lastStreamID, let errorCode, let opaqueData) = frame.payload else {
             preconditionFailure("Goaway frames can never match non-Goaway frames.")
         }
         self.assertGoAwayFrame(lastStreamID: lastStreamID,
                                errorCode: UInt32(http2ErrorCode: errorCode),
                                opaqueData: opaqueData.flatMap { $0.getBytes(at: $0.readerIndex, length: $0.readableBytes) },
-                               file: file,
+                               file: (file),
                                line: line)
     }
 
-    func assertGoAwayFrame(lastStreamID: HTTP2StreamID, errorCode: UInt32, opaqueData: [UInt8]?, file: StaticString = (#file), line: UInt = #line) {
+    func assertGoAwayFrame(lastStreamID: HTTP2StreamID, errorCode: UInt32, opaqueData: [UInt8]?, file: StaticString = #file, line: UInt = #line) {
         guard case .goAway(let actualLastStreamID, let actualErrorCode, let actualOpaqueData) = self.payload else {
-            XCTFail("Expected GOAWAY frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected GOAWAY frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
         let integerErrorCode = UInt32(http2ErrorCode: actualErrorCode)
         let byteArrayOpaqueData = actualOpaqueData.flatMap { $0.getBytes(at: $0.readerIndex, length: $0.readableBytes) }
 
-        XCTAssertEqual(self.streamID, .rootStream, "Goaway frame must be on the root stream!", file: file, line: line)
+        XCTAssertEqual(self.streamID, .rootStream, "Goaway frame must be on the root stream!", file: (file), line: line)
         XCTAssertEqual(lastStreamID, actualLastStreamID,
-                       "Unexpected last stream ID: expected \(lastStreamID), got \(actualLastStreamID)", file: file, line: line)
+                       "Unexpected last stream ID: expected \(lastStreamID), got \(actualLastStreamID)", file: (file), line: line)
         XCTAssertEqual(integerErrorCode, errorCode,
-                       "Unexpected error code: expected \(errorCode), got \(integerErrorCode)", file: file, line: line)
+                       "Unexpected error code: expected \(errorCode), got \(integerErrorCode)", file: (file), line: line)
         XCTAssertEqual(byteArrayOpaqueData, opaqueData,
-                       "Unexpected opaque data: expected \(String(describing: opaqueData)), got \(String(describing: byteArrayOpaqueData))", file: file, line: line)
+                       "Unexpected opaque data: expected \(String(describing: opaqueData)), got \(String(describing: byteArrayOpaqueData))", file: (file), line: line)
     }
 
-    func assertPingFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertPingFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .ping(let opaqueData, let ack) = frame.payload else {
             preconditionFailure("Ping frames can never match non-Ping frames.")
         }
-        self.assertPingFrame(ack: ack, opaqueData: opaqueData, file: file, line: line)
+        self.assertPingFrame(ack: ack, opaqueData: opaqueData, file: (file), line: line)
     }
 
-    func assertPingFrame(ack: Bool, opaqueData: HTTP2PingData, file: StaticString = (#file), line: UInt = #line) {
+    func assertPingFrame(ack: Bool, opaqueData: HTTP2PingData, file: StaticString = #file, line: UInt = #line) {
         guard case .ping(let actualPingData, let actualAck) = self.payload else {
-            XCTFail("Expected PING frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected PING frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(self.streamID, .rootStream, "Ping frame must be on the root stream!", file: file, line: line)
-        XCTAssertEqual(actualAck, ack, "Non-matching ACK: expected \(ack), got \(actualAck)", file: file, line: line)
+        XCTAssertEqual(self.streamID, .rootStream, "Ping frame must be on the root stream!", file: (file), line: line)
+        XCTAssertEqual(actualAck, ack, "Non-matching ACK: expected \(ack), got \(actualAck)", file: (file), line: line)
         XCTAssertEqual(actualPingData, opaqueData, "Non-matching ping data: expected \(opaqueData), got \(actualPingData)",
-                       file: file, line: line)
+                       file: (file), line: line)
     }
 
-    func assertWindowUpdateFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertWindowUpdateFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .windowUpdate(let increment) = frame.payload else {
-            XCTFail("WINDOW_UPDATE frames can never match non-WINDOW_UPDATE frames", file: file, line: line)
+            XCTFail("WINDOW_UPDATE frames can never match non-WINDOW_UPDATE frames", file: (file), line: line)
             return
         }
         self.assertWindowUpdateFrame(streamID: frame.streamID, windowIncrement: increment)
     }
 
-    func assertWindowUpdateFrame(streamID: HTTP2StreamID, windowIncrement: Int, file: StaticString = (#file), line: UInt = #line) {
+    func assertWindowUpdateFrame(streamID: HTTP2StreamID, windowIncrement: Int, file: StaticString = #file, line: UInt = #line) {
         guard case .windowUpdate(let actualWindowIncrement) = self.payload else {
-            XCTFail("Expected WINDOW_UPDATE frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected WINDOW_UPDATE frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(self.streamID, streamID, "Unexpected stream ID!", file: file, line: line)
-        XCTAssertEqual(windowIncrement, actualWindowIncrement, "Unexpected window increment!", file: file, line: line)
+        XCTAssertEqual(self.streamID, streamID, "Unexpected stream ID!", file: (file), line: line)
+        XCTAssertEqual(windowIncrement, actualWindowIncrement, "Unexpected window increment!", file: (file), line: line)
     }
 
-    func assertRstStreamFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertRstStreamFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .rstStream(let errorCode) = frame.payload else {
             preconditionFailure("RstStream frames can never match non-RstStream frames.")
         }
-        self.assertRstStreamFrame(streamID: frame.streamID, errorCode: errorCode, file: file, line: line)
+        self.assertRstStreamFrame(streamID: frame.streamID, errorCode: errorCode, file: (file), line: line)
     }
 
-    func assertRstStreamFrame(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: StaticString = (#file), line: UInt = #line) {
+    func assertRstStreamFrame(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: StaticString = #file, line: UInt = #line) {
         guard case .rstStream(let actualErrorCode) = self.payload else {
-            XCTFail("Expected RST_STREAM frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected RST_STREAM frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(self.streamID, streamID, "Non matching stream IDs: expected \(streamID), got \(self.streamID)!", file: file, line: line)
-        XCTAssertEqual(actualErrorCode, errorCode, "Non-matching error-code: expected \(errorCode), got \(actualErrorCode)", file: file, line: line)
+        XCTAssertEqual(self.streamID, streamID, "Non matching stream IDs: expected \(streamID), got \(self.streamID)!", file: (file), line: line)
+        XCTAssertEqual(actualErrorCode, errorCode, "Non-matching error-code: expected \(errorCode), got \(actualErrorCode)", file: (file), line: line)
     }
 
-    func assertPriorityFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertPriorityFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .priority(let expectedPriorityData) = frame.payload else {
             preconditionFailure("Priority frames can never match non-Priority frames.")
         }
-        self.assertPriorityFrame(streamPriorityData: expectedPriorityData, file: file, line: line)
+        self.assertPriorityFrame(streamPriorityData: expectedPriorityData, file: (file), line: line)
     }
 
-    func assertPriorityFrame(streamPriorityData: HTTP2Frame.StreamPriorityData, file: StaticString = (#file), line: UInt = #line) {
+    func assertPriorityFrame(streamPriorityData: HTTP2Frame.StreamPriorityData, file: StaticString = #file, line: UInt = #line) {
         guard case .priority(let actualPriorityData) = self.payload else {
-            XCTFail("Expected PRIORITY frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected PRIORITY frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(streamPriorityData, actualPriorityData, file: file, line: line)
+        XCTAssertEqual(streamPriorityData, actualPriorityData, file: (file), line: line)
     }
 
-    func assertPushPromiseFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertPushPromiseFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .pushPromise(let payload) = frame.payload else {
             preconditionFailure("PushPromise frames can never match non-PushPromise frames.")
         }
-        self.assertPushPromiseFrame(streamID: frame.streamID, pushedStreamID: payload.pushedStreamID, headers: payload.headers, file: file, line: line)
+        self.assertPushPromiseFrame(streamID: frame.streamID, pushedStreamID: payload.pushedStreamID, headers: payload.headers, file: (file), line: line)
     }
 
-    func assertPushPromiseFrame(streamID: HTTP2StreamID, pushedStreamID: HTTP2StreamID, headers: HPACKHeaders, file: StaticString = (#file), line: UInt = #line) {
+    func assertPushPromiseFrame(streamID: HTTP2StreamID, pushedStreamID: HTTP2StreamID, headers: HPACKHeaders, file: StaticString = #file, line: UInt = #line) {
         guard case .pushPromise(let actualPayload) = self.payload else {
-            XCTFail("Expected PUSH_PROMISE frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected PUSH_PROMISE frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(streamID, self.streamID, "Non matching stream IDs: expected \(streamID), got \(self.streamID)!", file: file, line: line)
-        XCTAssertEqual(pushedStreamID, actualPayload.pushedStreamID, "Non matching pushed stream IDs: expected \(pushedStreamID), got \(actualPayload.pushedStreamID)", file: file, line: line)
-        XCTAssertEqual(headers, actualPayload.headers, "Non matching pushed headers: expected \(headers), got \(actualPayload.headers)", file: file, line: line)
+        XCTAssertEqual(streamID, self.streamID, "Non matching stream IDs: expected \(streamID), got \(self.streamID)!", file: (file), line: line)
+        XCTAssertEqual(pushedStreamID, actualPayload.pushedStreamID, "Non matching pushed stream IDs: expected \(pushedStreamID), got \(actualPayload.pushedStreamID)", file: (file), line: line)
+        XCTAssertEqual(headers, actualPayload.headers, "Non matching pushed headers: expected \(headers), got \(actualPayload.headers)", file: (file), line: line)
     }
 
-    func assertAlternativeServiceFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertAlternativeServiceFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .alternativeService(let origin, let field) = frame.payload else {
             preconditionFailure("AltSvc frames can never match non-AltSvc frames.")
         }
-        self.assertAlternativeServiceFrame(origin: origin, field: field, file: file, line: line)
+        self.assertAlternativeServiceFrame(origin: origin, field: field, file: (file), line: line)
     }
 
-    func assertAlternativeServiceFrame(origin: String?, field: ByteBuffer?, file: StaticString = (#file), line: UInt = #line) {
+    func assertAlternativeServiceFrame(origin: String?, field: ByteBuffer?, file: StaticString = #file, line: UInt = #line) {
         guard case .alternativeService(let actualOrigin, let actualField) = self.payload else {
-            XCTFail("Expected ALTSVC frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected ALTSVC frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(.rootStream, self.streamID, "ALTSVC frame must be on the root stream!, got \(self.streamID)!", file: file, line: line)
+        XCTAssertEqual(.rootStream, self.streamID, "ALTSVC frame must be on the root stream!, got \(self.streamID)!", file: (file), line: line)
         XCTAssertEqual(origin,
                        actualOrigin,
                        "Non matching origins: expected \(String(describing: origin)), got \(String(describing: actualOrigin))",
-                       file: file, line: line)
+                       file: (file), line: line)
         XCTAssertEqual(field,
                        actualField,
                        "Non matching field: expected \(String(describing: field)), got \(String(describing: actualField))",
-                       file: file, line: line)
+                       file: (file), line: line)
     }
 
-    func assertOriginFrameMatches(this frame: HTTP2Frame, file: StaticString = (#file), line: UInt = #line) {
+    func assertOriginFrameMatches(this frame: HTTP2Frame, file: StaticString = #file, line: UInt = #line) {
         guard case .origin(let payload) = frame.payload else {
             preconditionFailure("ORIGIN frames can never match non-ORIGIN frames.")
         }
-        self.assertOriginFrame(streamID: frame.streamID, origins: payload, file: file, line: line)
+        self.assertOriginFrame(streamID: frame.streamID, origins: payload, file: (file), line: line)
     }
 
-    func assertOriginFrame(streamID: HTTP2StreamID, origins: [String], file: StaticString = (#file), line: UInt = #line) {
+    func assertOriginFrame(streamID: HTTP2StreamID, origins: [String], file: StaticString = #file, line: UInt = #line) {
         guard case .origin(let actualPayload) = self.payload else {
-            XCTFail("Expected ORIGIN frame, got \(self.payload) instead", file: file, line: line)
+            XCTFail("Expected ORIGIN frame, got \(self.payload) instead", file: (file), line: line)
             return
         }
 
-        XCTAssertEqual(.rootStream, self.streamID, "ORIGIN frame must be on the root stream!, got \(self.streamID)!", file: file, line: line)
-        XCTAssertEqual(origins, actualPayload, "Non matching origins: expected \(origins), got \(actualPayload)", file: file, line: line)
+        XCTAssertEqual(.rootStream, self.streamID, "ORIGIN frame must be on the root stream!, got \(self.streamID)!", file: (file), line: line)
+        XCTAssertEqual(origins, actualPayload, "Non matching origins: expected \(origins), got \(actualPayload)", file: (file), line: line)
     }
 }
 
 extension Array where Element == HTTP2Frame {
-    func assertFramesMatch<Candidate: Collection>(_ target: Candidate, dataFileRegionToByteBuffer: Bool = true, file: StaticString = (#file), line: UInt = #line) where Candidate.Element == HTTP2Frame {
+    func assertFramesMatch<Candidate: Collection>(_ target: Candidate, dataFileRegionToByteBuffer: Bool = true, file: StaticString = #file, line: UInt = #line) where Candidate.Element == HTTP2Frame {
         guard self.count == target.count else {
-            XCTFail("Different numbers of frames: expected \(target.count), got \(self.count)", file: file, line: line)
+            XCTFail("Different numbers of frames: expected \(target.count), got \(self.count)", file: (file), line: line)
             return
         }
 
         for (expected, actual) in zip(target, self) {
-            expected.assertFrameMatches(this: actual, dataFileRegionToByteBuffer: dataFileRegionToByteBuffer, file: file, line: line)
+            expected.assertFrameMatches(this: actual, dataFileRegionToByteBuffer: dataFileRegionToByteBuffer, file: (file), line: line)
         }
     }
 }
@@ -618,11 +618,11 @@ extension NIO.NIOFileHandle {
     }
 }
 
-func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = (#file), line: UInt = #line) throws -> T {
+func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {
-        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: file, line: line)
+        XCTFail("\(message.map { $0 + ": " } ?? "")unexpected error \(error) thrown", file: (file), line: line)
         if let defaultValue = defaultValue {
             return defaultValue
         } else {


### PR DESCRIPTION
Motivation:

only works if done when _calling_ a function, not when defining one :|.

- https://github.com/apple/swift/pull/32445
- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

Modifications:

Silence #file to #filePath differently.

Result:

Hopefully at some point we get this working.