### PR TITLE
Re-add "run all" mode to performance tester

### DIFF
--- a/Sources/NIOHTTP2PerformanceTester/main.swift
+++ b/Sources/NIOHTTP2PerformanceTester/main.swift
@@ -66,7 +66,7 @@ public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void
 
 func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: @autoclosure () -> B) throws {
     // Avoids running setUp/tearDown when we don't want that benchmark.
-    guard limitSet.contains(desc) else {
+    guard limitSet.count == 0 || limitSet.contains(desc) else {
         return
     }
 

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -18,11 +18,11 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=318000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=356000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -35,11 +35,11 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=328000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=372000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=62000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=61000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=435000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=318000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=356000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,10 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=379000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=68000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=67000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000
 
   performance-test:
@@ -35,10 +35,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=67000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=352000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=395000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=69000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=68000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=379000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=68000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=67000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=505000
 
   shell:

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,10 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=314000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=353000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=60000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
 
   performance-test:
@@ -35,10 +35,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=61000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=60000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=314000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=353000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=60000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=434000
 
 

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -18,10 +18,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=313000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=352000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=57000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000
 
   performance-test:
@@ -35,10 +35,10 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=63000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=323000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=368000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=313000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=352000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=57000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=414000
 
   shell:


### PR DESCRIPTION
The run-all mode of the performance tester inadvertently got removed in
a previous patch. This adds it back.