### PR TITLE
Add Transfer-Encoding chunked to HTTP1 requests and responses.

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -587,15 +587,13 @@ internal extension HTTPResponseHead {
         // NOTE: We don't need to create the header array here ourselves. The HTTP/1 response
         //       headers, will not contain a :status field, but may contain a "Transfer-Encoding"
         //       field. For this reason the default allocation works great for us.
-        var h1Headers = HTTPHeaders(regularHeadersFrom: headers)
         if self.shouldAddContentLengthOrTransferEncodingHeaderToResponse(hpackHeaders: headers, requestHead: requestHead) {
             if endStream {
-                h1Headers.add(name: "content-length", value: "0")
+                self.headers.add(name: "content-length", value: "0")
             } else {
-                h1Headers.add(name: "transfer-encoding", value: "chunked")
+                self.headers.add(name: "transfer-encoding", value: "chunked")
             }
         }
-        self.init(version: .init(major: 2, minor: 0), status: status, headers: h1Headers)
     }
     
     private func shouldAddContentLengthOrTransferEncodingHeaderToResponse(
@@ -607,7 +605,7 @@ internal extension HTTPResponseHead {
             && statusCode != 304
             && requestHead.method != .HEAD
             && requestHead.method != .CONNECT
-            && !headers.contains(name: "content-length") // compare on h2 headers - for speed
+            && !hpackHeaders.contains(name: "content-length") // compare on h2 headers - for speed
     }
 }
 

--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -570,7 +570,7 @@ internal extension HTTPRequestHead {
 
 
 internal extension HTTPResponseHead {
-    /// Create a `HTTPResponseHead` from the header block. Use this for informational responses
+    /// Create a `HTTPResponseHead` from the header block. Use this for informational responses.
     init(http2HeaderBlock headers: HPACKHeaders) throws {
         // A response head should have only one psuedo-header. We strip it off.
         let statusHeader = try headers.peekPseudoHeader(name: ":status")
@@ -581,7 +581,7 @@ internal extension HTTPResponseHead {
         self.init(version: .init(major: 2, minor: 0), status: status, headers: HTTPHeaders(regularHeadersFrom: headers))
     }
     
-    /// Create a `HTTPResponseHead` from the header block. Use this for non-informational responses
+    /// Create a `HTTPResponseHead` from the header block. Use this for non-informational responses.
     init(http2HeaderBlock headers: HPACKHeaders, requestHead: HTTPRequestHead, endStream: Bool) throws {
         // A response head should have only one psuedo-header. We strip it off.
         let statusHeader = try headers.peekPseudoHeader(name: ":status")

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadToHTTP1CodecTests+XCTest.swift
@@ -64,6 +64,13 @@ extension HTTP2FramePayloadToHTTP1CodecTests {
                 ("testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses", testWeStripIllegalHeadersAsWellAsTheHeadersNominatedByTheConnectionHeaderForResponses),
                 ("testServerSideWithEmptyFinalPackage", testServerSideWithEmptyFinalPackage),
                 ("testClientSideWithEmptyFinalPackage", testClientSideWithEmptyFinalPackage),
+                ("testRequestMethodsWithoutDefinedSemanticsForAPayloadDontGetTransferEncodingAdded", testRequestMethodsWithoutDefinedSemanticsForAPayloadDontGetTransferEncodingAdded),
+                ("testRequestMethodsWithoutDefinedSemanticsForAPayloadDontRemoveContentLengthIfSet", testRequestMethodsWithoutDefinedSemanticsForAPayloadDontRemoveContentLengthIfSet),
+                ("testRequestMethodsWithDefinedSemanticsForAPayloadAddContentLengthHeaderIfEmpty", testRequestMethodsWithDefinedSemanticsForAPayloadAddContentLengthHeaderIfEmpty),
+                ("testRequestMethodsWithDefinedSemanticsForAPayloadAddTransferEncodingIfNotEmpty", testRequestMethodsWithDefinedSemanticsForAPayloadAddTransferEncodingIfNotEmpty),
+                ("testRequestContentLengthIsAlwaysPreserved", testRequestContentLengthIsAlwaysPreserved),
+                ("testResponseTransferEncodingIsNotAddedInReponseToHEADorCONNECT", testResponseTransferEncodingIsNotAddedInReponseToHEADorCONNECT),
+                ("testResponseTransferEncodingIsNotAddedInReponseWithStatus1xxor204or304", testResponseTransferEncodingIsNotAddedInReponseWithStatus1xxor204or304),
            ]
    }
 }


### PR DESCRIPTION
### Motivation

When translating HTTP2 to HTTP1, developers assume HTTP1 header semantics. HTTP2 does not know the Transfer-Encoding header. For this reason, we should add the Transfer-Encoding header, when needed to HTTP2 requests and responses.

### Changes

- Adds the Transfer-Encoding to incoming HTTP requests on the server http2 to http1 translation side
- Adds the Transfer-Encoding to incoming HTTP responses on the client http2 to http1 translation side

### Result

Users get more real http1.1 semantics, when using the HTTP2 to HTTP1 translation.