### PR TITLE
Verify payload-based stream channel fixes #214

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -433,7 +433,7 @@ extension HTTP2StreamMultiplexer {
     }
 
     internal func childChannelFlush() {
-        self.flush(context: context)
+        self.flush(context: self.context)
     }
 
     /// Requests a `HTTP2StreamID` for the given `Channel`.

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
@@ -73,6 +73,7 @@ extension HTTP2FramePayloadStreamMultiplexerTests {
                 ("testMultiplexerModifiesStreamChannelWritabilityBasedOnFixedSizeTokensAndChannelWritability", testMultiplexerModifiesStreamChannelWritabilityBasedOnFixedSizeTokensAndChannelWritability),
                 ("testStreamChannelToleratesFailingInitializer", testStreamChannelToleratesFailingInitializer),
                 ("testInboundChannelWindowSizeIsCustomisable", testInboundChannelWindowSizeIsCustomisable),
+                ("testWeCanCreateFrameAndPayloadBasedStreamsOnAMultiplexer", testWeCanCreateFrameAndPayloadBasedStreamsOnAMultiplexer),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
@@ -73,6 +73,7 @@ extension SimpleClientServerFramePayloadStreamTests {
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromServer", testNoStreamWindowUpdateOnEndStreamFrameFromServer),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
                 ("testGreasedSettingsAreTolerated", testGreasedSettingsAreTolerated),
+                ("testStreamCreationOrder", testStreamCreationOrder),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -32,6 +32,7 @@ extension SimpleClientServerTests {
                 ("testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges", testStreamMultiplexerAcknowledgesSettingsBasedFlowControlChanges),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromServer", testNoStreamWindowUpdateOnEndStreamFrameFromServer),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
+                ("testStreamCreationOrder", testStreamCreationOrder),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

We made a bunch of changes to resolve #214. We should add a test to
ensure we actually fixed the issue.

Modifications:

- Add a test verifying that we can write on streams in a different order
  to the order in which we create them
- Add a corresponding test for frame-based streams verifying that the
  first write on each stream must match the order in which the streams
  were created
- Remove an unnecessary `throws` in the base HTTP2 to HTTP1 server codec

Result:

- No functionality change, just more tests.