### PR TITLE
Improve performance of `HPACKHeaders.subscript(canonicalForm:)`

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -467,24 +467,32 @@ internal extension UInt8 {
 }
 
 /* private but inlinable */
-internal extension Character {
+internal extension UTF8.CodeUnit {
     @inlinable
     var isASCIIWhitespace: Bool {
-        return self == " " || self == "\t" || self == "\r" || self == "\n" || self == "\r\n"
+        switch self {
+        case UInt8(ascii: " "),
+             UInt8(ascii: "\t"),
+             UInt8(ascii: "\r"),
+             UInt8(ascii: "\n"):
+            return true
+        default:
+            return false
+        }
     }
 }
 
 extension Substring {
     @inlinable
     func _trimWhitespace() -> Substring {
-        var me = self
-        while me.first?.isASCIIWhitespace == .some(true) {
-            me = me.dropFirst()
+        guard let firstNonWhitespace = self.utf8.firstIndex(where: { !$0.isASCIIWhitespace }) else {
+           // The whole substring is ASCII whitespace.
+           return Substring()
         }
-        while me.last?.isASCIIWhitespace == .some(true) {
-            me = me.dropLast()
-        }
-        return me
+
+        // There must be at least one non-ascii whitespace character, so banging here is safe.
+        let lastNonWhitespace = self.utf8.lastIndex(where: { !$0.isASCIIWhitespace })!
+        return Substring(self.utf8[firstNonWhitespace...lastNonWhitespace])
     }
 }
 

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -35,6 +35,7 @@ extension HPACKCodingTests {
                 ("testInlineDynamicTableResize", testInlineDynamicTableResize),
                 ("testHPACKHeadersDescription", testHPACKHeadersDescription),
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
+                ("testHPACKHeadersCanonicalFormStripsWhitespace", testHPACKHeadersCanonicalFormStripsWhitespace),
                 ("testHPACKHeadersFirst", testHPACKHeadersFirst),
                 ("testHPACKHeadersExpressedByDictionaryLiteral", testHPACKHeadersExpressedByDictionaryLiteral),
                 ("testHPACKHeadersAddingSequenceOfPairs", testHPACKHeadersAddingSequenceOfPairs),

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -571,6 +571,21 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["abcdefg,hijklmn,opqrst"])
     }
 
+    func testHPACKHeadersCanonicalFormStripsWhitespace() throws {
+        let headers: HPACKHeaders = [
+            "no-whitespace": "foo,bar",
+            "sp": " foo ,  bar  ",
+            "htab": "\tfoo\t,\t\tbar\t\t",
+            "sp-and-htab": " \t foo  \t\t,\t bar\t "
+        ]
+
+        let expected = ["foo", "bar"]
+        XCTAssertEqual(headers[canonicalForm: "no-whitespace"], expected)
+        XCTAssertEqual(headers[canonicalForm: "sp"], expected)
+        XCTAssertEqual(headers[canonicalForm: "htab"], expected)
+        XCTAssertEqual(headers[canonicalForm: "sp-and-htab"], expected)
+    }
+
     func testHPACKHeadersFirst() throws {
         let headers = HPACKHeaders([
             (":method", "GET"),


### PR DESCRIPTION
Motivation:

When getting the canonical form of header values any ascii whitespace
is stripped from the values. The current implementation does this by
doing equality checks on Character and dropping them from a Substring.

Modifications:

- Update the Substring._trimWhitespace() function to trim on a UTF8 view
- Add test

Result:

Retrieving the canonical form of header values is cheaper, significantly
so when values contain a lot of leading or trailing whitespace.