### PR TITLE
Use the non-deprecated 'configureHTTP2Pipeline' in benchmarks

### DIFF
--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
@@ -85,7 +85,7 @@ func run(identifier: String) {
             let clientChannel = EmbeddedChannel(loop: loop)
             let serverChannel = EmbeddedChannel(loop: loop)
 
-            let clientMultiplexer = try! clientChannel.configureHTTP2Pipeline(mode: .client).wait()
+            let clientMultiplexer = try! clientChannel.configureHTTP2Pipeline(mode: .client, inboundStreamInitializer: nil).wait()
             _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
                 return channel.pipeline.addHandlers([HTTP2FramePayloadToHTTP1ServerCodec(), ServerHandler()])
             }.wait()


### PR DESCRIPTION
Motivation:

CI is spitting out a bunch of warnings about 'configureHTTP2Pipeline'
being deprecated; it is called without providing the inbound stream state
initializer. The non-deprecated version requires that this is
explicitly passed as `nil`.

Modifications:

- Explicitly set the 'inboundStreamInitializer' to `nil`

Result:

Fewer warnings.