### PR TITLE
Move the huffman benchmark base64 out of init

### DIFF
--- a/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
@@ -17,13 +17,3 @@ protocol Benchmark: class {
     func tearDown()
     func run() throws -> Int
 }
-
-func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
-    try bench.setUp()
-    defer {
-        bench.tearDown()
-    }
-    try measureAndPrint(desc: desc) {
-        return try bench.run()
-    }
-}

--- a/Sources/NIOHTTP2PerformanceTester/main.swift
+++ b/Sources/NIOHTTP2PerformanceTester/main.swift
@@ -64,6 +64,23 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void
     #endif
 }
 
+func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: @autoclosure () -> B) throws {
+    // Avoids running setUp/tearDown when we don't want that benchmark.
+    guard limitSet.contains(desc) else {
+        return
+    }
+
+    let bench = bench()
+
+    try bench.setUp()
+    defer {
+        bench.tearDown()
+    }
+    try measureAndPrint(desc: desc) {
+        return try bench.run()
+    }
+}
+
 // MARK: Utilities
 
 try measureAndPrint(desc: "1_conn_10k_reqs", benchmark: Bench1Conn10kRequests())


### PR DESCRIPTION
Motivation:

The init() of all benchmarks will execute, even when we filter a
benchmark run down to a single benchmark. We should avoid doing heavy
work there, because it can confuse us when we look at traces elsewhere.

Modifications:

- Move some heavy work in the huffman benchmark base64 decode out of
  init().
- Prevent setUp() and tearDown() from running if a test is filtered out.
- Avoid even creating benchmarks unless they're filtered in.

Result:

Less confusing benchmark traces.