### PR TITLE
Avoid unnecessary futures in stream creation

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=308000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=346000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=308000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=346000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000
 
   shell:
     image: swift-nio-http2:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=304000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=343000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
 
   performance-test:
     image: swift-nio-http2:18.04-5.2
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=304000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=343000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
 
 
   shell:

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
 
   performance-test:
     image: swift-nio-http2:18.04-5.3
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
 
   shell:
     image: swift-nio-http2:18.04-5.3


### PR DESCRIPTION
Motivation:

The stream channel configure function uses a chain of futures where the
same can be achieved in fewer futures.

Modifications:

- Merge the future chains where possible in HTTP2StreamChannel.configure

Result:

A 1.3% reduction in instructions in server_only_10k_requests_1_concurrent