### PR TITLE
Micro-optimise checked arithmetic in huffman.

### DIFF
--- a/Sources/NIOHPACK/HuffmanCoding.swift
+++ b/Sources/NIOHPACK/HuffmanCoding.swift
@@ -189,6 +189,9 @@ extension ByteBuffer {
 
         let decoded = try String(customUnsafeUninitializedCapacity: capacity) { backingStorage in
             var state: UInt8 = 0
+
+            // We do unchecked math on offset. Offset is strictly unable to get any larger than `length * 2`,
+            // and we already did checked multiplication on that value.
             var offset = 0
             var acceptable = false
 
@@ -200,7 +203,7 @@ extension ByteBuffer {
                 }
                 if t.flags.contains(.symbol) {
                     backingStorage[offset] = t.sym
-                    offset += 1
+                    offset &+= 1
                 }
 
                 t = decoderTable[state: t.state, nybble: ch & 0xf]
@@ -209,7 +212,7 @@ extension ByteBuffer {
                 }
                 if t.flags.contains(.symbol) {
                     backingStorage[offset] = t.sym
-                    offset += 1
+                    offset &+= 1
                 }
 
                 state = t.state


### PR DESCRIPTION
Motivation:

Huffman decoding has rapidly become one of the most expensive parts of
the program. Some of the code here is unavoidably expensive, but there
is some unnecessary checked arithmetic here on offset. Removing that
provides a small but meaningful improvement to the performance of this
function.

Modifications:

- Remove the checked arithmetic on offset, which is bounded by a
   previous operation that was already checked.

Result:

This function gets cheaper by about 4%, though the benchmark as a whole
only sees a 0.1% improvement.