### PR TITLE
Reduce allocations..?

### DIFF
--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -64,7 +64,12 @@ struct HTTP2FrameDecoder {
         }
 
         mutating func accumulate(bytes: inout ByteBuffer) {
-            _ = self.unusedBytes.writeBuffer(&bytes)
+            if self.unusedBytes.readableBytes == 0 {
+                self.unusedBytes = bytes
+            }
+            else {
+                _ = self.unusedBytes.writeBuffer(&bytes)
+            }
         }
     }
 


### PR DESCRIPTION
I've been profiling large HTTP upload requests in swift-nio, and have noticed a lot of copying/allocations going on in `HTTPFrameDecoder`.

Is it possible in this instance to prevent the copy by just switching the accumulating byte buffer to the incoming one if the accumulate bytes are still zero? I don't know NIO well enough yet to understand what side effects this may have.