### PR TITLE
Update alloc limits and clean up soundness

### DIFF
--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -125,7 +125,7 @@ struct HTTP2FrameDecoder {
                         // There needs to be at least the padding length byte, so the minimum frame size is 1.
                         throw InternalError.codecError(code: .protocolError)
                     }
-                    
+
                     return .awaitingPaddingLengthByte(
                         AwaitingPaddingLengthByteParserState(fromAccumulatingFrameHeader: self, frameHeader: header)
                     )
@@ -363,7 +363,7 @@ struct HTTP2FrameDecoder {
         /// In this state if we succesfully move forward at all we'll produce a DATA frame, as
         /// well as a new target state.
         mutating func process() throws -> ProcessResult? {
-            // Sanity checking: the padded flag should be gone.
+            // Making sure the padded flag should be gone.
             assert(!self.header.flags.contains(.padded))
 
             let payloadSize = self.remainingByteCount - (self.expectedPadding ?? 0)

--- a/docker/docker-compose.1604.52.yaml
+++ b/docker/docker-compose.1604.52.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=48200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=47100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=311050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=275050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=310050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=274050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=323250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=323150
       - SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=310050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=274050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=309050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
 
   shell:
     image: swift-nio-http2:18.04-5.3

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -28,15 +28,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=310050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=274050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=309050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
 
   shell:
     image: swift-nio-http2:20.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=310050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=274050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=309050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=304050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=270050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=303050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=41050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=304050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=270050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=303050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=41050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293250
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
 
   shell:
     image: swift-nio-http2:20.04-main

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][8901]/YEARS/g' -e 's/2019/YEARS/g' -e 's/2020/YEARS/g' -e 's/2021/YEARS/g'
+    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
Some soundness checks were broken by our security fix (thanks to @tomerd in #330) and the allocation counts got dropped by the rewrite. This fixes both.