### PR TITLE
Update the test generation script to allow for deprecated tests

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -26,27 +26,38 @@ import XCTest
    @testable import NIOHPACKTests
    @testable import NIOHTTP2Tests
 
-   XCTMain([
-         testCase(CompoundOutboundBufferTest.allTests),
-         testCase(ConcurrentStreamBufferTests.allTests),
-         testCase(ConfiguringPipelineTests.allTests),
-         testCase(ConnectionStateMachineTests.allTests),
-         testCase(ControlFrameBufferTests.allTests),
-         testCase(HPACKCodingTests.allTests),
-         testCase(HPACKIntegrationTests.allTests),
-         testCase(HPACKRegressionTests.allTests),
-         testCase(HTTP2FrameConvertibleTests.allTests),
-         testCase(HTTP2FrameParserTests.allTests),
-         testCase(HTTP2StreamMultiplexerTests.allTests),
-         testCase(HTTP2ToHTTP1CodecTests.allTests),
-         testCase(HeaderTableTests.allTests),
-         testCase(HuffmanCodingTests.allTests),
-         testCase(InboundWindowManagerTests.allTests),
-         testCase(IntegerCodingTests.allTests),
-         testCase(OutboundFlowControlBufferTests.allTests),
-         testCase(ReentrancyTests.allTests),
-         testCase(SimpleClientServerTests.allTests),
-         testCase(StreamChannelFlowControllerTests.allTests),
-         testCase(StreamIDTests.allTests),
-    ])
+// This protocol is necessary to we can call the 'run' method (on an existential of this protocol)
+// without the compiler noticing that we're calling a deprecated function.
+// This hack exists so we can deprecate individual tests which test deprecated functionality without
+// getting a compiler warning...
+protocol LinuxMainRunner { func run() }
+class LinuxMainRunnerImpl: LinuxMainRunner {
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
+   func run() {
+       XCTMain([
+             testCase(CompoundOutboundBufferTest.allTests),
+             testCase(ConcurrentStreamBufferTests.allTests),
+             testCase(ConfiguringPipelineTests.allTests),
+             testCase(ConnectionStateMachineTests.allTests),
+             testCase(ControlFrameBufferTests.allTests),
+             testCase(HPACKCodingTests.allTests),
+             testCase(HPACKIntegrationTests.allTests),
+             testCase(HPACKRegressionTests.allTests),
+             testCase(HTTP2FrameConvertibleTests.allTests),
+             testCase(HTTP2FrameParserTests.allTests),
+             testCase(HTTP2StreamMultiplexerTests.allTests),
+             testCase(HTTP2ToHTTP1CodecTests.allTests),
+             testCase(HeaderTableTests.allTests),
+             testCase(HuffmanCodingTests.allTests),
+             testCase(InboundWindowManagerTests.allTests),
+             testCase(IntegerCodingTests.allTests),
+             testCase(OutboundFlowControlBufferTests.allTests),
+             testCase(ReentrancyTests.allTests),
+             testCase(SimpleClientServerTests.allTests),
+             testCase(StreamChannelFlowControllerTests.allTests),
+             testCase(StreamIDTests.allTests),
+        ])
+    }
+}
+(LinuxMainRunnerImpl() as LinuxMainRunner).run()
 #endif

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HPACKCodingTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HPACKCodingTests) -> () throws -> Void)] {
       return [
                 ("testRequestHeadersWithoutHuffmanCoding", testRequestHeadersWithoutHuffmanCoding),

--- a/Tests/NIOHPACKTests/HPACKIntegrationTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKIntegrationTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HPACKIntegrationTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HPACKIntegrationTests) -> () throws -> Void)] {
       return [
                 ("testAAEncoderWithoutHuffmanCoding", testAAEncoderWithoutHuffmanCoding),

--- a/Tests/NIOHPACKTests/HPACKRegressionTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKRegressionTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HPACKRegressionTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HPACKRegressionTests) -> () throws -> Void)] {
       return [
                 ("testWikipediaHeaders", testWikipediaHeaders),

--- a/Tests/NIOHPACKTests/HeaderTableTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HeaderTableTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HeaderTableTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HeaderTableTests) -> () throws -> Void)] {
       return [
                 ("testStaticHeaderTable", testStaticHeaderTable),

--- a/Tests/NIOHPACKTests/HuffmanCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HuffmanCodingTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HuffmanCodingTests) -> () throws -> Void)] {
       return [
                 ("testBasicCoding", testBasicCoding),

--- a/Tests/NIOHPACKTests/IntegerCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/IntegerCodingTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension IntegerCodingTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (IntegerCodingTests) -> () throws -> Void)] {
       return [
                 ("testIntegerEncoding", testIntegerEncoding),

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension CompoundOutboundBufferTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (CompoundOutboundBufferTest) -> () throws -> Void)] {
       return [
                 ("testSimpleControlFramePassthrough", testSimpleControlFramePassthrough),

--- a/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ConcurrentStreamBufferTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ConcurrentStreamBufferTests) -> () throws -> Void)] {
       return [
                 ("testBasicFunctionality", testBasicFunctionality),

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ConfiguringPipelineTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ConfiguringPipelineTests) -> () throws -> Void)] {
       return [
                 ("testBasicPipelineCommunicates", testBasicPipelineCommunicates),

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ConnectionStateMachineTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ConnectionStateMachineTests) -> () throws -> Void)] {
       return [
                 ("testSimpleRequestResponseFlow", testSimpleRequestResponseFlow),

--- a/Tests/NIOHTTP2Tests/ControlFrameBufferTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ControlFrameBufferTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ControlFrameBufferTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ControlFrameBufferTests) -> () throws -> Void)] {
       return [
                 ("testByDefaultAllFramesPassThroughWhenChannelIsWritable", testByDefaultAllFramesPassThroughWhenChannelIsWritable),

--- a/Tests/NIOHTTP2Tests/HTTP2FrameConvertibleTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameConvertibleTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HTTP2FrameConvertibleTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HTTP2FrameConvertibleTests) -> () throws -> Void)] {
       return [
                 ("testHTTP2FrameConvertible", testHTTP2FrameConvertible),

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HTTP2FrameParserTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HTTP2FrameParserTests) -> () throws -> Void)] {
       return [
                 ("testPaddingIsNotAllowedByEncoder", testPaddingIsNotAllowedByEncoder),

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HTTP2StreamMultiplexerTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HTTP2StreamMultiplexerTests) -> () throws -> Void)] {
       return [
                 ("testMultiplexerIgnoresFramesOnStream0", testMultiplexerIgnoresFramesOnStream0),

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension HTTP2ToHTTP1CodecTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (HTTP2ToHTTP1CodecTests) -> () throws -> Void)] {
       return [
                 ("testBasicRequestServerSide", testBasicRequestServerSide),

--- a/Tests/NIOHTTP2Tests/InboundWindowManagerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/InboundWindowManagerTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension InboundWindowManagerTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (InboundWindowManagerTests) -> () throws -> Void)] {
       return [
                 ("testNewWindowSizeWhenNewSizeIsAtOrAboveTarget", testNewWindowSizeWhenNewSizeIsAtOrAboveTarget),

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension OutboundFlowControlBufferTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (OutboundFlowControlBufferTests) -> () throws -> Void)] {
       return [
                 ("testJustLettingDataThrough", testJustLettingDataThrough),

--- a/Tests/NIOHTTP2Tests/ReentrancyTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ReentrancyTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ReentrancyTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ReentrancyTests) -> () throws -> Void)] {
       return [
                 ("testReEnterReadOnRead", testReEnterReadOnRead),

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension SimpleClientServerTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (SimpleClientServerTests) -> () throws -> Void)] {
       return [
                 ("testBasicRequestResponse", testBasicRequestResponse),

--- a/Tests/NIOHTTP2Tests/StreamChannelFlowControllerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/StreamChannelFlowControllerTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension StreamChannelFlowControllerTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (StreamChannelFlowControllerTests) -> () throws -> Void)] {
       return [
                 ("testChannelWritabilityChangesFromFlowControl", testChannelWritabilityChangesFromFlowControl),

--- a/Tests/NIOHTTP2Tests/StreamIDTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/StreamIDTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension StreamIDTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (StreamIDTests) -> () throws -> Void)] {
       return [
                 ("testStreamIDsAreStrideable", testStreamIDsAreStrideable),


### PR DESCRIPTION
Motivation:

To test deprecated functionality without a bunch of warnings, tests must
be marked as deprecated. This also needs to be bubbled up to anywhere
calling that test, such as in the generated linux test manifests.

Our script to generate the manifests currently doesn't support this and
as part of #214 we'll need to deprecate a few things while keeping their
tests.

Modifications:

- Pull in the latest version of the `generate_linux_tests.rb` script
  from SwiftNIO.
- Re-run the script, since it includes some formatting changes too.

Result:

- When we deprecate functionality, we can deprecate the tests without
  the generate manifests emitting warnings.