### PR TITLE
Don't count CR or LF as whitespace when trimming whitespace from header values

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -472,9 +472,7 @@ internal extension UTF8.CodeUnit {
     var isASCIIWhitespace: Bool {
         switch self {
         case UInt8(ascii: " "),
-             UInt8(ascii: "\t"),
-             UInt8(ascii: "\r"),
-             UInt8(ascii: "\n"):
+             UInt8(ascii: "\t"):
             return true
         default:
             return false


### PR DESCRIPTION
Motivation:

The OWS rule from the HTTP semantics draft only considers 'SP' and
'HTAB' to be whitespace. We also (unnecessarily) consider CR and LF to
be whitespace.

Modifications:

- Remove CR and LF from the characters we consider to be whitespace
- Update tests

Result:

We no longer consider CR or LF to be whitespace when trimming
whitespace when producing the canonical form of header values.