### PR TITLE
Make UnrepresentableInteger public

### DIFF
--- a/Sources/NIOHPACK/HPACKErrors.swift
+++ b/Sources/NIOHPACK/HPACKErrors.swift
@@ -120,7 +120,7 @@ public enum NIOHPACKErrors {
     }
 
     /// The integer being decoded is not representable by this implementation.
-    internal struct UnrepresentableInteger: NIOHPACKError {
+    public struct UnrepresentableInteger: NIOHPACKError {
         public init() {}
     }
 }


### PR DESCRIPTION
Motivation:

A new 'UnrepresentableInteger' error was added in GHSA-w3f6-pc54-gfw7.
This was added as internal so that the advisory could be published as a
patch release rather than a minor.

This error should be public so that callers may hold an instance of it.

Modifications:

- Make UnrepresentableInteger public

Result:

UnrepresentableInteger is part of the public API.