### PR TITLE
Add 5.6 nightly CI

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,41 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-http2:20.04-5.6
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.6-focal"
+        ubuntu_version: "focal"
+        h2spec_version: "2.2.1"
+
+  unit-tests:
+    image: swift-nio-http2:20.04-5.6
+
+  integration-tests:
+    image: swift-nio-http2:20.04-5.6
+
+  performance-test:
+    image: swift-nio-http2:20.04-5.6
+
+  h2spec:
+    image: swift-nio-http2:20.04-5.6
+
+  test:
+    image: swift-nio-http2:20.04-5.6
+    environment:
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=317250
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=284000
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=47050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
+      - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
+      - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=323200
+
+  shell:
+    image: swift-nio-http2:20.04-5.6


### PR DESCRIPTION
The 5.6 nightly images are available, let's use them.

@tomerd Can you add a 5.6 builder for this?