### PR TITLE
Use case-insensitive comparision rather than lowercasing

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -256,7 +256,7 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral {
         }
 
         // It's not safe to split Set-Cookie on comma.
-        guard name.lowercased() != "set-cookie" else {
+        if name.isEqualCaseInsensitiveASCIIBytes(to: "set-cookie") {
             return result
         }
 

--- a/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests+XCTest.swift
@@ -37,6 +37,7 @@ extension HPACKCodingTests {
                 ("testHPACKHeadersSubscript", testHPACKHeadersSubscript),
                 ("testHPACKHeadersCanonicalFormStripsWhitespace", testHPACKHeadersCanonicalFormStripsWhitespace),
                 ("testHPACKHeadersCanonicalFormDropsEmptyStrings", testHPACKHeadersCanonicalFormDropsEmptyStrings),
+                ("testHPACKHeadersCanonicalFormSetCookie", testHPACKHeadersCanonicalFormSetCookie),
                 ("testHPACKHeadersFirst", testHPACKHeadersFirst),
                 ("testHPACKHeadersExpressedByDictionaryLiteral", testHPACKHeadersExpressedByDictionaryLiteral),
                 ("testHPACKHeadersAddingSequenceOfPairs", testHPACKHeadersAddingSequenceOfPairs),

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -17,7 +17,7 @@ import NIOCore
 @testable import NIOHPACK
 
 class HPACKCodingTests: XCTestCase {
-    
+
     let allocator = ByteBufferAllocator()
 
     private func buffer<C: Collection>(wrapping bytes: C) -> ByteBuffer where C.Element == UInt8 {
@@ -25,14 +25,14 @@ class HPACKCodingTests: XCTestCase {
         buffer.writeBytes(bytes)
         return buffer
     }
-    
+
     // HPACK RFC7541 § C.3
     // http://httpwg.org/specs/rfc7541.html#request.examples.without.huffman.coding
     func testRequestHeadersWithoutHuffmanCoding() throws {
         var request1 = buffer(wrapping: [0x82, 0x86, 0x84, 0x41, 0x0f, 0x77, 0x77, 0x77, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d])
         var request2 = buffer(wrapping: [0x82, 0x86, 0x84, 0xbe, 0x58, 0x08, 0x6e, 0x6f, 0x2d, 0x63, 0x61, 0x63, 0x68, 0x65])
         var request3 = buffer(wrapping: [0x82, 0x87, 0x85, 0xbf, 0x40, 0x0a, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x6b, 0x65, 0x79, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x2d, 0x76, 0x61, 0x6c, 0x75, 0x65])
-        
+
         let headers1 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "http"),
@@ -53,21 +53,21 @@ class HPACKCodingTests: XCTestCase {
             (":authority", "www.example.com"),
             ("custom-key", "custom-value")
         ])
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator())
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded1 = try decoder.decodeHeaders(from: &request1)
         XCTAssertEqual(decoded1, headers1)
         XCTAssertEqual(decoder.dynamicTableLength, 57)
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 62))
-        
+
         let decoded2 = try decoder.decodeHeaders(from: &request2)
         XCTAssertEqual(decoded2, headers2)
         XCTAssertEqual(decoder.dynamicTableLength, 110)
         XCTAssertEqualTuple(headers2[4], try decoder.headerTable.header(at: 62))
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 63))
-        
+
         let decoded3 = try decoder.decodeHeaders(from: &request3)
         XCTAssertEqual(decoded3, headers3)
         XCTAssertEqual(decoder.dynamicTableLength, 164)
@@ -75,14 +75,14 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers2[4], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 64))
     }
-    
+
     // HPACK RFC7541 § C.4
     // http://httpwg.org/specs/rfc7541.html#request.examples.with.huffman.coding
     func testRequestHeadersWithHuffmanCoding() throws {
         var request1 = buffer(wrapping: [0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
         var request2 = buffer(wrapping: [0x82, 0x86, 0x84, 0xbe, 0x58, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c, 0xbf])
         var request3 = buffer(wrapping: [0x82, 0x87, 0x85, 0xbf, 0x40, 0x88, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xa9, 0x7d, 0x7f, 0x89, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xb8, 0xe8, 0xb4, 0xbf])
-        
+
         let headers1 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "http"),
@@ -103,22 +103,22 @@ class HPACKCodingTests: XCTestCase {
             (":authority", "www.example.com"),
             ("custom-key", "custom-value")
         ])
-        
+
         var encoder = HPACKEncoder(allocator: allocator)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers1)
         XCTAssertEqual(try encoder.endEncoding(), request1)
         XCTAssertEqual(encoder.headerIndexTable.dynamicTableLength, 57)
         XCTAssertEqualTuple(headers1[3], try encoder.headerIndexTable.header(at: 62))
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers2)
         XCTAssertEqual(try encoder.endEncoding(), request2)
         XCTAssertEqual(encoder.headerIndexTable.dynamicTableLength, 110)
         XCTAssertEqualTuple(headers2[4], try encoder.headerIndexTable.header(at: 62))
         XCTAssertEqualTuple(headers1[3], try encoder.headerIndexTable.header(at: 63))
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers3)
         XCTAssertEqual(try encoder.endEncoding(), request3)
@@ -126,21 +126,21 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers3[4], try encoder.headerIndexTable.header(at: 62))
         XCTAssertEqualTuple(headers2[4], try encoder.headerIndexTable.header(at: 63))
         XCTAssertEqualTuple(headers1[3], try encoder.headerIndexTable.header(at: 64))
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator())
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded1 = try decoder.decodeHeaders(from: &request1)
         XCTAssertEqual(decoded1, headers1)
         XCTAssertEqual(decoder.dynamicTableLength, 57)
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 62))
-        
+
         let decoded2 = try decoder.decodeHeaders(from: &request2)
         XCTAssertEqual(decoded2, headers2)
         XCTAssertEqual(decoder.dynamicTableLength, 110)
         XCTAssertEqualTuple(headers2[4], try decoder.headerTable.header(at: 62))
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 63))
-        
+
         let decoded3 = try decoder.decodeHeaders(from: &request3)
         XCTAssertEqual(decoded3, headers3)
         XCTAssertEqual(decoder.dynamicTableLength, 164)
@@ -148,7 +148,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers2[4], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 64))
     }
-    
+
     // HPACK RFC7541 § C.5
     // http://httpwg.org/specs/rfc7541.html#response.examples.without.huffman.coding
     func testResponseHeadersWithoutHuffmanCoding() throws {
@@ -186,7 +186,7 @@ class HPACKCodingTests: XCTestCase {
             // set-cookie: foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1
             0x77, 0x38, 0x66, 0x6f, 0x6f, 0x3d, 0x41, 0x53, 0x44, 0x4a, 0x4b, 0x48, 0x51, 0x4b, 0x42, 0x5a, 0x58, 0x4f, 0x51, 0x57, 0x45, 0x4f, 0x50, 0x49, 0x55, 0x41, 0x58, 0x51, 0x57, 0x45, 0x4f, 0x49, 0x55, 0x3b, 0x20, 0x6d, 0x61, 0x78, 0x2d, 0x61, 0x67, 0x65, 0x3d, 0x33, 0x36, 0x30, 0x30, 0x3b, 0x20, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x3d, 0x31
         ])
-        
+
         let headers1 = HPACKHeaders([
             (":status", "302"),
             ("cache-control", "private"),
@@ -207,10 +207,10 @@ class HPACKCodingTests: XCTestCase {
             ("content-encoding", "gzip"),
             ("set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1")
         ])
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator(), maxDynamicTableSize: 256)
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded1 = try decoder.decodeHeaders(from: &response1)
         XCTAssertEqual(decoded1, headers1)
         XCTAssertEqual(decoder.dynamicTableLength, 222)
@@ -218,7 +218,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[2], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[1], try decoder.headerTable.header(at: 64))
         XCTAssertEqualTuple(headers1[0], try decoder.headerTable.header(at: 65))
-        
+
         let decoded2 = try decoder.decodeHeaders(from: &response2)
         XCTAssertEqual(decoded2, headers2)
         XCTAssertEqual(decoder.dynamicTableLength, 222)
@@ -226,7 +226,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[2], try decoder.headerTable.header(at: 64))
         XCTAssertEqualTuple(headers1[1], try decoder.headerTable.header(at: 65))
-        
+
         let decoded3 = try decoder.decodeHeaders(from: &response3)
         XCTAssertEqual(decoded3, headers3)
         XCTAssertEqual(decoder.dynamicTableLength, 215)
@@ -234,7 +234,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers3[4], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers3[2], try decoder.headerTable.header(at: 64))
     }
-    
+
     // HPACK RFC7541 § C.6
     // http://httpwg.org/specs/rfc7541.html#response.examples.with.huffman.coding
     func testResponseHeadersWithHuffmanCoding() throws {
@@ -247,7 +247,7 @@ class HPACKCodingTests: XCTestCase {
         var response3 = buffer(wrapping: [
             0x88, 0xc1, 0x61, 0x96, 0xd0, 0x7a, 0xbe, 0x94, 0x10, 0x54, 0xd4, 0x44, 0xa8, 0x20, 0x05, 0x95, 0x04, 0x0b, 0x81, 0x66, 0xe0, 0x84, 0xa6, 0x2d, 0x1b, 0xff, 0xc0, 0x5a, 0x83, 0x9b, 0xd9, 0xab, 0x77, 0xad, 0x94, 0xe7, 0x82, 0x1d, 0xd7, 0xf2, 0xe6, 0xc7, 0xb3, 0x35, 0xdf, 0xdf, 0xcd, 0x5b, 0x39, 0x60, 0xd5, 0xaf, 0x27, 0x08, 0x7f, 0x36, 0x72, 0xc1, 0xab, 0x27, 0x0f, 0xb5, 0x29, 0x1f, 0x95, 0x87, 0x31, 0x60, 0x65, 0xc0, 0x03, 0xed, 0x4e, 0xe5, 0xb1, 0x06, 0x3d, 0x50, 0x07
         ])
-        
+
         let headers1 = HPACKHeaders([
             (":status", "302"),
             ("cache-control", "private"),
@@ -268,9 +268,9 @@ class HPACKCodingTests: XCTestCase {
             ("content-encoding", "gzip"),
             ("set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1")
         ])
-        
+
         var encoder = HPACKEncoder(allocator: allocator)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers1)
         XCTAssertEqual(try encoder.endEncoding(), response1)
@@ -278,7 +278,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[2], try encoder.headerIndexTable.header(at: 63))
         XCTAssertEqualTuple(headers1[1], try encoder.headerIndexTable.header(at: 64))
         XCTAssertEqualTuple(headers1[0], try encoder.headerIndexTable.header(at: 65))
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers2)
         XCTAssertEqual(try encoder.endEncoding(), response2)
@@ -286,17 +286,17 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[3], try encoder.headerIndexTable.header(at: 63))
         XCTAssertEqualTuple(headers1[2], try encoder.headerIndexTable.header(at: 64))
         XCTAssertEqualTuple(headers1[1], try encoder.headerIndexTable.header(at: 65))
-        
+
         try encoder.beginEncoding(allocator: allocator)
         try encoder.append(headers: headers3)
         XCTAssertEqual(try encoder.endEncoding(), response3)
         XCTAssertEqualTuple(headers3[5], try encoder.headerIndexTable.header(at: 62))
         XCTAssertEqualTuple(headers3[4], try encoder.headerIndexTable.header(at: 63))
         XCTAssertEqualTuple(headers3[2], try encoder.headerIndexTable.header(at: 64))
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator(), maxDynamicTableSize: 256)
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded1 = try decoder.decodeHeaders(from: &response1)
         XCTAssertEqual(decoded1, headers1)
         XCTAssertEqual(decoder.dynamicTableLength, 222)
@@ -304,7 +304,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[2], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[1], try decoder.headerTable.header(at: 64))
         XCTAssertEqualTuple(headers1[0], try decoder.headerTable.header(at: 65))
-        
+
         let decoded2 = try decoder.decodeHeaders(from: &response2)
         XCTAssertEqual(decoded2, headers2)
         XCTAssertEqual(decoder.dynamicTableLength, 222)
@@ -312,7 +312,7 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers1[2], try decoder.headerTable.header(at: 64))
         XCTAssertEqualTuple(headers1[1], try decoder.headerTable.header(at: 65))
-        
+
         let decoded3 = try decoder.decodeHeaders(from: &response3)
         XCTAssertEqual(decoded3, headers3)
         XCTAssertEqual(decoder.dynamicTableLength, 215)
@@ -320,12 +320,12 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertEqualTuple(headers3[4], try decoder.headerTable.header(at: 63))
         XCTAssertEqualTuple(headers3[2], try decoder.headerTable.header(at: 64))
     }
-    
+
     func testNonIndexedRequest() throws {
         var request1 = buffer(wrapping: [0x82, 0x86, 0x84, 0x01, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
         var request2 = buffer(wrapping: [0x82, 0x86, 0x84, 0x01, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff, 0x0f, 0x09, 0x86, 0xa8, 0xeb, 0x10, 0x64, 0x9c, 0xbf, 0x00, 0x88, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xa9, 0x7d, 0x7f, 0x89, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xb8, 0xe8, 0xb4, 0xbf])
         var request3 = buffer(wrapping: [0x82, 0x87, 0x85, 0x11, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff, 0x10, 0x88, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xa9, 0x7d, 0x7f, 0x89, 0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xb8, 0xe8, 0xb4, 0xbf])
-        
+
         let headers1 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "http"),
@@ -333,22 +333,22 @@ class HPACKCodingTests: XCTestCase {
         ])
         let h1NoIndex = (name: ":authority", value: "www.example.com")
         let h2NoIndex = (name: "cache-control", value: "no-cache")
-        
+
         let headers3 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "https"),
             (":path", "/index.html")
         ])
         let h3NeverIndex = (name: "custom-key", value: "custom-value")
-        
+
         var encoder = HPACKEncoder(allocator: allocator)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         XCTAssertNoThrow(try encoder.append(headers: headers1))
         try encoder.appendNonIndexed(header: h1NoIndex.name, value: h1NoIndex.value)
         XCTAssertEqual(try encoder.endEncoding(), request1)
         XCTAssertEqual(encoder.headerIndexTable.dynamicTableLength, 0)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         XCTAssertNoThrow(try encoder.append(headers: headers1))
         try encoder.appendNonIndexed(header: h1NoIndex.name, value: h1NoIndex.value)
@@ -356,17 +356,17 @@ class HPACKCodingTests: XCTestCase {
         try encoder.appendNonIndexed(header: h3NeverIndex.name, value: h3NeverIndex.value)
         XCTAssertEqual(try encoder.endEncoding(), request2)
         XCTAssertEqual(encoder.headerIndexTable.dynamicTableLength, 0)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         XCTAssertNoThrow(try encoder.append(headers: headers3))
         try encoder.appendNeverIndexed(header: h1NoIndex.name, value: h1NoIndex.value)
         try encoder.appendNeverIndexed(header: h3NeverIndex.name, value: h3NeverIndex.value)
         XCTAssertEqual(try encoder.endEncoding(), request3)
         XCTAssertEqual(encoder.headerIndexTable.dynamicTableLength, 0)
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator())
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let fullHeaders1 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "http"),
@@ -388,38 +388,38 @@ class HPACKCodingTests: XCTestCase {
             (":authority", "www.example.com"),
             ("custom-key", "custom-value")
         ])
-        
+
         let decoded1 = try decoder.decodeHeaders(from: &request1)
         XCTAssertEqual(decoded1, fullHeaders1)
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded2 = try decoder.decodeHeaders(from: &request2)
         XCTAssertEqual(decoded2, fullHeaders2)
         XCTAssertEqual(decoder.dynamicTableLength, 0)
-        
+
         let decoded3 = try decoder.decodeHeaders(from: &request3)
         XCTAssertEqual(decoded3, fullHeaders3)
         XCTAssertEqual(decoder.dynamicTableLength, 0)
     }
-    
+
     func testInlineDynamicTableResize() throws {
         var request1 = buffer(wrapping: [0x3f, 0x32, 0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
         let request2 = buffer(wrapping: [0x3f, 0x21, 0x3f, 0x32, 0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
         var request3 = buffer(wrapping: [0x3f, 0xe1, 0x20, 0x82, 0x86, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
         var request4 = buffer(wrapping: [0x82, 0x86, 0x3f, 0x32, 0x84, 0x41, 0x8c, 0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a, 0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff])
-        
+
         let headers1 = HPACKHeaders([
             (":method", "GET"),
             (":scheme", "http"),
             (":path", "/"),
             (":authority", "www.example.com")
         ])
-        
+
         let oddMaxTableSize = 81
-        
+
         var encoder = HPACKEncoder(allocator: allocator)
         XCTAssertNotEqual(encoder.allowedDynamicTableSize, oddMaxTableSize)
-        
+
         // adding these all manually to ensure our table size insert happens
         try encoder.setDynamicTableSize(oddMaxTableSize)
         try encoder.beginEncoding(allocator: allocator)
@@ -427,12 +427,12 @@ class HPACKCodingTests: XCTestCase {
         XCTAssertNoThrow(try encoder.append(header: ":scheme", value: "http"))
         XCTAssertNoThrow(try encoder.append(header: ":path", value: "/"))
         XCTAssertNoThrow(try encoder.append(header: ":authority", value: "www.example.com"))
-        
+
         XCTAssertEqual(try encoder.endEncoding(), request1)
         XCTAssertEqual(encoder.dynamicTableSize, 57)
         XCTAssertEqual(encoder.allowedDynamicTableSize, oddMaxTableSize)
         XCTAssertEqualTuple(headers1[3], try encoder.headerIndexTable.header(at: 62))
-        
+
         var decoder = HPACKDecoder(allocator: ByteBufferAllocator())
         decoder.maxDynamicTableLength = oddMaxTableSize      // not enough to store the value we expect it to eventually store, but enough for the initial run
         let decoded: HPACKHeaders
@@ -443,54 +443,54 @@ class HPACKCodingTests: XCTestCase {
             XCTFail("Failed to decode header set containing dynamic-table-resize command: \(error)")
             return
         }
-        
+
         XCTAssertEqual(decoded, headers1)
         XCTAssertEqual(decoder.maxDynamicTableLength, oddMaxTableSize)
         XCTAssertEqualTuple(headers1[3], try decoder.headerTable.header(at: 62))
-        
+
         // Now, ensure some special cases.
         request1.moveReaderIndex(to: 0) // make the data available again in our sample buffer
-        
+
         // 1 - if we try to change the size mid-buffer, it'll throw an error.
         try encoder.setDynamicTableSize(4096)
         // consume the table size change
         try encoder.beginEncoding(allocator: ByteBufferAllocator())
         _ = try encoder.endEncoding()
         encoder.headerIndexTable.dynamicTable.clear()
-        
+
         try encoder.beginEncoding(allocator: allocator)
         XCTAssertNoThrow(try encoder.append(header: ":method", value: "GET"))
         XCTAssertNoThrow(try encoder.append(header: ":scheme", value: "http"))
         XCTAssertNoThrow(try encoder.append(header: ":path", value: "/"))
         XCTAssertThrowsError(try encoder.setDynamicTableSize(oddMaxTableSize)) // should throw
         XCTAssertNoThrow(try encoder.append(header: ":authority", value: "www.example.com"))
-        
+
         // No resize information, but the rest of the block will be there
         XCTAssertEqual(try encoder.endEncoding(), request1.getSlice(at: 2, length: request1.readableBytes - 2))
-        
+
         try encoder.setDynamicTableSize(4096)
         // consume the table size change
         try encoder.beginEncoding(allocator: ByteBufferAllocator())
         _ = try encoder.endEncoding()
         encoder.headerIndexTable.dynamicTable.clear()
-        
+
         // 2 - We can set multiple sizes, and both the smallest and the latest will be sent.
         try encoder.setDynamicTableSize(64)
         try encoder.setDynamicTableSize(75)
         try encoder.setDynamicTableSize(oddMaxTableSize /* 81 */)
-        
+
         try encoder.beginEncoding(allocator: allocator)
         XCTAssertNoThrow(try encoder.append(header: ":method", value: "GET"))
         XCTAssertNoThrow(try encoder.append(header: ":scheme", value: "http"))
         XCTAssertNoThrow(try encoder.append(header: ":path", value: "/"))
         XCTAssertNoThrow(try encoder.append(header: ":authority", value: "www.example.com"))
-        
+
         XCTAssertEqual(try encoder.endEncoding(), request2)
-        
+
         // 3 - Encoder will throw if the requested size exceeds the maximum value.
         // NB: current size is 81 bytes.
         encoder.headerIndexTable.dynamicTable.clear()
-        
+
         XCTAssertThrowsError(try encoder.setDynamicTableSize(8192)) { error in
             guard let err = error as? NIOHPACKErrors.InvalidDynamicTableSize else {
                 XCTFail()
@@ -499,11 +499,11 @@ class HPACKCodingTests: XCTestCase {
             XCTAssertEqual(err.requestedSize, 8192)
             XCTAssertEqual(err.allowedSize, 4096)
         }
-        
+
         XCTAssertThrowsError(try decoder.decodeHeaders(from: &request3)) {error in
             XCTAssertTrue(error is NIOHPACKErrors.InvalidDynamicTableSize)
         }
-        
+
         // 5 - Decoder will not accept a table size update unless it appears at the start of a header block.
         decoder.headerTable.dynamicTable.clear()
 
@@ -511,7 +511,7 @@ class HPACKCodingTests: XCTestCase {
             XCTAssertTrue(error is NIOHPACKErrors.IllegalDynamicTableSizeChange)
         }
     }
-    
+
     func testHPACKHeadersDescription() throws {
         let headerList1: [(String, String)] = [(":method", "GET"),
                                                (":scheme", "http"),
@@ -528,24 +528,24 @@ class HPACKCodingTests: XCTestCase {
                                                               (.indexable, ":authority", "www.example.com"),
                                                               (.indexable, "custom-key", "custom-value"),
                                                               (.nonIndexable, "content-length", "42")]
-        
+
         let headers1 = HPACKHeaders(headerList1)
         let headers2 = HPACKHeaders(headerList2)
         let headers3 = HPACKHeaders(fullHeaders: headerList3)
-        
+
         let description1 = headers1.description
         let expected1 = headerList1.map { (HPACKIndexing.indexable, $0.0, $0.1) }.description
         XCTAssertEqual(description1, expected1)
-        
+
         let description2 = headers2.description
         let expected2 = headerList2.map { (HPACKIndexing.indexable, $0.0, $0.1) }.description
         XCTAssertEqual(description2, expected2)
-        
+
         let description3 = headers3.description
         let expected3 = headerList3.description // already contains indexing where we'd expect
         XCTAssertEqual(description3, expected3)
     }
-    
+
     func testHPACKHeadersSubscript() throws {
         let headers = HPACKHeaders([
             (":method", "GET"),
@@ -557,16 +557,16 @@ class HPACKCodingTests: XCTestCase {
             ("set-cookie", "abcdefg,hijklmn,opqrst"),
             ("custom-key", "value-3")
         ])
-        
+
         XCTAssertEqual(headers[":method"], ["GET"])
         XCTAssertEqual(headers[":authority"], ["www.example.com"])
         XCTAssertTrue(headers.contains(name: "cache-control"))
         XCTAssertTrue(headers.contains(name: "Cache-Control"))
         XCTAssertFalse(headers.contains(name: "content-length"))
-        
+
         XCTAssertEqual(headers["custom-key"], ["value-1,value-2", "value-3"])
         XCTAssertEqual(headers[canonicalForm: "custom-key"], ["value-1", "value-2", "value-3"])
-        
+
         XCTAssertEqual(headers["set-cookie"], ["abcdefg,hijklmn,opqrst"])
         XCTAssertEqual(headers[canonicalForm: "set-cookie"], ["abcdefg,hijklmn,opqrst"])
     }
@@ -594,6 +594,14 @@ class HPACKCodingTests: XCTestCase {
         let expected = ["foo", "bar"]
         XCTAssertEqual(headers[canonicalForm: "no-whitespace"], expected)
         XCTAssertEqual(headers[canonicalForm: "with-whitespace"], expected)
+    }
+
+    func testHPACKHeadersCanonicalFormSetCookie() throws {
+        let shouldNotBeSplitOrStripped = "should, not , be , split, or, stripped"
+        let headers: HPACKHeaders = ["set-cookie": shouldNotBeSplitOrStripped]
+
+        XCTAssertEqual(headers[canonicalForm: "set-cookie"],  [shouldNotBeSplitOrStripped])
+        XCTAssertEqual(headers[canonicalForm: "Set-Cookie"],  [shouldNotBeSplitOrStripped])
     }
 
     func testHPACKHeadersFirst() throws {


### PR DESCRIPTION
Motivation:

When getting the canonical form of headers we check whether the header
name is 'set-cookie' to avoid splitting values which are not safe to
split.

This check is done against a `lowercased()` version of the header name.
However, we don't need to produce a new `String` here as we already have
a case insensitive string comparision function.

Modifications:

- Add a test to verify that getting the canonical form of "set-cookie"
  does not split any header values
- Switch to `isEqualCaseInsensitiveASCIIBytes`

Result:

More tests, cheaper comparision.