### PR TITLE
Clients can't push!

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
@@ -68,8 +68,8 @@ extension ReceivingPushPromiseState {
 
     /// Whether the remote peer may push.
     var peerMayPush: Bool {
-        // In the case where we don't have local settings, we have to assume the default value, in which the peer may push.
-        return true
+        // In the case where we don't have local settings, we have to assume the default value, in which servers may push and clients may not.
+        return self.role == .client
     }
 }
 
@@ -93,6 +93,6 @@ extension ReceivingPushPromiseState where Self: LocallyQuiescingState {
 
 extension ReceivingPushPromiseState where Self: HasLocalSettings {
     var peerMayPush: Bool {
-        return self.localSettings.enablePush == 1
+        return self.localSettings.enablePush == 1 && self.role == .client
     }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
@@ -18,6 +18,8 @@ import NIOHPACK
 ///
 /// This protocol should only be conformed to by states for the HTTP/2 connection state machine.
 protocol SendingPushPromiseState: HasFlowControlWindows {
+    var role: HTTP2ConnectionStateMachine.ConnectionRole { get }
+
     var headerBlockValidation: HTTP2ConnectionStateMachine.ValidationState { get }
 
     var streamState: ConnectionStreamState { get set }
@@ -67,8 +69,8 @@ extension SendingPushPromiseState {
 
     /// Whether we may push.
     var mayPush: Bool {
-        // In the case where we don't have remote settings, we have to assume the default value, in which case we may push.
-        return true
+        // In the case where we don't have remote settings, we have to assume the default value, in which case if we're a server we may push.
+        return self.role == .server
     }
 
 }
@@ -83,6 +85,6 @@ extension SendingPushPromiseState where Self: RemotelyQuiescingState {
 
 extension SendingPushPromiseState where Self: HasRemoteSettings {
     var mayPush: Bool {
-        return self.remoteSettings.enablePush == 1
+        return self.remoteSettings.enablePush == 1 && self.role == .server
     }
 }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -82,6 +82,7 @@ extension ConnectionStateMachineTests {
                 ("testUnknownSettingsAreIgnored", testUnknownSettingsAreIgnored),
                 ("testMaxConcurrentStreamsEnforcement", testMaxConcurrentStreamsEnforcement),
                 ("testDisablingPushPreventsPush", testDisablingPushPreventsPush),
+                ("testClientsCannotPush", testClientsCannotPush),
                 ("testRatchetingGoawayEvenWhenFullyQueisced", testRatchetingGoawayEvenWhenFullyQueisced),
                 ("testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced", testRatchetingGoawayForBothPeersEvenWhenFullyQuiesced),
                 ("testClientTrailersMustHaveEndStreamSet", testClientTrailersMustHaveEndStreamSet),


### PR DESCRIPTION
Motivation:

Nowhere in the PUSH_PROMISE code do we explicitly check whether or not
we're a client or a server, and we don't provide special handling for
SETTINGS_ENABLE_PUSH contingent on that fact. As a result, we do
technically allow clients to push. This eventually gets caught, but not
until we've created an idle stream, which we shouldn't do.

Modifications:

- Forbid clients from pushing.

Result:

Clients won't be allowed to push.