### PR TITLE
Use sync options when creating a stream channel

### DIFF
--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
@@ -197,14 +197,6 @@ fileprivate class TestServer: ChannelInboundHandler {
 }
 
 func run(identifier: String) {
-    var noninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1)
-
-    measure(identifier: identifier + "_noninterleaved") {
-        return try! noninterleaved.run()
-    }
-
-    noninterleaved.tearDown()
-
     var interleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100)
 
     measure(identifier: identifier + "_interleaved") {
@@ -212,4 +204,12 @@ func run(identifier: String) {
     }
 
     interleaved.tearDown()
+
+    var noninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1)
+
+    measure(identifier: identifier + "_noninterleaved") {
+        return try! noninterleaved.run()
+    }
+
+    noninterleaved.tearDown()
 }

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0")
     ],
     targets: [
         .target(name: "NIOHTTP2Server",

--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=336000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=300000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=306000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 
   performance-test:
     image: swift-nio-http2:16.04-5.1
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:16.04-5.1
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=336000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=300000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=306000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=342000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=56000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=55000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=60000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=359000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=59000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=330000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=365000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=425000
 
   performance-test:
     image: swift-nio-http2:18.04-5.0
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.0
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=62000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=60000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=359000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=59000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=330000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=365000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=63000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=62000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=455000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=425000
 
   shell:
     image: swift-nio-http2:18.04-5.0

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=52000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=51000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=333000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=302000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=339000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 
   performance-test:
     image: swift-nio-http2:18.04-5.2
@@ -33,14 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.2
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=52000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=51000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=333000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=302000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=339000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=55000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=54000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=384000
-
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 
   shell:
     image: swift-nio-http2:18.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -16,13 +16,13 @@ services:
   integration-tests:
     image: swift-nio-http2:18.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
   performance-test:
     image: swift-nio-http2:18.04-5.3
@@ -33,13 +33,13 @@ services:
   test:
     image: swift-nio-http2:18.04-5.3
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
   shell:
     image: swift-nio-http2:18.04-5.3

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -17,13 +17,13 @@ services:
   integration-tests:
     image: swift-nio-http2:20.04-5.4
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
   performance-test:
     image: swift-nio-http2:20.04-5.4
@@ -34,13 +34,13 @@ services:
   test:
     image: swift-nio-http2:20.04-5.4
     environment:
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=58000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=338000
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=364000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
   shell:
     image: swift-nio-http2:20.04-5.4


### PR DESCRIPTION
Motivation:

SwiftNIO 2.27.0 added synchronous channel options. We can use these if
available when creating a stream channel to avoid a future allocation.

Modifications:

- 'getAutoReadFromParent' is synchronous when possible and now takes a
  closure to handle the result.
- Update allocation counts (and sort them to make updating them easier,
  this also includes switching the order we run test_1k_requests
  interleaved and noninterleaved)

Result:

Fewer allocations.