### PR TITLE
Delete dead code.

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -474,14 +474,6 @@ internal extension Character {
     }
 }
 
-/* private but inlinable */
-internal extension String {
-    @inlinable
-    func trimASCIIWhitespace() -> Substring {
-        return self.dropFirst(0)._trimWhitespace()
-    }
-}
-
 extension Substring {
     @inlinable
     func _trimWhitespace() -> Substring {


### PR DESCRIPTION
No-one calls this function so we can remove it.