### PR TITLE
Add sync option support to HTTP2StreamChannel

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0")
     ],
     targets: [
         .target(name: "NIOHTTP2Server",

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -344,31 +344,31 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     }
 
     func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> EventLoopFuture<Void> {
-        if eventLoop.inEventLoop {
+        if self.eventLoop.inEventLoop {
             do {
-                return eventLoop.makeSucceededFuture(try setOption0(option, value: value))
+                return self.eventLoop.makeSucceededFuture(try self.setOption0(option, value: value))
             } catch {
-                return eventLoop.makeFailedFuture(error)
+                return self.eventLoop.makeFailedFuture(error)
             }
         } else {
-            return eventLoop.submit { try self.setOption0(option, value: value) }
+            return self.eventLoop.submit { try self.setOption0(option, value: value) }
         }
     }
 
     public func getOption<Option: ChannelOption>(_ option: Option) -> EventLoopFuture<Option.Value> {
-        if eventLoop.inEventLoop {
+        if self.eventLoop.inEventLoop {
             do {
-                return eventLoop.makeSucceededFuture(try getOption0(option))
+                return self.eventLoop.makeSucceededFuture(try self.getOption0(option))
             } catch {
-                return eventLoop.makeFailedFuture(error)
+                return self.eventLoop.makeFailedFuture(error)
             }
         } else {
-            return eventLoop.submit { try self.getOption0(option) }
+            return self.eventLoop.submit { try self.getOption0(option) }
         }
     }
 
     private func setOption0<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.preconditionInEventLoop()
 
         switch option {
         case _ as ChannelOptions.Types.AutoReadOption:
@@ -379,7 +379,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     }
 
     private func getOption0<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
-        assert(eventLoop.inEventLoop)
+        self.eventLoop.preconditionInEventLoop()
 
         switch option {
         case _ as HTTP2StreamChannelOptions.Types.StreamIDOption:
@@ -876,5 +876,34 @@ extension HTTP2StreamChannel {
 extension HTTP2StreamChannel {
     public var description: String {
         return "HTTP2StreamChannel(streamID: \(String(describing: self.streamID)), isActive: \(self.isActive), isWritable: \(self.isWritable))"
+    }
+}
+
+extension HTTP2StreamChannel {
+    internal struct SynchronousOptions: NIOSynchronousChannelOptions {
+        private let channel: HTTP2StreamChannel
+
+        fileprivate init(channel: HTTP2StreamChannel) {
+            self.channel = channel
+        }
+
+        /// Set `option` to `value` on this `Channel`.
+        ///
+        /// - Important: Must be called on the `EventLoop` the `Channel` is running on.
+        public func setOption<Option: ChannelOption>(_ option: Option, value: Option.Value) throws {
+            try self.channel.setOption0(option, value: value)
+        }
+
+        /// Get the value of `option` for this `Channel`.
+        ///
+        /// - Important: Must be called on the `EventLoop` the `Channel` is running on.
+        public func getOption<Option: ChannelOption>(_ option: Option) throws -> Option.Value {
+            return try self.channel.getOption0(option)
+        }
+    }
+
+    /// Returns a view of the `Channel` exposing synchronous versions of `setOption` and `getOption`.
+    public var syncOptions: NIOSynchronousChannelOptions? {
+        return SynchronousOptions(channel: self)
     }
 }

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
@@ -77,6 +77,7 @@ extension HTTP2FramePayloadStreamMultiplexerTests {
                 ("testReadWhenUsingAutoreadOnChildChannel", testReadWhenUsingAutoreadOnChildChannel),
                 ("testWindowUpdateIsNotEmittedAfterStreamIsClosed", testWindowUpdateIsNotEmittedAfterStreamIsClosed),
                 ("testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame", testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame),
+                ("testStreamChannelSupportsSyncOptions", testStreamChannelSupportsSyncOptions),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

SwiftNIO 2.27.0 added support for synchronous channel options allowing
callers to get options synchronously -- saving a future allocation -- if
they know they're on the correct event loop. 'HTTP2StreamChannel' should
support this.

Modifications:

- Add 'HTTP2StreamChannel.SynchronousOptions' with conformance to
  'NIOSynchronousChannelOptions'

Result:

Callers can get and set options synchronously on 'HTTP2StreamChannel'