### PR TITLE
Use non-deprecated API for removing handlers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0")
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0")
     ],
     targets: [
         .target(

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -605,7 +605,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         self.pipeline.fireChannelInactive()
 
         self.eventLoop.execute {
-            self.removeHandlers(channel: self)
+            self.removeHandlers(pipeline: self.pipeline)
             self.closePromise.succeed(())
             if let streamID = self.streamID {
                 self.multiplexer.childChannelClosed(streamID: streamID)
@@ -630,7 +630,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         self.pipeline.fireChannelInactive()
 
         self.eventLoop.execute {
-            self.removeHandlers(channel: self)
+            self.removeHandlers(pipeline: self.pipeline)
             self.closePromise.fail(error)
             if let streamID = self.streamID {
                 self.multiplexer.childChannelClosed(streamID: streamID)


### PR DESCRIPTION
### Motivation:

removeHandlers(channel:) was deprecated in NIO 2.32.0.

### Modifications:

- Raise minimum required NIO version to 2.32.0
- Use removeHandlers(pipeline:)

### Result:

We don't use deprecated API.