### PR TITLE
Stop using deprecated API in allocation counting tests

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,8 +19,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=336000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=300000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 
@@ -36,8 +36,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=53000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=52000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=336000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=300000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=301000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
       - SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -20,7 +20,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=359000
       - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=59000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=53000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=425000
 
@@ -37,7 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=59000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=359000
       - MAX_ALLOCS_ALLOWED_client_server_request_response=324000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=59000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=53000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=425000
 

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -19,8 +19,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=52000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=51000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=333000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=297000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 
@@ -36,8 +36,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=52000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=51000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=333000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=297000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=354000
 

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -19,8 +19,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
@@ -36,8 +36,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -20,8 +20,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
@@ -37,8 +37,8 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=295000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=55000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 


### PR DESCRIPTION
Motivation:

Some of the allocation counting tests used frame-based stream channels
rather than the frame payload based ones. These were deprecated some
time ago.

Modifications:

- Update test handlers to be `HTTP2Frame.FramePayload` based
- Update the 'create_client_stream_channel' test to count streams rather
  than summing their stream ID (as stream IDs aren't assigned until the
  stream channel delivers pending writes for the first time).
- Update allocation limits

Result:

Allocation counting tests don't use deprecated APIs.