### PR TITLE
Avoid emitting WINDOW_UPDATE frames when receiving stream closed

### DIFF
--- a/Sources/NIOHTTP2/InboundWindowManager.swift
+++ b/Sources/NIOHTTP2/InboundWindowManager.swift
@@ -25,6 +25,9 @@ struct InboundWindowManager {
     /// The number of bytes of buffered frames.
     private var bufferedBytes: Int = 0
 
+    /// Whether the inbound window is closed. If this is true then no window size changes will be emitted.
+    var closed = false
+
     init(targetSize: Int32) {
         assert(targetSize <= HTTP2FlowControlWindow.maxSize)
         assert(targetSize >= 0)
@@ -68,6 +71,11 @@ struct InboundWindowManager {
     }
 
     private func calculateWindowIncrement(windowSize: Int) -> Int? {
+        // No point calculating an increment if we're closed.
+        if self.closed {
+            return nil
+        }
+
         // The simplest case is where newSize >= targetWindowSize. In that case, we do nothing.
         //
         // The next simplest case is where 0 <= newSize < targetWindowSize. In that case,

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
@@ -75,6 +75,7 @@ extension HTTP2FramePayloadStreamMultiplexerTests {
                 ("testInboundChannelWindowSizeIsCustomisable", testInboundChannelWindowSizeIsCustomisable),
                 ("testWeCanCreateFrameAndPayloadBasedStreamsOnAMultiplexer", testWeCanCreateFrameAndPayloadBasedStreamsOnAMultiplexer),
                 ("testReadWhenUsingAutoreadOnChildChannel", testReadWhenUsingAutoreadOnChildChannel),
+                ("testWindowUpdateIsNotEmittedAfterStreamIsClosed", testWindowUpdateIsNotEmittedAfterStreamIsClosed),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/InboundWindowManagerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/InboundWindowManagerTests+XCTest.swift
@@ -32,6 +32,7 @@ extension InboundWindowManagerTests {
                 ("testNewWindowSizeWhenNewSizeIsLessThanOrEqualHalfTarget", testNewWindowSizeWhenNewSizeIsLessThanOrEqualHalfTarget),
                 ("testNewWindowSizeWithBufferedBytes", testNewWindowSizeWithBufferedBytes),
                 ("testInitialWindowSizeChanged", testInitialWindowSizeChanged),
+                ("testWindowSizeWhenClosed", testWindowSizeWhenClosed),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/InboundWindowManagerTests.swift
+++ b/Tests/NIOHTTP2Tests/InboundWindowManagerTests.swift
@@ -71,4 +71,15 @@ class InboundWindowManagerTests: XCTestCase {
         // adjusted size is 8 (new size 5, buffered 3) which is less than half the target (now 20).
         XCTAssertEqual(windowManager.newWindowSize(5), 12)
     }
+
+    func testWindowSizeWhenClosed() {
+        var windowManager = InboundWindowManager(targetSize: 10)
+        XCTAssertEqual(windowManager.newWindowSize(5), 5)
+
+        windowManager.closed = true
+        XCTAssertNil(windowManager.newWindowSize(5))
+
+        windowManager.bufferedFrameReceived(size: 5)
+        XCTAssertNil(windowManager.bufferedFrameEmitted(size: 5))
+    }
 }


### PR DESCRIPTION
Motivation:

In some cases it's possible for a stream to emit a WINDOW_UPDATE frame
after receiving close from the network. This is unfortunate because in
the eyes of the `NIOHTTP2Handler` the stream no longer exists which
results in a connection-level error.

Modifications:

- Add a flag to `deliverPendingReads` telling it whether it is allowed
  to emit a WINDOW_UPDATE frame
- Use the above functionality when the stream is closing

Result:

WINDOW_UPDATE frames are no longer emitted from the stream as a result
of delivering pending reads while closing.