### PR TITLE
ci update

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -6,8 +6,8 @@ services:
     image: swift-nio-http2:20.04-5.6
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.6-focal"
         ubuntu_version: "focal"
+        swift_version: "5.6"
         h2spec_version: "2.2.1"
 
   unit-tests:

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -3,26 +3,26 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-focal"
         h2spec_version: "2.2.1"
 
   unit-tests:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
 
   integration-tests:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
 
   performance-test:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
 
   h2spec:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
 
   test:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
@@ -37,4 +37,4 @@ services:
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293250
 
   shell:
-    image: swift-nio-http2:20.04-main
+    image: swift-nio-http2:20.04-5.7


### PR DESCRIPTION
motivation: 5.6 is out

changes:
* use release version of 5.6
* add docker setup for 5.7 (using nightly for now)