### PR TITLE
Update our allocation counter numbers.

### DIFF
--- a/dev/alloc-limits-from-test-output
+++ b/dev/alloc-limits-from-test-output
@@ -1,0 +1,88 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# This script allows you to consume any Jenkins/alloc counter run output and
+# convert it into the right for for the docker-compose script.
+
+set -eu
+
+mode_flag=${1---docker-compose}
+
+function usage() {
+    echo >&1 "Usage: $0 [--docker-compose|--export]"
+    echo >&1
+    echo >&1 "Example:"
+    echo >&1 "  # copy the output from the Jenkins CI into your clipboard, then"
+    echo >&1 "  pbpaste | $0 --docker-compose"
+}
+
+function die() {
+    echo >&2 "ERROR: $*"
+    exit 1
+}
+
+case "$mode_flag" in
+    --docker-compose)
+        mode=docker
+        ;;
+    --export)
+        mode=export
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+
+function allow_slack() {
+    raw="$1"
+    if [[ ! "$raw" =~ ^[0-9]+$ ]]; then
+        die "not a malloc count: '$raw'"
+    fi
+    if [[ "$raw" -lt 1000 ]]; then
+        echo "$raw"
+        return
+    fi
+
+    allocs=$raw
+    while true; do
+        allocs=$(( allocs + 1 ))
+        if [[ "$allocs" =~ [0-9]+00$ || "$allocs" =~ [0-9]+50$ ]]; then
+            echo "$allocs"
+            return
+        fi
+    done
+}
+
+grep -e "total number of mallocs" -e ".total_allocations" -e "export MAX_ALLOCS_ALLOWED_" | \
+    sed -e "s/: total number of mallocs: /=/g" \
+        -e "s/.total_allocations: /=/g" \
+        -e "s/info: /test_/g" \
+        -e "s/export MAX_ALLOCS_ALLOWED_/test_/g" | \
+    grep -Eo 'test_[a-zA-Z0-9_-]+=[0-9]+' | sort | uniq | while read info; do
+    test_name=$(echo "$info" | sed "s/test_//g" | cut -d= -f1 )
+    allocs=$(allow_slack "$(echo "$info" | cut -d= -f2 | sed "s/ //g")")
+    case "$mode" in
+        docker)
+            echo "      - MAX_ALLOCS_ALLOWED_$test_name=$allocs"
+            ;;
+        export)
+            echo "export MAX_ALLOCS_ALLOWED_$test_name=$allocs"
+            ;;
+        *)
+            die "Unexpected mode: $mode"
+            ;;
+    esac
+done

--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -1,0 +1,47 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+set -o pipefail
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio-http2-2-"}
+target_repo=${2-"$here/.."}
+tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
+
+for f in swift51 swift52 swift53 swift54 swift55 nightly; do
+    echo "$f"
+    url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
+    stripped=${f#"swift"}
+    echo "$url"
+    curl -s "$url" | "$here/alloc-limits-from-test-output" > "$tmpdir/limits$stripped"
+
+    if [[ "$(wc -l < "$tmpdir/limits$stripped")" -lt 5 ]]; then
+        echo >&2 "ERROR: fewer than 5 limits found, something's not right"
+        exit 1
+    fi
+
+
+    docker_file=$(if [[ "$stripped" == "nightly" ]]; then stripped=main; fi && ls "$target_repo/docker/docker-compose."*"$stripped"*".yaml")
+
+    echo "$docker_file"
+    cat "$tmpdir/limits$stripped"
+    cat "$docker_file" | grep -v MAX_ALLOCS_ALLOWED | grep -B10000 "^    environment:" > "$tmpdir/pre$stripped"
+    cat "$docker_file" | grep -v MAX_ALLOCS_ALLOWED | grep -A10000 "^    environment:" | sed 1d > "$tmpdir/post$stripped"
+    cat "$tmpdir/pre$stripped" "$tmpdir/limits$stripped" "$tmpdir/post$stripped" > "$docker_file"
+done
+
+rm -rf "$tmpdir"

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -24,14 +24,6 @@ services:
 
   test:
     image: swift-nio-http2:18.04-5.0
-    environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=59150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=58100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=351000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=316000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=52050
-      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=423800
 
   shell:
     image: swift-nio-http2:18.04-5.0

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -15,14 +15,6 @@ services:
 
   integration-tests:
     image: swift-nio-http2:20.04-5.5
-    environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
-      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
 
   performance-test:
     image: swift-nio-http2:20.04-5.5
@@ -33,13 +25,13 @@ services:
   test:
     image: swift-nio-http2:20.04-5.5
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=50000
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=49000
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=332000
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=296000
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=49000
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=49150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=48100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=324000
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=288000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=48050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=334000
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=333200
 
   shell:
     image: swift-nio-http2:20.04-5.5


### PR DESCRIPTION
Motivation:

Our 5.5 allocation counts were off. Rather than just update that by hand
we should bring over some tooling to do it automatically.

Modifications:

- Bring over and adapt the update-alloc-limits scripts from NIO.
- Run them and commit the updates.

Result:

CI should pass again.