### PR TITLE
Protect against reentrancy inside the HTT2ChannelHandler

### DIFF
--- a/Tests/NIOHTTP2Tests/ReentrancyTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ReentrancyTests+XCTest.swift
@@ -30,6 +30,7 @@ extension ReentrancyTests {
                 ("testReEnterReadOnRead", testReEnterReadOnRead),
                 ("testReenterInactiveOnRead", testReenterInactiveOnRead),
                 ("testReenterReadEOFOnRead", testReenterReadEOFOnRead),
+                ("testReenterAutomaticFrames", testReenterAutomaticFrames),
            ]
    }
 }


### PR DESCRIPTION
In rare cases, the `HTTP2ChannelHandler`s method `unbufferAndFlushAutomaticFrames` and the `HTTP2StreaMultiplexer`s `newConnectionWindowSize` method were recursively calling themselves. This was causing a stack overflow. To protect ourselves from this stack overflow, I added a variable to guard against reentrancy inside the `unbufferAndFlushAutomaticFrames` method.