### PR TITLE
Reduce allocations in OutboundFlowControlBuffer.

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,9 +19,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=394000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=76000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=75000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=392000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=394000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=76000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=75000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=392000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -19,9 +19,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=413000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=81000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=80000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=411000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=80000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=79000
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=413000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=81000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=80000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=411000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=80000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=79000
 
   shell:
     image: swift-nio-http2:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -19,9 +19,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=389000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=74000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=73000
 
   performance-test:
     image: swift-nio-http2:18.04-5.2
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=389000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=74000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=73000
 
 
   shell:

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -19,9 +19,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=389000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=74000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=73000
 
   performance-test:
     image: swift-nio-http2:18.04-5.3
@@ -35,9 +35,9 @@ services:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=391000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=75000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=74000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=389000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=74000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=73000
 
   shell:
     image: swift-nio-http2:18.04-5.3


### PR DESCRIPTION
Motivation:

Heap allocations that aren't necessary for program correctness are to be
avoided.

Modifications:

- Avoid heap allocating for constructing indirect enum cases.

Result:

Fewer heap allocations.
Resolves #255.
Reduces instructions executed in cachegrind server-only benchmarks by
about 0.15%.
Reduces icache miss rate by 3% in cachegrind due to reduced jumps to
cold malloc code.