### PR TITLE
Make HTTP2StreamChannel generic over a message type

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Frame.swift
+++ b/Sources/NIOHTTP2/HTTP2Frame.swift
@@ -253,6 +253,10 @@ public struct HTTP2Frame {
 }
 
 extension HTTP2Frame: HTTP2FrameConvertible, HTTP2FramePayloadConvertible {
+    init(http2Frame: HTTP2Frame) {
+        self = http2Frame
+    }
+
     func makeHTTP2Frame(streamID: HTTP2StreamID) -> HTTP2Frame {
         assert(self.streamID == streamID, "streamID does not match")
         return self
@@ -262,6 +266,10 @@ extension HTTP2Frame: HTTP2FrameConvertible, HTTP2FramePayloadConvertible {
 extension HTTP2Frame.FramePayload: HTTP2FrameConvertible, HTTP2FramePayloadConvertible {
     var payload: HTTP2Frame.FramePayload {
         return self
+    }
+
+    init(http2Frame: HTTP2Frame) {
+        self = http2Frame.payload
     }
 
     func makeHTTP2Frame(streamID: HTTP2StreamID) -> HTTP2Frame {

--- a/Sources/NIOHTTP2/HTTP2FrameConvertible.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameConvertible.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 protocol HTTP2FrameConvertible {
+    /// Initialize `Self` from an `HTTP2Frame`.
+    init(http2Frame: HTTP2Frame)
+
     /// Makes an `HTTPFrame` with the given `streamID`.
     ///
     /// - Parameter streamID: The `streamID` to use when constructing the frame.
@@ -22,4 +25,40 @@ protocol HTTP2FrameConvertible {
 protocol HTTP2FramePayloadConvertible {
     /// Makes a `HTTP2Frame.FramePayload`.
     var payload: HTTP2Frame.FramePayload { get }
+}
+
+extension HTTP2FrameConvertible where Self: HTTP2FramePayloadConvertible {
+    /// A shorthand heuristic for how many bytes we assume a frame consumes on the wire.
+    ///
+    /// Here we concern ourselves only with per-stream frames: that is, `HEADERS`, `DATA`,
+    /// `WINDOW_UDPATE`, `RST_STREAM`, and I guess `PRIORITY`. As a simple heuristic we
+    /// hard code fixed lengths for fixed length frames, use a calculated length for
+    /// variable length frames, and just ignore encoded headers because it's not worth doing a better
+    /// job.
+    var estimatedFrameSize: Int {
+        let frameHeaderSize = 9
+
+        switch self.payload {
+        case .data(let d):
+            let paddingBytes = d.paddingBytes.map { $0 + 1 } ?? 0
+            return d.data.readableBytes + paddingBytes + frameHeaderSize
+        case .headers(let h):
+            let paddingBytes = h.paddingBytes.map { $0 + 1 } ?? 0
+            return paddingBytes + frameHeaderSize
+        case .priority:
+            return frameHeaderSize + 5
+        case .pushPromise(let p):
+            // Like headers, this is variably size, and we just ignore the encoded headers because
+            // it's not worth having a heuristic.
+            let paddingBytes = p.paddingBytes.map { $0 + 1 } ?? 0
+            return paddingBytes + frameHeaderSize
+        case .rstStream:
+            return frameHeaderSize + 4
+        case .windowUpdate:
+            return frameHeaderSize + 4
+        default:
+            // Unknown or unexpected control frame: say 9 bytes.
+            return frameHeaderSize
+        }
+    }
 }

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -318,12 +318,12 @@ extension HTTP2StreamMultiplexer {
 
 // MARK:- Child to parent calls
 extension HTTP2StreamMultiplexer {
-    internal func childChannelClosed(_ channel: MultiplexerAbstractChannel) {
-        if let streamID = channel.streamID {
-            self.streams.removeValue(forKey: streamID)
-        } else {
-            preconditionFailure("Child channels always have stream IDs right now.")
-        }
+    internal func childChannelClosed(streamID: HTTP2StreamID) {
+        self.streams.removeValue(forKey: streamID)
+    }
+
+    internal func childChannelClosed(channelID: ObjectIdentifier) {
+        preconditionFailure("We don't currently support closing channels by 'channelID'")
     }
 
     internal func childChannelWrite(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {


### PR DESCRIPTION
Motivation:

As part of #214 we need to make `HTTP2StreamChannel` generic over the type
of message it expects to read and write. This allows us to define an
`HTTP2StreamChannel` which uses `HTTP2Frame.FramePayload` as its
currency type, rather than `HTTP2Frame`.

Modifications:

- Make `HTTP2StreamChannel` generic over `Message` which is constrained
  by conformance to `HTTP2FrameConvertible` and
  `HTTP2FramePayloadConvertible`
- `HTTP2StreamChannel` now expects to read in `Message`s (as opposed to
  `HTTP2Frame`s) and have `Message`s written in to it.
- Added typealiases for frame and payload based stream channels.
- Added support for the payload based channel in
  `MultiplexerAbstractChannel` (although one can't be created yet).

Result:

We can create payload based stream channels.