### PR TITLE
Add benchmarks and improve benchmarking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ Package.resolved
 DerivedData
 .swiftpm
 Tests/hpack-test-case
-
+cachegrind.out.*

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
@@ -1,0 +1,215 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHPACK
+import NIOHTTP2
+
+struct ServerOnly1KRequestsBenchmark {
+    private let concurrentStreams: Int
+
+    private let channel: EmbeddedChannel
+
+    // This offset is preserved across runs.
+    var streamID = HTTP2StreamID(1)
+
+    // A manually constructed data frame.
+    private var dataFrame: ByteBuffer = {
+        var buffer = ByteBuffer(repeating: 0xff, count: 1024 + 9)
+
+        // UInt24 length, is 1024 bytes.
+        buffer.setInteger(UInt8(0), at: buffer.readerIndex)
+        buffer.setInteger(UInt16(1024), at: buffer.readerIndex + 1)
+
+        // Type
+        buffer.setInteger(UInt8(0x00), at: buffer.readerIndex + 3)
+
+        // Flags, turn on end-stream.
+        buffer.setInteger(UInt8(0x01), at: buffer.readerIndex + 4)
+
+        // 4 byte stream identifier, set to zero for now as we update it later.
+        buffer.setInteger(UInt32(0), at: buffer.readerIndex + 5)
+
+        return buffer
+    }()
+
+    // A manually constructed headers frame.
+    private var headersFrame: ByteBuffer = {
+        var headers = HPACKHeaders()
+        headers.add(name: ":method", value: "GET", indexing: .indexable)
+        headers.add(name: ":authority", value: "localhost", indexing: .nonIndexable)
+        headers.add(name: ":path", value: "/", indexing: .indexable)
+        headers.add(name: ":scheme", value: "https", indexing: .indexable)
+        headers.add(name: "user-agent",
+                    value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                    indexing: .nonIndexable)
+        headers.add(name: "accept-encoding", value: "gzip, deflate", indexing: .indexable)
+
+        var hpackEncoder = HPACKEncoder(allocator: .init())
+        var buffer = ByteBuffer()
+        buffer.writeRepeatingByte(0, count: 9)
+        buffer.moveReaderIndex(forwardBy: 9)
+        try! hpackEncoder.encode(headers: headers, to: &buffer)
+        let encodedLength = buffer.readableBytes
+        buffer.moveReaderIndex(to: buffer.readerIndex - 9)
+
+        // UInt24 length
+        buffer.setInteger(UInt8(0), at: buffer.readerIndex)
+        buffer.setInteger(UInt16(encodedLength), at: buffer.readerIndex + 1)
+
+        // Type
+        buffer.setInteger(UInt8(0x01), at: buffer.readerIndex + 3)
+
+        // Flags, turn on END_HEADERs.
+        buffer.setInteger(UInt8(0x04), at: buffer.readerIndex + 4)
+
+        // 4 byte stream identifier, set to zero for now as we update it later.
+        buffer.setInteger(UInt32(0), at: buffer.readerIndex + 5)
+
+        return buffer
+    }()
+
+    private let emptySettings: ByteBuffer = {
+        var buffer = ByteBuffer()
+        buffer.reserveCapacity(9)
+
+        // UInt24 length, is 0 bytes.
+        buffer.writeInteger(UInt8(0))
+        buffer.writeInteger(UInt16(0))
+
+        // Type
+        buffer.writeInteger(UInt8(0x04))
+
+        // Flags, none.
+        buffer.writeInteger(UInt8(0x00))
+
+        // 4 byte stream identifier, set to zero.
+        buffer.writeInteger(UInt32(0))
+
+        return buffer
+    }()
+
+    private var settingsACK: ByteBuffer {
+        // Copy the empty SETTINGS and add the ACK flag
+        var settingsCopy = self.emptySettings
+        settingsCopy.setInteger(UInt8(0x01), at: settingsCopy.readerIndex + 4)
+        return settingsCopy
+    }
+
+    init(concurrentStreams: Int) throws {
+        self.concurrentStreams = concurrentStreams
+
+        self.channel = EmbeddedChannel()
+        _ = try self.channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+
+        try self.channel.connect(to: .init(unixDomainSocketPath: "/fake"), promise: nil)
+
+        // Gotta do the handshake here.
+        var initialBytes = ByteBuffer(string: "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+        initialBytes.writeImmutableBuffer(self.emptySettings)
+        initialBytes.writeImmutableBuffer(self.settingsACK)
+
+        try self.channel.writeInbound(initialBytes)
+        while try self.channel.readOutbound(as: ByteBuffer.self) != nil { }
+    }
+
+    func tearDown() {
+        _ = try! self.channel.finish()
+    }
+
+    mutating func run() throws -> Int {
+        var bodyByteCount = 0
+        var completedIterations = 0
+        while completedIterations < 1_000 {
+            bodyByteCount &+= try self.sendInterleavedRequests(self.concurrentStreams)
+            completedIterations += self.concurrentStreams
+        }
+        return bodyByteCount
+    }
+
+    private mutating func sendInterleavedRequests(_ interleavedRequests: Int) throws -> Int {
+        var streamID = self.streamID
+
+        for _ in 0 ..< interleavedRequests {
+            self.headersFrame.setInteger(UInt32(Int32(streamID)), at: self.headersFrame.readerIndex + 5)
+            try self.channel.writeInbound(self.headersFrame)
+            streamID = streamID.advanced(by: 2)
+        }
+
+        streamID = self.streamID
+
+        for _ in 0 ..< interleavedRequests {
+            self.dataFrame.setInteger(UInt32(Int32(streamID)), at: self.dataFrame.readerIndex + 5)
+            try self.channel.writeInbound(self.dataFrame)
+            streamID = streamID.advanced(by: 2)
+        }
+
+        self.channel.embeddedEventLoop.run()
+
+        self.streamID = streamID
+
+        var count = 0
+        while let data = try self.channel.readOutbound(as: ByteBuffer.self) {
+            count &+= data.readableBytes
+            self.channel.embeddedEventLoop.run()
+        }
+        return count
+    }
+}
+
+fileprivate class TestServer: ChannelInboundHandler {
+    public typealias InboundIn = HTTP2Frame.FramePayload
+    public typealias OutboundOut = HTTP2Frame.FramePayload
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let payload = self.unwrapInboundIn(data)
+
+        switch payload {
+        case .headers(let headers) where headers.endStream:
+            self.sendResponse(context: context)
+        case .data(let data) where data.endStream:
+            self.sendResponse(context: context)
+        default:
+            ()
+        }
+    }
+
+    private func sendResponse(context: ChannelHandlerContext) {
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("server", "test-benchmark")])
+        let response = HTTP2Frame.FramePayload.headers(.init(headers: responseHeaders, endStream: false))
+        let responseData = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(ByteBuffer()), endStream: true))
+        context.write(self.wrapOutboundOut(response), promise: nil)
+        context.writeAndFlush(self.wrapOutboundOut(responseData), promise: nil)
+    }
+}
+
+func run(identifier: String) {
+    var noninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1)
+
+    measure(identifier: identifier + "_noninterleaved") {
+        return try! noninterleaved.run()
+    }
+
+    noninterleaved.tearDown()
+
+    var interleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100)
+
+    measure(identifier: identifier + "_interleaved") {
+        return try! interleaved.run()
+    }
+
+    interleaved.tearDown()
+}

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
     ],
     targets: [
         .target(name: "NIOHTTP2Server",

--- a/Sources/NIOHTTP2PerformanceTester/ServerOnly10KRequestsBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/ServerOnly10KRequestsBenchmark.swift
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHPACK
+import NIOHTTP2
+
+final class ServerOnly10KRequestsBenchmark: Benchmark {
+    private let concurrentStreams: Int
+
+    var channel: EmbeddedChannel?
+
+    // This offset is preserved across runs.
+    var streamID = HTTP2StreamID(1)
+
+    // A manually constructed data frame.
+    private var dataFrame: ByteBuffer = {
+        var buffer = ByteBuffer(repeating: 0xff, count: 1024 + 9)
+
+        // UInt24 length, is 1024 bytes.
+        buffer.setInteger(UInt8(0), at: buffer.readerIndex)
+        buffer.setInteger(UInt16(1024), at: buffer.readerIndex + 1)
+
+        // Type
+        buffer.setInteger(UInt8(0x00), at: buffer.readerIndex + 3)
+
+        // Flags, turn on end-stream.
+        buffer.setInteger(UInt8(0x01), at: buffer.readerIndex + 4)
+
+        // 4 byte stream identifier, set to zero for now as we update it later.
+        buffer.setInteger(UInt32(0), at: buffer.readerIndex + 5)
+
+        return buffer
+    }()
+
+    // A manually constructed headers frame.
+    private var headersFrame: ByteBuffer = {
+        var headers = HPACKHeaders()
+        headers.add(name: ":method", value: "GET", indexing: .indexable)
+        headers.add(name: ":authority", value: "localhost", indexing: .nonIndexable)
+        headers.add(name: ":path", value: "/", indexing: .indexable)
+        headers.add(name: ":scheme", value: "https", indexing: .indexable)
+        headers.add(name: "user-agent",
+                    value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
+                    indexing: .nonIndexable)
+        headers.add(name: "accept-encoding", value: "gzip, deflate", indexing: .indexable)
+
+        var hpackEncoder = HPACKEncoder(allocator: .init())
+        var buffer = ByteBuffer()
+        buffer.writeRepeatingByte(0, count: 9)
+        buffer.moveReaderIndex(forwardBy: 9)
+        try! hpackEncoder.encode(headers: headers, to: &buffer)
+        let encodedLength = buffer.readableBytes
+        buffer.moveReaderIndex(to: buffer.readerIndex - 9)
+
+        // UInt24 length
+        buffer.setInteger(UInt8(0), at: buffer.readerIndex)
+        buffer.setInteger(UInt16(encodedLength), at: buffer.readerIndex + 1)
+
+        // Type
+        buffer.setInteger(UInt8(0x01), at: buffer.readerIndex + 3)
+
+        // Flags, turn on END_HEADERs.
+        buffer.setInteger(UInt8(0x04), at: buffer.readerIndex + 4)
+
+        // 4 byte stream identifier, set to zero for now as we update it later.
+        buffer.setInteger(UInt32(0), at: buffer.readerIndex + 5)
+
+        return buffer
+    }()
+
+    private let emptySettings: ByteBuffer = {
+        var buffer = ByteBuffer()
+        buffer.reserveCapacity(9)
+
+        // UInt24 length, is 0 bytes.
+        buffer.writeInteger(UInt8(0))
+        buffer.writeInteger(UInt16(0))
+
+        // Type
+        buffer.writeInteger(UInt8(0x04))
+
+        // Flags, none.
+        buffer.writeInteger(UInt8(0x00))
+
+        // 4 byte stream identifier, set to zero.
+        buffer.writeInteger(UInt32(0))
+
+        return buffer
+    }()
+
+    private var settingsACK: ByteBuffer {
+        // Copy the empty SETTINGS and add the ACK flag
+        var settingsCopy = self.emptySettings
+        settingsCopy.setInteger(UInt8(0x01), at: settingsCopy.readerIndex + 4)
+        return settingsCopy
+    }
+
+    init(concurrentStreams: Int) {
+        self.concurrentStreams = concurrentStreams
+    }
+
+    func setUp() throws {
+        let channel = EmbeddedChannel()
+        _ = try channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+
+        try channel.connect(to: .init(unixDomainSocketPath: "/fake"), promise: nil)
+
+        // Gotta do the handshake here.
+        var initialBytes = ByteBuffer(string: "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+        initialBytes.writeImmutableBuffer(self.emptySettings)
+        initialBytes.writeImmutableBuffer(self.settingsACK)
+
+        try channel.writeInbound(initialBytes)
+        while try channel.readOutbound(as: ByteBuffer.self) != nil { }
+
+        self.channel = channel
+    }
+
+    func tearDown() {
+        _ = try! self.channel!.finish()
+        self.channel = nil
+    }
+
+    func run() throws -> Int {
+        var bodyByteCount = 0
+        var completedIterations = 0
+        while completedIterations < 10_000 {
+            bodyByteCount &+= try self.sendInterleavedRequests(self.concurrentStreams)
+            completedIterations += self.concurrentStreams
+        }
+        return bodyByteCount
+    }
+
+    private func sendInterleavedRequests(_ interleavedRequests: Int) throws -> Int {
+        var streamID = self.streamID
+
+        for _ in 0 ..< interleavedRequests {
+            self.headersFrame.setInteger(UInt32(Int32(streamID)), at: self.headersFrame.readerIndex + 5)
+            try self.channel!.writeInbound(self.headersFrame)
+            streamID = streamID.advanced(by: 2)
+        }
+
+        streamID = self.streamID
+
+        for _ in 0 ..< interleavedRequests {
+            self.dataFrame.setInteger(UInt32(Int32(streamID)), at: self.dataFrame.readerIndex + 5)
+            try self.channel!.writeInbound(self.dataFrame)
+            streamID = streamID.advanced(by: 2)
+        }
+
+        self.channel!.embeddedEventLoop.run()
+
+        self.streamID = streamID
+
+        var count = 0
+        while let data = try self.channel!.readOutbound(as: ByteBuffer.self) {
+            count &+= data.readableBytes
+            self.channel!.embeddedEventLoop.run()
+        }
+        return count
+    }
+}
+
+fileprivate class TestServer: ChannelInboundHandler {
+    public typealias InboundIn = HTTP2Frame.FramePayload
+    public typealias OutboundOut = HTTP2Frame.FramePayload
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let payload = self.unwrapInboundIn(data)
+
+        switch payload {
+        case .headers(let headers) where headers.endStream:
+            self.sendResponse(context: context)
+        case .data(let data) where data.endStream:
+            self.sendResponse(context: context)
+        default:
+            ()
+        }
+    }
+
+    private func sendResponse(context: ChannelHandlerContext) {
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("server", "test-benchmark")])
+        let response = HTTP2Frame.FramePayload.headers(.init(headers: responseHeaders, endStream: false))
+        let responseData = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(ByteBuffer()), endStream: true))
+        context.write(self.wrapOutboundOut(response), promise: nil)
+        context.writeAndFlush(self.wrapOutboundOut(responseData), promise: nil)
+    }
+}

--- a/Sources/NIOHTTP2PerformanceTester/main.swift
+++ b/Sources/NIOHTTP2PerformanceTester/main.swift
@@ -48,6 +48,12 @@ public func measure(_ fn: () throws -> Int) rethrows -> [TimeInterval] {
 let limitSet = CommandLine.arguments.dropFirst()
 
 public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void {
+    #if CACHEGRIND
+    // When CACHEGRIND is set we only run a single requested test, and we only run it once. No printing or other mess.
+    if limitSet.contains(desc) {
+        _ = try fn()
+    }
+    #else
     if limitSet.count == 0 || limitSet.contains(desc) {
         print("measuring\(warning): \(desc): ", terminator: "")
         let measurements = try measure(fn)
@@ -55,6 +61,7 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void
     } else {
         print("skipping '\(desc)', limit set = \(limitSet)")
     }
+    #endif
 }
 
 // MARK: Utilities
@@ -70,3 +77,5 @@ try measureAndPrint(desc: "huffman_encode_basic", benchmark: HuffmanEncodingBenc
 try measureAndPrint(desc: "huffman_encode_complex", benchmark: HuffmanEncodingBenchmark(huffmanString: .complexHuffmanString, loopCount: 100))
 try measureAndPrint(desc: "huffman_decode_basic", benchmark: HuffmanDecodingBenchmark(huffmanBytes: .basicHuffmanBytes, loopCount: 25))
 try measureAndPrint(desc: "huffman_decode_complex", benchmark: HuffmanDecodingBenchmark(huffmanBytes: .complexHuffmanBytes, loopCount: 10))
+try measureAndPrint(desc: "server_only_10k_requests_1_concurrent", benchmark: ServerOnly10KRequestsBenchmark(concurrentStreams: 1))
+try measureAndPrint(desc: "server_only_10k_requests_100_concurrent", benchmark: ServerOnly10KRequestsBenchmark(concurrentStreams: 100))

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -18,8 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=338000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=406000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=394000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=76000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=75000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -32,8 +34,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=338000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=406000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=394000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=76000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=75000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,8 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=358000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=425000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=413000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=81000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=80000
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -32,8 +34,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=358000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=425000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=413000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=81000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=80000
 
   shell:
     image: swift-nio-http2:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,8 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=334000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=403000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
 
   performance-test:
     image: swift-nio-http2:18.04-5.2
@@ -32,8 +34,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=334000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=403000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
 
 
   shell:

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -18,8 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=334000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=403000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
 
   performance-test:
     image: swift-nio-http2:18.04-5.3
@@ -32,8 +34,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=334000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=403000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
 
   shell:
     image: swift-nio-http2:18.04-5.3


### PR DESCRIPTION
Motivation:

Performance benchmarking wants accurate numbers, and a wide range of
possible benchmarks. One way to get somewhat more accurate numbers is to
use a tool like Cachegrind to measure the instruction counts of a
program. Cachegrind allows us to isolate a number of noise-introducing
effects, as "number of executed instructions" is a much more stable
number than how long a program takes to run.

When running under cachegrind we want to change the way our performance
benchmarks work. Instead of running lots of times to try to average out
noise, we only want to run once to save ourselves time, as the benchmark
itself should be drastically more stable.

While we're here, let's add some much more isolated benchmarks than our
current "make lots of streams" benchmark. This is basically the same
logic, but it does less of NIO and so makes the impact of NIOHTTP2
substantially more prominent.

Modifications:

- Added a cachegrind build mode to the benchmarks.
- Added new benchmarks and alloc counters.

Result:

More info