### PR TITLE
Shrink NIOHTTP2WindowUpdatedEvent.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2UserEvents.swift
+++ b/Sources/NIOHTTP2/HTTP2UserEvents.swift
@@ -45,10 +45,28 @@ public struct NIOHTTP2WindowUpdatedEvent {
     public let streamID: HTTP2StreamID
 
     /// The new inbound window size for this stream, if any. May be nil if this stream is half-closed.
-    public let inboundWindowSize: Int?
+    public var inboundWindowSize: Int? {
+        get {
+            return self._inboundWindowSize.map { Int($0) }
+        }
+        set {
+            self._inboundWindowSize = newValue.map { Int32($0) }
+        }
+    }
 
     /// The new outbound window size for this stream, if any. May be nil if this stream is half-closed.
-    public let outboundWindowSize: Int?
+    public var outboundWindowSize: Int? {
+        get {
+            return self._outboundWindowSize.map { Int($0) }
+        }
+        set {
+            self._outboundWindowSize = newValue.map { Int32($0) }
+        }
+    }
+
+    private var _inboundWindowSize: Int32?
+
+    private var _outboundWindowSize: Int32?
 
     public init(streamID: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?) {
         // We use Int here instead of Int32. Nonetheless, the value must fit in the Int32 range.
@@ -58,8 +76,8 @@ public struct NIOHTTP2WindowUpdatedEvent {
         precondition(outboundWindowSize == nil || outboundWindowSize! >= Int(Int32.min))
 
         self.streamID = streamID
-        self.inboundWindowSize = inboundWindowSize
-        self.outboundWindowSize = outboundWindowSize
+        self._inboundWindowSize = inboundWindowSize.map { Int32($0) }
+        self._outboundWindowSize = outboundWindowSize.map { Int32($0) }
     }
 }
 


### PR DESCRIPTION
Motivation:

NIOHTTP2WindowUpdatedEvent was larger than 24 bytes, forcing heap
allocations whenever we wanted to put it into an existential. Given that
the range of the two optional integers stored on the type are both
explicitly documented to be the Int32 range, this type can happily just
contain Int32s.

Modifications:

- Changed the backing storage from Int? to Int32?.

Result:

NIOHTTP2WindowUpdatedEvent will be smaller.
Resolves #235.