### PR TITLE
Remove some generics that were triggering ARC

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingDataState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingDataState.swift
@@ -47,7 +47,9 @@ extension ReceivingDataState {
 private extension StateMachineResultWithEffect {
     static func withGuaranteedFlowControlEffect<ConnectionState: ReceivingDataState>(_ result: StateMachineResultWithStreamEffect, connectionState: ConnectionState) -> StateMachineResultWithEffect {
         // In most cases, this will update the underlying effect with the new flow control window info.
-        var newResult = StateMachineResultWithEffect(result, connectionState: connectionState)
+        var newResult = StateMachineResultWithEffect(result,
+                                                     inboundFlowControlWindow: connectionState.inboundFlowControlWindow,
+                                                     outboundFlowControlWindow: connectionState.outboundFlowControlWindow)
         if newResult.effect == nil {
             // But if we aren't noting it anywhere else, we note it here.
             newResult.effect = .flowControlChange(.init(localConnectionWindowSize: Int(connectionState.outboundFlowControlWindow), remoteConnectionWindowSize: Int(connectionState.inboundFlowControlWindow), localStreamWindowSize: nil))

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
@@ -53,7 +53,9 @@ extension ReceivingHeadersState {
             }
         }
 
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }
 
@@ -76,6 +78,8 @@ extension ReceivingHeadersState where Self: LocallyQuiescingState {
         let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true) {
             $0.receiveHeaders(headers: headers, validateHeaderBlock: validateHeaderBlock, validateContentLength: validateContentLength, isEndStreamSet: endStream)
         }
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
@@ -58,7 +58,9 @@ extension ReceivingPushPromiseState {
             let result = self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: true) {
                 $0.receivePushPromise(headers: headers, validateHeaderBlock: validateHeaderBlock)
             }
-            return StateMachineResultWithEffect(result, connectionState: self)
+            return StateMachineResultWithEffect(result,
+                                                inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                                outboundFlowControlWindow: self.outboundFlowControlWindow)
         } catch {
             return StateMachineResultWithEffect(result: .connectionError(underlyingError: error, type: .protocolError), effect: nil)
         }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingRstStreamState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingRstStreamState.swift
@@ -28,6 +28,8 @@ extension ReceivingRstStreamState {
         let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true, ignoreClosed: true) {
             $0.receiveRstStream(reason: reason)
         }
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingWindowUpdateState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingWindowUpdateState.swift
@@ -44,7 +44,9 @@ extension ReceivingWindowUpdateState {
             let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true, ignoreClosed: true) {
                 $0.receiveWindowUpdate(windowIncrement: increment)
             }
-            return StateMachineResultWithEffect(result, connectionState: self)
+            return StateMachineResultWithEffect(result,
+                                                inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                                outboundFlowControlWindow: self.outboundFlowControlWindow)
         }
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingDataState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingDataState.swift
@@ -36,6 +36,8 @@ extension SendingDataState {
         let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: false) {
             $0.sendData(contentLength: contentLength, flowControlledBytes: flowControlledBytes, isEndStreamSet: endStream)
         }
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
@@ -57,7 +57,9 @@ extension SendingHeadersState {
             }
         }
 
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }
 
@@ -72,6 +74,8 @@ extension SendingHeadersState where Self: RemotelyQuiescingState {
         let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: false) {
             $0.sendHeaders(headers: headers, validateHeaderBlock: validateHeaderBlock, validateContentLength: validateContentLength, isEndStreamSet: endStream)
         }
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
@@ -49,7 +49,11 @@ extension SendingPushPromiseState {
         }
 
         do {
-            let result = StateMachineResultWithEffect(self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: false, parentStateModifier), connectionState: self)
+            let result = StateMachineResultWithEffect(
+                self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: false, parentStateModifier),
+                inboundFlowControlWindow: self.inboundFlowControlWindow,
+                outboundFlowControlWindow: self.outboundFlowControlWindow
+            )
             guard case .succeed = result.result else {
                 return result
             }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingRstStreamState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingRstStreamState.swift
@@ -26,6 +26,8 @@ extension SendingRstStreamState {
         let result = self.streamState.locallyResetStreamState(streamID: streamID) {
             $0.sendRstStream(reason: reason)
         }
-        return StateMachineResultWithEffect(result, connectionState: self)
+        return StateMachineResultWithEffect(result,
+                                            inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                            outboundFlowControlWindow: self.outboundFlowControlWindow)
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingWindowUpdateState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingWindowUpdateState.swift
@@ -41,7 +41,9 @@ extension SendingWindowUpdateState {
             let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: false) {
                 $0.sendWindowUpdate(windowIncrement: increment)
             }
-            return StateMachineResultWithEffect(result, connectionState: self)
+            return StateMachineResultWithEffect(result,
+                                                inboundFlowControlWindow: self.inboundFlowControlWindow,
+                                                outboundFlowControlWindow: self.outboundFlowControlWindow)
         }
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/StateMachineResult.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/StateMachineResult.swift
@@ -66,9 +66,13 @@ struct StateMachineResultWithEffect {
         self.effect = effect
     }
 
-    init<ConnectionState: HasFlowControlWindows>(_ streamEffect: StateMachineResultWithStreamEffect, connectionState: ConnectionState) {
+    init(_ streamEffect: StateMachineResultWithStreamEffect,
+         inboundFlowControlWindow: HTTP2FlowControlWindow,
+         outboundFlowControlWindow: HTTP2FlowControlWindow) {
         self.result = streamEffect.result
-        self.effect = streamEffect.effect.map { NIOHTTP2ConnectionStateChange($0, connectionState: connectionState) }
+        self.effect = streamEffect.effect.map {
+            NIOHTTP2ConnectionStateChange($0, inboundFlowControlWindow: inboundFlowControlWindow, outboundFlowControlWindow: outboundFlowControlWindow)
+        }
     }
 }
 

--- a/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
+++ b/Sources/NIOHTTP2/HTTP2ConnectionStateChange.swift
@@ -193,20 +193,20 @@ internal enum StreamStateChange: Hashable {
 
 
 internal extension NIOHTTP2ConnectionStateChange {
-    init<ConnectionState: HasFlowControlWindows>(_ streamChange: StreamStateChange, connectionState: ConnectionState) {
+    init(_ streamChange: StreamStateChange, inboundFlowControlWindow: HTTP2FlowControlWindow, outboundFlowControlWindow: HTTP2FlowControlWindow) {
         switch streamChange {
         case .streamClosed(let streamClosedState):
             self = .streamClosed(.init(streamID: streamClosedState.streamID,
-                                       localConnectionWindowSize: Int(connectionState.outboundFlowControlWindow),
-                                       remoteConnectionWindowSize: Int(connectionState.inboundFlowControlWindow),
+                                       localConnectionWindowSize: Int(outboundFlowControlWindow),
+                                       remoteConnectionWindowSize: Int(inboundFlowControlWindow),
                                        reason: streamClosedState.reason))
         case .streamCreated(let streamCreated):
             self = .streamCreated(streamCreated)
         case .streamCreatedAndClosed(let streamCreatedAndClosed):
             self = .streamCreatedAndClosed(streamCreatedAndClosed)
         case .windowSizeChange(let streamSizeChange):
-            self = .flowControlChange(.init(localConnectionWindowSize: Int(connectionState.outboundFlowControlWindow),
-                                            remoteConnectionWindowSize: Int(connectionState.inboundFlowControlWindow),
+            self = .flowControlChange(.init(localConnectionWindowSize: Int(outboundFlowControlWindow),
+                                            remoteConnectionWindowSize: Int(inboundFlowControlWindow),
                                             localStreamWindowSize: streamSizeChange))
         }
     }


### PR DESCRIPTION
Motivation:

To save myself some lines of code I wrote a function that was generic
over a protocol to copy out a pair of fields from a wide range of types.
It turns out this generic was triggering a retain/release on the state
machine states, which triggers 12 ARC operations total (6 retain/release
pairs).

Removing this generic and just, you know, calling a function with some
arguments turns out to save us a bunch of this ARC traffic.

Modifications:

- Remove the generic initializer of StateMachineResultWithEffect.

Result:

Approximately 1% performance improvement in hot benchmarks.