### PR TITLE
Remove forbidden HTTP1 headers even if no connection header is present

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -33,11 +33,10 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral {
             self.headers = httpHeaders.map { HPACKHeader(name: $0.name.lowercased(), value: $0.value) }
 
             let connectionHeaderValue = httpHeaders[canonicalForm: "connection"]
-            if !connectionHeaderValue.isEmpty {
-                self.headers.removeAll { header in
-                    return HPACKHeaders.illegalHeaders.contains(header.name) ||
-                        connectionHeaderValue.contains(header.name[...])
-                }
+            
+            self.headers.removeAll { header in
+                connectionHeaderValue.contains(header.name[...]) ||
+                    HPACKHeaders.illegalHeaders.contains(header.name)
             }
         } else {
             self.headers = httpHeaders.map { HPACKHeader(name: $0.name, value: $0.value) }

--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -225,10 +225,10 @@ public final class HTTP2FramePayloadToHTTP1ClientCodec: ChannelInboundHandler, C
     }
 
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        let responsePart = self.unwrapOutboundIn(data)
+        let requestPart = self.unwrapOutboundIn(data)
 
         do {
-            let transformedPayload = try self.baseCodec.processOutboundData(responsePart, allocator: context.channel.allocator)
+            let transformedPayload = try self.baseCodec.processOutboundData(requestPart, allocator: context.channel.allocator)
             context.write(self.wrapOutboundOut(transformedPayload), promise: promise)
         } catch {
             promise?.fail(error)

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
@@ -60,6 +60,7 @@ extension HTTP2FramePayloadToHTTP1CodecTests {
                 ("testWeDoNotNormalizeHeadersIfUserAskedUsNotToForRequests", testWeDoNotNormalizeHeadersIfUserAskedUsNotToForRequests),
                 ("testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses", testWeDoNotNormalizeHeadersIfUserAskedUsNotToForResponses),
                 ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForRequests),
+                ("testWeStripTransferEncodingChunkedHeader", testWeStripTransferEncodingChunkedHeader),
                 ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses),
                 ("testServerSideWithEmptyFinalPackage", testServerSideWithEmptyFinalPackage),
                 ("testClientSideWithEmptyFinalPackage", testClientSideWithEmptyFinalPackage),


### PR DESCRIPTION
### Motivation

Currently we only remove forbidden HTTP/1.1 headers when translating to HTTP/2.0, if a connection header is present. Since a connection header is not required on HTTP/1.1, forward forbidden headers are currently sometimes forwarded (like "transfer-encoding").

### Changes

- Remove forbidden HTTP/1.1 headers, even if no connection header is present.

### Result

We don't leak forbidden headers.