### PR TITLE
Ignore empty values when returning canonical form of header values

### DIFF
--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -36,6 +36,7 @@ extension HPACKCodingTests {
                 ("testHPACKHeadersDescription", testHPACKHeadersDescription),
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
                 ("testHPACKHeadersCanonicalFormStripsWhitespace", testHPACKHeadersCanonicalFormStripsWhitespace),
+                ("testHPACKHeadersCanonicalFormDropsEmptyStrings", testHPACKHeadersCanonicalFormDropsEmptyStrings),
                 ("testHPACKHeadersFirst", testHPACKHeadersFirst),
                 ("testHPACKHeadersExpressedByDictionaryLiteral", testHPACKHeadersExpressedByDictionaryLiteral),
                 ("testHPACKHeadersAddingSequenceOfPairs", testHPACKHeadersAddingSequenceOfPairs),

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -586,6 +586,16 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqual(headers[canonicalForm: "sp-and-htab"], expected)
     }
 
+    func testHPACKHeadersCanonicalFormDropsEmptyStrings() throws {
+        let headers: HPACKHeaders = [
+            "no-whitespace": "foo,,bar",
+            "with-whitespace": "foo, ,bar"
+        ]
+        let expected = ["foo", "bar"]
+        XCTAssertEqual(headers[canonicalForm: "no-whitespace"], expected)
+        XCTAssertEqual(headers[canonicalForm: "with-whitespace"], expected)
+    }
+
     func testHPACKHeadersFirst() throws {
         let headers = HPACKHeaders([
             (":method", "GET"),


### PR DESCRIPTION
Motivation:

The return value from `HPACKHeaders.subscript(canonicalForm:)` is
inconsistent with respect to returning empty strings.

If a value for a header field is an empty string then the canonical form
will not return that empty string. However, if a value is a string
containing only whitespace then an empty string will be returned.

Modifications:

- Filter out empty substrings after trimming whitespace
- Add a test

Result:

- `HPACKHeaders.subscript(canonicalForm:)` does not produce empty strings