### PR TITLE
Forward all reads before stream channel inactive

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -815,7 +815,7 @@ internal extension HTTP2StreamChannel {
         // The stream is closed, we should force forward all pending frames, even without
         // unsatisfied read, to ensure the handlers can see all frames before receiving
         // channelInactive.
-        if self.pendingReads.count > 0, self._isActive {
+        if self.pendingReads.count > 0 && self._isActive {
             self.unsatisfiedRead = false
             self.deliverPendingReads()
         }

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -812,8 +812,13 @@ internal extension HTTP2StreamChannel {
         // Avoid emitting any WINDOW_UPDATE frames now that we're closed.
         self.windowManager.closed = true
 
-        // The stream is closed, we should aim to deliver any read frames we have for it.
-        self.tryToRead()
+        // The stream is closed, we should force forward all pending frames, even without
+        // unsatisfied read, to ensure the handlers can see all frames before receiving
+        // channelInactive.
+        if self.pendingReads.count > 0, self._isActive {
+            self.unsatisfiedRead = false
+            self.deliverPendingReads()
+        }
 
         if let reason = reason {
             // To receive from the network, it must be safe to force-unwrap here.

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests+XCTest.swift
@@ -79,6 +79,7 @@ extension HTTP2FramePayloadStreamMultiplexerTests {
                 ("testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame", testWindowUpdateIsNotEmittedAfterStreamIsClosedEvenOnLaterFrame),
                 ("testStreamChannelSupportsSyncOptions", testStreamChannelSupportsSyncOptions),
                 ("testStreamErrorIsDeliveredToChannel", testStreamErrorIsDeliveredToChannel),
+                ("testPendingReadsAreFlushedEvenWithoutUnsatisfiedReadOnChannelInactive", testPendingReadsAreFlushedEvenWithoutUnsatisfiedReadOnChannelInactive),
            ]
    }
 }


### PR DESCRIPTION
### Motivation

In the AsyncHTTPClient the read event is not always forwarded right away. We have seen instances, in which we see a `HTTPClientError.remoteConnectionClosed` error, on requests that finish normally. https://github.com/swift-server/async-http-client/issues/488 

On deeper inspection, I noticed: If there is no unsatisfied read event, when a stream is closed, the pending reads are not forwarded. This can lead to response bytes being ignored on successful requests. NIOHTTP2 should behave as NIO and force forward all pending reads on channelInactive.

### Changes

- Forward all pending reads on channelInactive even if no read event has hit the channel

### Result

All requests will receive the complete request body.