### PR TITLE
Partially revert #263.

### DIFF
--- a/Sources/NIOHPACK/HuffmanCoding.swift
+++ b/Sources/NIOHPACK/HuffmanCoding.swift
@@ -264,7 +264,11 @@ extension String {
     }
 }
 
-#if compiler(>=5.3)
+// Frustratingly, Swift 5.3 shipped before the macOS 11 SDK did, so we cannot gate the availability of
+// this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
+// to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
+// enhancement on Apple platforms.
+#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))) || compiler(>=5.4)
 extension String {
     init(customUnsafeUninitializedCapacity capacity: Int,
          initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {


### PR DESCRIPTION
Motivation:

In #263 we took advantage of the addition of the
unsafeUninitializedCapacity:initializingWith constructor on String,
added in the latest Swift SDKs and Swift versions.

Unfortunately, there were a few Xcode releases that shipped with Swift
5.3 but _without_ the macOS 11 SDK. These releases therefore had a 5.3
compiler, but no access to the macOS 11 SDK where the constructor is
defined.

This means this change regressed builds on those platforms.

Modifications:

Removed access to the fast-path initializer on Apple platforms in 5.3.
The initializer is present and will continue to work on non-Apple
platforms. Apple platforms will get access to that initializer from 5.4
onwards.

Result:

Fewer build issues for users using Xcode 12.0 and 12.1.