### PR TITLE
Add properties to HTTP2StreamID to determine stream initiator

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1678,10 +1678,9 @@ extension HTTP2StreamID {
     func mayBeInitiatedBy(_ role: HTTP2ConnectionStateMachine.ConnectionRole) -> Bool {
         switch role {
         case .client:
-            return self.networkStreamID % 2 == 1
+            return self.isClientInitiated
         case .server:
-            // Noone may initiate the root stream.
-            return self.networkStreamID % 2 == 0 && self != .rootStream
+            return self.isServerInitiated
         }
     }
 }

--- a/Sources/NIOHTTP2/HTTP2StreamID.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamID.swift
@@ -37,6 +37,17 @@ public struct HTTP2StreamID {
     /// that can be used to "quiesce" a HTTP/2 connection on a GOAWAY frame.
     public static let maxID: HTTP2StreamID = HTTP2StreamID(Int32.max)
 
+    /// Returns a boolean indicating whether this stream ID relates to a client initiated stream.
+    public var isClientInitiated: Bool {
+        return self.networkStreamID % 2 == 1
+    }
+
+    /// Returns a boolean indicating whether this stream ID relates to a server initiated stream.
+    public var isServerInitiated: Bool {
+        // Noone may initiate the root stream.
+        return self.networkStreamID % 2 == 0 && self != .rootStream
+    }
+
     /// Create a `HTTP2StreamID` for a specific integer value.
     public init(_ integerID: Int) {
         precondition(integerID >= 0 && integerID <= Int32.max, "\(integerID) is not a valid HTTP/2 stream ID value")

--- a/Tests/NIOHTTP2Tests/StreamIDTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/StreamIDTests+XCTest.swift
@@ -28,6 +28,8 @@ extension StreamIDTests {
    static var allTests : [(String, (StreamIDTests) -> () throws -> Void)] {
       return [
                 ("testStreamIDsAreStrideable", testStreamIDsAreStrideable),
+                ("testIsClientInitiated", testIsClientInitiated),
+                ("testIsServerInitiated", testIsServerInitiated),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/StreamIDTests.swift
+++ b/Tests/NIOHTTP2Tests/StreamIDTests.swift
@@ -22,4 +22,20 @@ final class StreamIDTests: XCTestCase {
         XCTAssertEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1], Array(stride(from: HTTP2StreamID(10), through: HTTP2StreamID(1), by: -1)))
         XCTAssertEqual([1, 3, 5, 7, 9], Array(stride(from: HTTP2StreamID(1), to: HTTP2StreamID(10), by: 2)))
     }
+
+    func testIsClientInitiated() {
+        XCTAssertFalse(HTTP2StreamID(0).isClientInitiated)
+        XCTAssertTrue(HTTP2StreamID(1).isClientInitiated)
+        XCTAssertFalse(HTTP2StreamID(2).isClientInitiated)
+        XCTAssertTrue(HTTP2StreamID(3).isClientInitiated)
+        XCTAssertFalse(HTTP2StreamID(4).isClientInitiated)
+    }
+
+    func testIsServerInitiated() {
+        XCTAssertFalse(HTTP2StreamID(0).isServerInitiated)
+        XCTAssertFalse(HTTP2StreamID(1).isServerInitiated)
+        XCTAssertTrue(HTTP2StreamID(2).isServerInitiated)
+        XCTAssertFalse(HTTP2StreamID(3).isServerInitiated)
+        XCTAssertTrue(HTTP2StreamID(4).isServerInitiated)
+    }
 }


### PR DESCRIPTION
Motivation:

It's not possible (at least trivially) from the public API to determine
which peer in a connection initiated a given stream ID. In some cases
it's possible with prior knowledge (i.e. in a given application the
client may always initiate streams), however, such conditions aren't
guaranteed to always hold.

Modifications:

- Add `isClientInitiated` and `isServerInitiated` computed properties to
  `HTTP2StreamID`.
- Add a few tests.

Result:

Users can easily get the answer to the question 'did a client/server
create this stream?'