### PR TITLE
Update allocation count requirements

### DIFF
--- a/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/Benchmark.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-protocol Benchmark: class {
+protocol Benchmark: AnyObject {
     func setUp() throws
     func tearDown()
     func run() throws -> Int

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=308000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=346000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=306000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=308000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=346000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=306000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=330000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=365000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=369000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=330000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=365000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=304000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=343000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=302000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=339000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=304000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=343000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=302000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=339000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -18,8 +18,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
@@ -35,8 +35,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -19,8 +19,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
@@ -36,8 +36,8 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=303000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000


### PR DESCRIPTION
Motivation:

NIO 2.26.0 saved us some allocations, some of our limits are now too
high and CI fails as a result.

Modifications:

Adjust the allocation counter limits.

Result:

CI passes.