### PR TITLE
Update HTTP2StreamChannel to tolerate nil stream ID.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -301,6 +301,11 @@ public enum NIOHTTP2Errors {
     public struct ExcessivelyLargeHeaderBlock: NIOHTTP2Error {
         public init() { }
     }
+
+    /// The channel does not yet have a stream ID, as it has not reached the network yet.
+    public struct NoStreamIDAvailable: NIOHTTP2Error {
+        public init() { }
+    }
 }
 
 

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -41,6 +41,10 @@ struct MultiplexerAbstractChannel {
                                              outboundBytesHighWatermark: outboundBytesHighWatermark,
                                              outboundBytesLowWatermark: outboundBytesLowWatermark))
     }
+
+    init(_ channel: HTTP2StreamChannel) {
+        self.baseChannel = .frameBased(channel)
+    }
 }
 
 extension MultiplexerAbstractChannel {
@@ -51,6 +55,13 @@ extension MultiplexerAbstractChannel {
 
 // MARK: API for HTTP2StreamMultiplexer
 extension MultiplexerAbstractChannel {
+    var streamID: HTTP2StreamID? {
+        switch self.baseChannel {
+        case .frameBased(let base):
+            return base.streamID
+        }
+    }
+
     var inList: Bool {
         switch self.baseChannel {
         case .frameBased(let base):


### PR DESCRIPTION
Motivation:

As part of the work in #214, HTTP2StreamID will need to be able to
tolerate not knowing its stream ID. For now this is not a problem, but
we should think about everywhere we use the stream ID and make sure we
have a solid principle in mind. This lays the groundwork for future
enhancements.

Modifications:

- Update HTTP2StreamChannel to hold an optional stream ID.
- Update interface to HTTP2StreamMultiplexer to tolerate closing
  channels without stream IDs (we'll need it later).
- Move the "get a new stream ID" functionality to a method on
  HTTP2StreamMultiplexer.
- Validate we behave correctly with optional stream IDs in the channel.

Result:

We can tolerate stream IDs being not present.