### PR TITLE
Deliver outbound stream errors to channels.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -868,6 +868,11 @@ internal extension HTTP2StreamChannel {
             self.pipeline.fireChannelWritabilityChanged()
         }
     }
+
+    func receiveStreamError(_ error: NIOHTTP2Errors.StreamError) {
+        assert(error.streamID == self.streamID)
+        self.pipeline.fireErrorCaught(error.baseError)
+    }
 }
 
 extension HTTP2StreamChannel {

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -205,6 +205,15 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
         context.fireChannelWritabilityChanged()
     }
 
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
+        if let streamError = error as? NIOHTTP2Errors.StreamError,
+           let channel = self.streams[streamError.streamID] {
+            channel.receiveStreamError(streamError)
+        }
+
+        context.fireErrorCaught(error)
+    }
+
     private func newConnectionWindowSize(newSize: Int, context: ChannelHandlerContext) {
         guard let increment = self.connectionFlowControlManager.newWindowSize(newSize) else {
             return

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -137,6 +137,10 @@ extension MultiplexerAbstractChannel {
     func receiveStreamClosed(_ reason: HTTP2ErrorCode?) {
         self.baseChannel.receiveStreamClosed(reason)
     }
+
+    func receiveStreamError(_ error: NIOHTTP2Errors.StreamError) {
+        self.baseChannel.receiveStreamError(error)
+    }
 }
 
 extension MultiplexerAbstractChannel: Equatable {

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
@@ -78,6 +78,7 @@ extension HTTP2FramePayloadStreamMultiplexerTests {
                 ("testWindowUpdateIsNotEmittedAfterStreamIsClosed", testWindowUpdateIsNotEmittedAfterStreamIsClosed),
                 ("testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame", testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame),
                 ("testStreamChannelSupportsSyncOptions", testStreamChannelSupportsSyncOptions),
+                ("testStreamErrorIsDeliveredToChannel", testStreamErrorIsDeliveredToChannel),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
@@ -74,6 +74,7 @@ extension SimpleClientServerFramePayloadStreamTests {
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
                 ("testGreasedSettingsAreTolerated", testGreasedSettingsAreTolerated),
                 ("testStreamCreationOrder", testStreamCreationOrder),
+                ("testStreamClosedInvalidRequestHeaders", testStreamClosedInvalidRequestHeaders),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -1945,14 +1945,14 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         }
 
         XCTAssertThrowsError(try self.clientChannel.throwIfErrorCaught()) { error in
-            guard let error = error as? NIOHTTP2Errors.StreamError else {
+            guard let streamError = error as? NIOHTTP2Errors.StreamError else {
                 XCTFail("Unexpected error kind: \(error)")
                 return
             }
 
-            XCTAssertEqual(error.streamID, 1)
+            XCTAssertEqual(streamError.streamID, 1)
             XCTAssertEqual(
-                error.baseError as? NIOHTTP2Errors.ForbiddenHeaderField,
+                streamError.baseError as? NIOHTTP2Errors.ForbiddenHeaderField,
                 NIOHTTP2Errors.forbiddenHeaderField(name: "transfer-encoding", value: "chunked")
             )
         }


### PR DESCRIPTION
Motivation:

When we hit a stream error on an outbound frame, we don't currently
distinguish between them and channel errors. This makes it impossible
for anyone to tell them apart. It also makes it impossible for the
multiplexer to deliver these errors into the relevant stream channels
that triggered them, making it essentially certain they'll be lost.

Better diagnostics would be good, so we are providing them.

Modifications:

- Add new StreamError type that carries a stream ID and an underlying
  error.
- Emit this StreamError type for outbound stream errors.
- Deliver this StreamError type into the relevant child channels when
  possible.

Result:

Better diagnostics for stream errors.