### PR TITLE
Only flush when necessary in the HTTP2ChannelHandler

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
@@ -75,6 +75,7 @@ extension SimpleClientServerFramePayloadStreamTests {
                 ("testGreasedSettingsAreTolerated", testGreasedSettingsAreTolerated),
                 ("testStreamCreationOrder", testStreamCreationOrder),
                 ("testStreamClosedInvalidRequestHeaders", testStreamClosedInvalidRequestHeaders),
+                ("testHTTP2HandlerDoesNotFlushExcessively", testHTTP2HandlerDoesNotFlushExcessively),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The `wroteFrame` flag in `HTTP2ChannelHandler` indicates whether a frame
has been written. This flag is checked before flushing in order to avoid
unnecessary flushes. Unfortunately this is only ever set to `true`.

Modifications:

- Add a `flushIfNecessary` to check and toggle `wroteFrame` and flush if
  necessary
- Add a test

Result:

- Few unnecessary flushes
- Resolves https://github.com/apple/swift-nio-http2/issues/245