### PR TITLE
Use SPM API diff checker

### DIFF
--- a/scripts/check_no_api_breakages.sh
+++ b/scripts/check_no_api_breakages.sh
@@ -15,39 +15,10 @@
 
 set -eu
 
-# repodir
-function all_modules() {
-    local repodir="$1"
-    (
-    set -eu
-    cd "$repodir"
-    swift package dump-package | jq '.products |
-                                     map(select(.type | has("library") )) |
-                                     map(.name) | .[]' | tr -d '"'
-    )
-}
-
-# repodir tag output
-function build_and_do() {
-    local repodir=$1
-    local tag=$2
-    local output=$3
-
-    (
-    cd "$repodir"
-    git checkout -q "$tag"
-    swift build
-    while read -r module; do
-        swift api-digester -sdk "$sdk" -dump-sdk -module "$module" \
-            -o "$output/$module.json" -I "$repodir/.build/debug"
-    done < <(all_modules "$repodir")
-    )
-}
-
 function usage() {
     echo >&2 "Usage: $0 REPO-GITHUB-URL NEW-VERSION OLD-VERSIONS..."
     echo >&2
-    echo >&2 "This script requires a Swift 5.1+ toolchain."
+    echo >&2 "This script requires a Swift 5.2+ toolchain."
     echo >&2
     echo >&2 "Examples:"
     echo >&2
@@ -63,12 +34,6 @@ if [[ $# -lt 3 ]]; then
     exit 1
 fi
 
-sdk=/
-if [[ "$(uname -s)" == Darwin ]]; then
-    sdk=$(xcrun --show-sdk-path)
-fi
-
-hash jq 2> /dev/null || { echo >&2 "ERROR: jq must be installed"; exit 1; }
 tmpdir=$(mktemp -d /tmp/.check-api_XXXXXX)
 repo_url=$1
 new_tag=$2
@@ -77,46 +42,13 @@ shift 2
 repodir="$tmpdir/repo"
 git clone "$repo_url" "$repodir"
 git -C "$repodir" fetch -q origin '+refs/pull/*:refs/remotes/origin/pr/*'
-errors=0
+cd "$repodir"
+git checkout -q "$new_tag"
 
 for old_tag in "$@"; do
-    mkdir "$tmpdir/api-old"
-    mkdir "$tmpdir/api-new"
-
     echo "Checking public API breakages from $old_tag to $new_tag"
 
-    build_and_do "$repodir" "$new_tag" "$tmpdir/api-new/"
-    build_and_do "$repodir" "$old_tag" "$tmpdir/api-old/"
-
-    for f in "$tmpdir/api-new"/*; do
-        f=$(basename "$f")
-        report="$tmpdir/$f.report"
-        if [[ ! -f "$tmpdir/api-old/$f" ]]; then
-            echo "NOTICE: NEW MODULE $f"
-            continue
-        fi
-
-        echo -n "Checking $f... "
-        swift api-digester -sdk "$sdk" -diagnose-sdk \
-            --input-paths "$tmpdir/api-old/$f" -input-paths "$tmpdir/api-new/$f" 2>&1 \
-            > "$report" 2>&1
-
-        if ! shasum "$report" | grep -q afd2a1b542b33273920d65821deddc653063c700; then
-            echo ERROR
-            echo >&2 "=============================="
-            echo >&2 "ERROR: public API change in $f"
-            echo >&2 "=============================="
-            cat >&2 "$report"
-            errors=$(( errors + 1 ))
-        else
-            echo OK
-        fi
-    done
-    rm -rf "$tmpdir/api-new" "$tmpdir/api-old"
+    swift package diagnose-api-breaking-changes "$old_tag"
 done
 
-if [[ "$errors" == 0 ]]; then
-    echo "OK, all seems good"
-fi
 echo done
-exit "$errors"


### PR DESCRIPTION
### Motivation:

SPM has built in functionality to check the API of modules against a target git treeish. We can use this to simplify our `check_no_api_breakages.sh` script. Closes https://github.com/apple/swift-nio/issues/1239

### Modifications:

This PR, exchanges the direct calls to Swift's API checker with the new SPM `diagnose-api-breaking-changes` tool. This allows us to get rid of the manual module parsing, build invocations and result comparisons.

### Result:

We are now using SPMs `diagnose-api-breaking-changes` to check for breaking changes.