### PR TITLE
Reduce the cost of flushing

### DIFF
--- a/Sources/NIOHTTP2/Frame Buffers/OutboundFlowControlBuffer.swift
+++ b/Sources/NIOHTTP2/Frame Buffers/OutboundFlowControlBuffer.swift
@@ -14,12 +14,44 @@
 import NIO
 
 /// A structure that manages buffering outbound frames for active streams to ensure that those streams do not violate flow control rules.
+///
+/// This buffer is an extremely performance sensitive part of the HTTP/2 stack. This is because all outbound data passes through it, and
+/// all application data needs to be actively buffered by it. The result of this is that state management is extremely expensive, and we
+/// need efficient algorithms to process them.
+///
+/// The core of the data structure are a collection of `StreamFlowControlState` objects. These objects keep track of the flow control window
+/// available for a given stream, as well as any pending writes that may be present on the stream. The pending writes include both DATA and
+/// HEADERS frames, as if we've buffered any DATA frames we need to queue HEADERS frames up behind them.
+///
+/// Data is appended to these objects on write(). Each write() will trigger both a lookup in the stream data buffers _and_ an append to a
+/// data buffer. It is therefore deeply important that both of these operations are as cheap as possible.
+///
+/// However, these operations are fundamentally constant in size. Once we have found the stream data buffer, we do not need to worry about
+/// all the others. The cost of the write() operation is therefore no more expensive than the cost of the lookup. The same is unfortunately
+/// not true for flush().
+///
+/// When we get a flush(), we need to update a bunch of state. In particular, we need to record any previously-written frames that are
+/// now flushed, as well as compute which streams may have become writable as a result of the flush call. In early versions of this code
+/// we would do a linear scan across _all buffers_, check whether they were writable before, mark their flush point, check if they'd become
+/// writable, and then store them in the set of flushable streams. This was monstrously expensive, and worse still the cost was not proportional
+/// to the amount of writing done but to the amount of flushing done and the number of active streams.
+///
+/// The current design avoids this by having the `StreamFlowControlState` be much more explicit about when it transitions from non-writable to
+/// writable and back again. This allows us to keep an Array of writable streams that we use to avoid needing to touch all the streams whenever
+/// a flush occurs. This greatly reduces our workload! Additionally, by caching all stream state changes we are not forced to perform repeated
+/// expensive computations, but can instead incrementalise the cost on a per-write instead of per-flush basis, keeping track of exactly the
+/// decisions we're making.
 internal struct OutboundFlowControlBuffer {
     /// A buffer of the data sent on the stream that has not yet been passed to the the connection state machine.
     private var streamDataBuffers: StreamMap<StreamFlowControlState>
 
-    // TODO(cory): This will eventually need to grow into a priority implementation. For now, it's sufficient to just
-    // use a set and worry about the data structure costs later.
+    /// The streams that have been written to since the last flush.
+    ///
+    /// This object is a cache that is used to keep track of what streams need to be modified whenever we get a flush()
+    /// call. Streams that have been invalidated or removed don't get removed from here: we deal with them once we flush
+    /// and go to find them to actually write from them. They are not a correctness problem.
+    private var writableStreams: Set<HTTP2StreamID> = Set()
+
     /// The streams with pending data to output.
     private var flushableStreams: Set<HTTP2StreamID> = Set()
 
@@ -34,28 +66,36 @@ internal struct OutboundFlowControlBuffer {
         self.streamDataBuffers = StreamMap()
         self.connectionWindowSize = initialConnectionWindowSize
         self.maxFrameSize = initialMaxFrameSize
+
+        // Avoid some resizes.
+        self.writableStreams.reserveCapacity(16)
+        self.flushableStreams.reserveCapacity(16)
     }
 
     internal mutating func processOutboundFrame(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?) throws -> OutboundFrameAction {
         // A side note: there is no special handling for RST_STREAM frames here, unlike in the concurrent streams buffer. This is because
         // RST_STREAM frames will cause stream closure notifications, which will force us to drop our buffers. For this reason we can
         // simplify our code here, which helps a lot.
+        let streamID = frame.streamID
+
         switch frame.payload {
         case .data:
             // We buffer DATA frames.
-            if !self.streamDataBuffers.apply(streamID: frame.streamID, { $0.dataBuffer.bufferWrite((frame.payload, promise)) }) {
+            if !self.streamDataBuffers.apply(streamID: streamID, { $0.bufferWrite((frame.payload, promise)) }) {
                 // We don't have this stream ID. This is an internal error, but we won't precondition on it as
                 // it can happen due to channel handler misconfiguration or other weirdness. We'll just complain.
-                throw NIOHTTP2Errors.noSuchStream(streamID: frame.streamID)
+                throw NIOHTTP2Errors.noSuchStream(streamID: streamID)
             }
+
+            self.writableStreams.insert(streamID)
             return .nothing
         case .headers:
             // Headers are special. If we have a data frame buffered, we buffer behind it to avoid frames
             // being reordered. However, if we don't have a data frame buffered we pass the headers frame on
             // immediately, as there is no risk of violating ordering guarantees.
-            let bufferResult = self.streamDataBuffers.modify(streamID: frame.streamID) { (state: inout StreamFlowControlState) -> Bool in
-                if state.dataBuffer.haveBufferedDataFrame {
-                    state.dataBuffer.bufferWrite((frame.payload, promise))
+            let bufferResult = self.streamDataBuffers.modify(streamID: streamID) { (state: inout StreamFlowControlState) -> Bool in
+                if state.haveBufferedDataFrame {
+                    state.bufferWrite((frame.payload, promise))
                     return true
                 } else {
                     return false
@@ -64,7 +104,7 @@ internal struct OutboundFlowControlBuffer {
 
             switch bufferResult {
             case .some(true):
-                // Buffered, do nothing.
+                self.writableStreams.insert(streamID)
                 return .nothing
             case .some(false), .none:
                 // We don't need to buffer this, pass it on.
@@ -77,15 +117,21 @@ internal struct OutboundFlowControlBuffer {
     }
 
     internal mutating func flushReceived() {
-        // Mark the flush points on all the streams we have.
-        self.streamDataBuffers.mutatingForEachValue {
-            let hadData = $0.hasPendingData
-            $0.dataBuffer.markFlushPoint()
-            if $0.hasPendingData && !hadData {
-                assert(!self.flushableStreams.contains($0.streamID))
-                self.flushableStreams.insert($0.streamID)
+        // Mark the flush points on all the streams we believe are writable.
+        // We need to double-check here: has their flow control window dropped below zero? If it
+        // has, the streamID isn't actually writable, and we should abandon adding it here. However,
+        // we still mark the flush point.
+        for streamID in self.writableStreams {
+            let actuallyWritable: Bool? = self.streamDataBuffers.modify(streamID: streamID) { dataBuffer in
+                dataBuffer.markFlushPoint()
+                return dataBuffer.hasFlowControlWindowSpaceForNextWrite
+            }
+            if let actuallyWritable = actuallyWritable, actuallyWritable {
+                self.flushableStreams.insert(streamID)
             }
         }
+
+        self.writableStreams.removeAll(keepingCapacity: true)
     }
 
     private func nextStreamToSend() -> HTTP2StreamID? {
@@ -96,21 +142,23 @@ internal struct OutboundFlowControlBuffer {
         assert(streamID != .rootStream)
 
         self.streamDataBuffers.apply(streamID: streamID) {
-            let hadData = $0.hasPendingData
-            $0.currentWindowSize = Int(newSize)
-            if $0.hasPendingData && !hadData {
-                assert(!self.flushableStreams.contains($0.streamID))
-                self.flushableStreams.insert($0.streamID)
-            } else if !$0.hasPendingData && hadData {
-                assert(self.flushableStreams.contains($0.streamID))
-                self.flushableStreams.remove($0.streamID)
+            switch $0.updateWindowSize(newSize: Int(newSize)) {
+            case .unchanged:
+                // No change, do nothing.
+                ()
+            case .changed(newValue: true):
+                // Became writable, and specifically became _flushable_.
+                self.flushableStreams.insert(streamID)
+            case .changed(newValue: false):
+                // Became unwritable.
+                self.flushableStreams.remove(streamID)
             }
         }
     }
 
     internal func invalidateBuffer(reason: ChannelError) {
         self.streamDataBuffers.forEachValue { buffer in
-            buffer.dataBuffer.failAllWrites(error: reason)
+            buffer.failAllWrites(error: reason)
         }
     }
 
@@ -132,7 +180,7 @@ internal struct OutboundFlowControlBuffer {
         }
 
         // To avoid too much work higher up the stack, we only return writes from here if there actually are any.
-        let writes = streamData.dataBuffer.evacuatePendingWrites()
+        let writes = streamData.evacuatePendingWrites()
         if writes.count > 0 {
             return writes
         } else {
@@ -147,10 +195,15 @@ internal struct OutboundFlowControlBuffer {
         }
 
         let nextWrite = self.streamDataBuffers.modify(streamID: nextStreamID) { (state: inout StreamFlowControlState) -> DataBuffer.BufferElement in
-            let nextWrite = state.nextWrite(maxSize: min(self.connectionWindowSize, self.maxFrameSize))
-            if !state.hasPendingData {
+            let (nextWrite, writabilityState) = state.nextWrite(maxSize: min(self.connectionWindowSize, self.maxFrameSize))
+
+            switch writabilityState {
+            case .changed(newValue: false):
                 self.flushableStreams.remove(nextStreamID)
+            case .changed(newValue: true), .unchanged:
+                ()
             }
+
             return nextWrite
         }
         guard let (payload, promise) = nextWrite else {
@@ -165,15 +218,15 @@ internal struct OutboundFlowControlBuffer {
 
     internal mutating func initialWindowSizeChanged(_ delta: Int) {
         self.streamDataBuffers.mutatingForEachValue {
-            let hadPendingData = $0.hasPendingData
-            $0.currentWindowSize += delta
-            let hasPendingData = $0.hasPendingData
-
-            if !hadPendingData && hasPendingData {
-                assert(!self.flushableStreams.contains($0.streamID))
+            switch $0.updateWindowSize(newSize: $0.currentWindowSize + delta) {
+            case .unchanged:
+                // No change, do nothing.
+                ()
+            case .changed(newValue: true):
+                // Became flushable
                 self.flushableStreams.insert($0.streamID)
-            } else if hadPendingData && !hasPendingData {
-                assert(self.flushableStreams.contains($0.streamID))
+            case .changed(newValue: false):
+                // Became unflushable.
                 self.flushableStreams.remove($0.streamID)
             }
         }
@@ -197,11 +250,15 @@ extension OutboundFlowControlBuffer {
 
 private struct StreamFlowControlState: PerStreamData {
     let streamID: HTTP2StreamID
-    var currentWindowSize: Int
-    var dataBuffer: DataBuffer
+    internal private(set) var currentWindowSize: Int
+    private var dataBuffer: DataBuffer
 
-    var hasPendingData: Bool {
-        return self.dataBuffer.hasMark && (self.currentWindowSize > 0 || self.dataBuffer.nextWriteIsHeaders)
+    var haveBufferedDataFrame: Bool {
+        return self.dataBuffer.haveBufferedDataFrame
+    }
+
+    var hasFlowControlWindowSpaceForNextWrite: Bool {
+        return self.currentWindowSize > 0 || self.dataBuffer.nextWriteIsZeroSized
     }
 
     init(streamID: HTTP2StreamID, initialWindowSize: Int) {
@@ -210,17 +267,72 @@ private struct StreamFlowControlState: PerStreamData {
         self.dataBuffer = DataBuffer()
     }
 
-    mutating func nextWrite(maxSize: Int) -> DataBuffer.BufferElement {
+    mutating func bufferWrite(_ write: DataBuffer.BufferElement) {
+        self.dataBuffer.bufferWrite(write)
+    }
+
+    mutating func updateWindowSize(newSize: Int) -> WritabilityState {
+        let oldWindowSize = self.currentWindowSize
+        self.currentWindowSize = newSize
+
+        // If we have no marked writes, nothing changed.
+        guard self.dataBuffer.hasMark else {
+            return .unchanged
+        }
+
+        if oldWindowSize <= 0 && self.currentWindowSize > 0 {
+            // Window opened. We can now write.
+            return .changed(newValue: true)
+        }
+
+        if self.currentWindowSize <= 0 && oldWindowSize > 0 {
+            // Window closed. We can now only write if the first write is zero-sized.
+            if self.dataBuffer.nextWriteIsZeroSized {
+                return .unchanged
+            }
+
+            return .changed(newValue: false)
+        }
+
+        return .unchanged
+    }
+
+    mutating func markFlushPoint() {
+        self.dataBuffer.markFlushPoint()
+    }
+
+    /// Removes all pending writes, invalidating this structure as it does so.
+    mutating func evacuatePendingWrites() -> MarkedCircularBuffer<DataBuffer.BufferElement> {
+        return self.dataBuffer.evacuatePendingWrites()
+    }
+
+    func failAllWrites(error: ChannelError) {
+        self.dataBuffer.failAllWrites(error: error)
+    }
+
+    mutating func nextWrite(maxSize: Int) -> (DataBuffer.BufferElement, WritabilityState) {
         assert(maxSize > 0)
         let writeSize = min(maxSize, currentWindowSize)
         let nextWrite = self.dataBuffer.nextWrite(maxSize: writeSize)
+        var writabilityState = WritabilityState.unchanged
 
         if case .data(let payload) = nextWrite.0 {
             self.currentWindowSize -= payload.data.readableBytes
+
+            if !self.dataBuffer.hasMark {
+                // Eaten the mark, no longer writable.
+                writabilityState = .changed(newValue: false)
+            } else if !self.hasFlowControlWindowSpaceForNextWrite {
+                // No flow control space for writing anymore.
+                writabilityState = .changed(newValue: false)
+            }
+        } else if !self.dataBuffer.hasMark {
+            // Eaten the mark, no longer writable.
+            writabilityState = .changed(newValue: false)
         }
 
         assert(self.currentWindowSize >= 0)
-        return nextWrite
+        return (nextWrite, writabilityState)
     }
 }
 
@@ -230,20 +342,12 @@ private struct DataBuffer {
 
     private var bufferedChunks: MarkedCircularBuffer<BufferElement>
 
-    internal private(set) var flushedBufferedBytes: UInt
-
-    private var unflushedBufferedBytes: UInt
-
     var haveBufferedDataFrame: Bool {
         return self.bufferedChunks.count > 0
     }
 
-    var nextWriteIsHeaders: Bool {
-        if case .some(.headers) = self.bufferedChunks.first?.0 {
-            return true
-        } else {
-            return false
-        }
+    var nextWriteIsZeroSized: Bool {
+        return self.bufferedChunks.first?.0.isZeroSizedWrite ?? false
     }
 
     var hasMark: Bool {
@@ -255,27 +359,20 @@ private struct DataBuffer {
 
     init() {
         self.bufferedChunks = MarkedCircularBuffer(initialCapacity: 8)
-        self.flushedBufferedBytes = 0
-        self.unflushedBufferedBytes = 0
     }
 
     mutating func bufferWrite(_ write: BufferElement) {
-        if case .data(let contents) = write.0 {
-            self.unflushedBufferedBytes += UInt(contents.data.readableBytes)
-        }
-
         self.bufferedChunks.append(write)
     }
 
     /// Marks the current point in the buffer as the place up to which we have flushed.
     mutating func markFlushPoint() {
-        self.flushedBufferedBytes += self.unflushedBufferedBytes
-        self.unflushedBufferedBytes = 0
         self.bufferedChunks.mark()
     }
 
     mutating func nextWrite(maxSize: Int) -> BufferElement {
         assert(maxSize >= 0)
+        assert(self.hasMark)
         precondition(self.bufferedChunks.count > 0)
 
         let firstElementIndex = self.bufferedChunks.startIndex
@@ -289,14 +386,12 @@ private struct DataBuffer {
         let firstElementReadableBytes = contents.data.readableBytes
         if firstElementReadableBytes <= maxSize {
             // Return the whole element.
-            self.flushedBufferedBytes -= UInt(firstElementReadableBytes)
             return self.bufferedChunks.removeFirst()
         }
 
         // Here we have too many bytes. So we need to slice out a copy of the data we need
         // and leave the rest.
         let dataSlice = contents.data.slicePrefix(maxSize)
-        self.flushedBufferedBytes -= UInt(maxSize)
         self.bufferedChunks[self.bufferedChunks.startIndex].0 = .data(contents)
         return (.data(.init(data: dataSlice)), nil)
     }
@@ -316,6 +411,13 @@ private struct DataBuffer {
 }
 
 
+/// Used to communicate whether a stream has had its writability state change.
+fileprivate enum WritabilityState {
+    case changed(newValue: Bool)
+    case unchanged
+}
+
+
 private extension IOData {
     mutating func slicePrefix(_ length: Int) -> IOData {
         assert(length < self.readableBytes)
@@ -332,6 +434,18 @@ private extension IOData {
             region.moveReaderIndex(forwardBy: length)
             self = .fileRegion(region)
             return .fileRegion(newRegion)
+        }
+    }
+}
+
+
+extension HTTP2Frame.FramePayload {
+    fileprivate var isZeroSizedWrite: Bool {
+        switch self {
+        case .data(let payload):
+            return payload.data.readableBytes == 0 && payload.paddingBytes == nil
+        default:
+            return true
         }
     }
 }

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests+XCTest.swift
@@ -41,6 +41,10 @@ extension OutboundFlowControlBufferTests {
                 ("testChangingStreamWindowSizeToZeroAndBack", testChangingStreamWindowSizeToZeroAndBack),
                 ("testStreamWindowChanges", testStreamWindowChanges),
                 ("testRejectsPrioritySelfDependency", testRejectsPrioritySelfDependency),
+                ("testFlushableStreamStopsBeingFlushableIfTheWindowGoesAway", testFlushableStreamStopsBeingFlushableIfTheWindowGoesAway),
+                ("testFlushableStreamStopsBeingFlushableIfTheWindowIsShrunkByTheRemotePeer", testFlushableStreamStopsBeingFlushableIfTheWindowIsShrunkByTheRemotePeer),
+                ("testZeroSizedWritesAreStillAllowedWhenTheWindowIsZero", testZeroSizedWritesAreStillAllowedWhenTheWindowIsZero),
+                ("testZeroSizedWritesAreStillAllowedIfTheWindowChangesSize", testZeroSizedWritesAreStillAllowedIfTheWindowChangesSize),
            ]
    }
 }

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -18,11 +18,11 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=370000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -35,11 +35,11 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=370000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=348000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=393000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=348000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=393000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=320000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=367000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=320000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=367000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=319000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=366000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=319000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=366000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000

--- a/scripts/cachegrindify.sh
+++ b/scripts/cachegrindify.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set +ex
+
+# Benchmarks known to behave well under cachegrind.
+# When adding new benchmarks, consider adding them to this list.
+CACHEGRIND_BENCHES=( server_only_10k_requests_100_concurrent server_only_10k_requests_1_concurrent )
+
+function run_bench {
+    BRANCH="$1"
+
+    echo "Running against $BRANCH"
+    git checkout "$BRANCH"
+    swift build -c release -Xswiftc -g -Xswiftc -DCACHEGRIND > /dev/null
+
+    for BENCH in "${CACHEGRIND_BENCHES[@]}"; do
+        valgrind --tool=cachegrind --cachegrind-out-file="cachegrind.out.$BENCH.$BRANCH" ./.build/x86_64-unknown-linux-gnu/release/NIOHTTP2PerformanceTester "$BENCH" > /dev/null
+    done
+}
+
+function compare {
+    BASE_BRANCH="$1"
+    TARGET_BRANCH="$2"
+
+    for BENCH in "${CACHEGRIND_BENCHES[@]}"; do
+        BASE_TOTAL=$(cg_annotate "cachegrind.out.$BENCH.$BASE_BRANCH" | grep "PROGRAM TOTALS" | awk '{ print $1 }')
+        TARGET_TOTAL=$(cg_annotate "cachegrind.out.$BENCH.$TARGET_BRANCH" | grep "PROGRAM TOTALS" | awk '{ print $1 }')
+
+        echo "Bench $BENCH result changed: base $BASE_TOTAL, target $TARGET_TOTAL"
+    done
+}
+
+if ! command -v valgrind &> /dev/null; then
+    echo "Valgrind not installed, please install valgrind and re-run"
+    exit 1
+fi
+
+BASE_BRANCH="$1"
+TARGET_BRANCH="$2"
+
+run_bench "$BASE_BRANCH"
+run_bench "$TARGET_BRANCH"
+compare "$BASE_BRANCH" "$TARGET_BRANCH"
+


### PR DESCRIPTION
Motivation:

The OutboundFlowControlBuffer is responsible for managing DATA and
HEADERS frames for all streams in order to ensure that we obey HTTP/2
flow control rules, even when users don't. This object is therefore on
the data path for the vast majority of frames, and is extremely
performance sensitive.

Unfortunately, the current algorithm has some nasty performance cliffs.
Right now it has the awkward property of making flushes take an amount
of time linear in the number of streams on the connection, not the
number of streams that had had frames sent on them. The result is that
connections with highly parallel numbers of streams see extremely poor
performance when flushing, a problem that is exacerbated if other parts
of the HTTP/2 stack fail to coalesce those flushes.

We can clean this up in a few ways, but the easiest way is to just keep
track of which streams have done I/O since the last flush. While we're
there, we can make a few other optimisations to ensure we only flush
data on streams we are actually processing, to further reduce the risk
of wasting our time processing unnecessary work.

Modifications:

- Add a Set to keep track of where we've done writes since the last
   flush.
- Streams whose flow control window goes to zero stop being writable.
- Cheaper and more accurate calculation of zero-length writes, which
   avoids the possibility of awkward stalls with zero-length DATA frames
   and END_STREAM.
- Stop doing math about the number of flushed bytes, we don't use that
   information any more.

Results:

An approximately 10% performance gain on the 100 concurrent streams
server-only benchmark. The relative performance gain shifts with the
number of active streams, but it should be positive in all cases: no regression
is observed on the 1 concurrent stream equivalent test.