### PR TITLE
HTTP2ToHTTP1Codec: Fix receiving empty .body before .end

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -63,10 +63,14 @@ fileprivate struct BaseClientCodec {
                 preconditionFailure("Received DATA frame with non-bytebuffer IOData")
             }
 
-            let first = HTTPClientResponsePart.body(b)
+            var first = HTTPClientResponsePart.body(b)
             var second: HTTPClientResponsePart? = nil
             if content.endStream {
-                second = .end(nil)
+                if b.readableBytes == 0 {
+                    first = .end(nil)
+                } else {
+                    second = .end(nil)
+                }
             }
             return (first: first, second: second)
         case .alternativeService, .rstStream, .priority, .windowUpdate, .settings, .pushPromise, .ping, .goAway, .origin:
@@ -262,10 +266,14 @@ fileprivate struct BaseServerCodec {
             guard case .byteBuffer(let b) = dataContent.data else {
                 preconditionFailure("Received non-byteBuffer IOData from network")
             }
-            let first = HTTPServerRequestPart.body(b)
+            var first = HTTPServerRequestPart.body(b)
             var second: HTTPServerRequestPart? = nil
             if dataContent.endStream {
-                second = .end(nil)
+                if b.readableBytes == 0 {
+                    first = .end(nil)
+                } else {
+                    second = .end(nil)
+                }
             }
             return (first: first, second: second)
         default:

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
@@ -61,6 +61,8 @@ extension HTTP2FramePayloadToHTTP1CodecTests {
                 ("testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses", testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses),
                 ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests),
                 ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses),
+                ("testServerSideWithEmptyFinalPackage", testServerSideWithEmptyFinalPackage),
+                ("testClientSideWithEmptyFinalPackage", testClientSideWithEmptyFinalPackage),
            ]
    }
 }


### PR DESCRIPTION
### Motivation

Currently if a peer sends an empty `dataPayload` that signals the stream's end, the HTTP2ToHTTP1Codec will issue a HTTP1 `.body` with an empty `ByteBuffer` and an HTTP1 `.end`. The HTTP1 `.body` with the empty byte buffer can be saved.

### Changes

The `BaseClientCodec` was changed in such a way, that an empty `dataPayload` that signals the stream's end, will only create a HTTP1 `.end`.

### Result

Fewer empty `byteBuffer`s.