### PR TITLE
Improve HTTPHeader normalisation performance for large inputs

### DIFF
--- a/Tests/NIOHPACKTests/HPACKHeadersTests+XCTest.swift
+++ b/Tests/NIOHPACKTests/HPACKHeadersTests+XCTest.swift
@@ -28,6 +28,8 @@ extension HPACKHeadersTests {
    static var allTests : [(String, (HPACKHeadersTests) -> () throws -> Void)] {
       return [
                 ("testHPACKHeadersAreHashable", testHPACKHeadersAreHashable),
+                ("testNormalizationOfHTTPHeaders", testNormalizationOfHTTPHeaders),
+                ("testNormalizationOfHTTPHeadersWithManyConnectionHeaderValues", testNormalizationOfHTTPHeadersWithManyConnectionHeaderValues),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Header normalisation is expensive when the input headers contain a large
number of connection header values.

Modifications:

- When the headers to normalise contain more than 32 connection header
  values use a set to provide constant time lookup, rather than linear.

Result:

Better perf for HTTPHeader normalisation with large connection header
value lists.