### PR TITLE
Use Docc for documentation

### DIFF
--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -23,7 +23,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.35.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -23,7 +23,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.35.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/NIOHTTP2/Docs.docc/index.md
+++ b/Sources/NIOHTTP2/Docs.docc/index.md
@@ -1,0 +1,77 @@
+# ``NIOHTTP2``
+
+This project contains HTTP/2 support for Swift projects using SwiftNIO.
+
+## Getting Started
+
+``NIOHTTP2`` provides a number of types that make working with HTTP/2 practical using SwiftNIO. The simplest way to get started is to use the helpers provided to configure a HTTP/2 `ChannelPipeline`. As an example, to configure a HTTP/2 server, you can use `Channel.configureHTTP2Pipeline`:
+
+```swift
+channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+    // This closure will be called once for each new HTTP/2 stream on a given connection
+}
+```
+
+HTTP/2 implementations generally require a TLS handshake to negotiate, using ALPN. SwiftNIO has a number of TLS implementations available that are suitable for this purpose. As an example using [`swift-nio-ssl`](https://github.com/apple/swift-nio-ssl):
+
+```swift
+var serverConfig = TLSConfiguration.makeServerConfiguration(certificateChain: certificateChain, privateKey: sslPrivateKey)
+serverConfig.applicationProtocols = NIOHTTP2SupportedALPNProtocols
+// Configure the SSL context that is used by all SSL handlers.
+
+let sslContext = try! NIOSSLContext(configuration: serverConfig)
+channel.addHandler(NIOSSLServerHandler(context: sslContext).flatMap {
+    channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+        // This closure will be called once for each new HTTP/2 stream on a given connection
+    }
+}
+```
+
+A number of other helpers are available for configuring pipelines.
+
+## Topics
+
+### Core Channel Handlers
+
+- ``NIOHTTP2Handler``
+- ``HTTP2StreamMultiplexer``
+
+### HTTP/2 and HTTP/1.1 compatibility
+
+- ``HTTP2FramePayloadToHTTP1ClientCodec``
+- ``HTTP2FramePayloadToHTTP1ServerCodec``
+- ``HTTP2ToHTTP1ClientCodec``
+- ``HTTP2ToHTTP1ServerCodec``
+
+### Frames and Frame Payloads
+
+- ``HTTP2Frame``
+- ``HTTP2PingData``
+- ``HTTP2StreamID``
+- ``HTTP2Settings``
+- ``HTTP2Setting``
+- ``HTTP2SettingsParameter``
+- ``HTTP2ErrorCode``
+
+### User Inbound Events
+
+- ``NIOHTTP2StreamCreatedEvent``
+- ``NIOHTTP2WindowUpdatedEvent``
+- ``NIOHTTP2BulkStreamWindowChangeEvent``
+- ``StreamClosedEvent``
+
+### Stream Channel Options
+
+- ``HTTP2StreamChannelOptions``
+- ``StreamIDOption``
+
+### Errors
+
+- ``NIOHTTP2Errors``
+- ``NIOHTTP2Error``
+- ``NIOHTTP2StreamState``
+
+### Default Values
+
+- ``NIOHTTP2SupportedALPNProtocols``
+- ``nioDefaultSettings``

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,166 +13,264 @@
 //===----------------------------------------------------------------------===//
 import NIOHPACK
 
+/// The base protocol for all errors thrown by ``NIOHTTP2``.
+///
+/// Users are recommended not to implement this protocol with their own types.
 public protocol NIOHTTP2Error: Equatable, Error { }
 
-/// Errors that NIO raises when handling HTTP/2 connections.
+/// Errors that ``NIOHTTP2`` raises when handling HTTP/2 connections.
 public enum NIOHTTP2Errors {
+    /// Creates an ``ExcessiveOutboundFrameBuffering`` error with appropriate source context.
     public static func excessiveOutboundFrameBuffering(file: String = #file, line: UInt = #line) -> ExcessiveOutboundFrameBuffering {
         return ExcessiveOutboundFrameBuffering(file: file, line: line)
     }
 
+    /// Creates an ``InvalidALPNToken`` error with appropriate source context
     public static func invalidALPNToken(file: String = #file, line: UInt = #line) -> InvalidALPNToken {
         return InvalidALPNToken(file: file, line: line)
     }
 
+    /// Creates a ``NoSuchStream`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - streamID: The ``HTTP2StreamID`` for the stream that does not exist.
     public static func noSuchStream(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> NoSuchStream {
         return NoSuchStream(streamID: streamID, file: file, line: line)
     }
 
+    /// Creates a ``StreamClosed`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - streamID: The ``HTTP2StreamID`` for the stream that is or has been closed
+    ///     - errorCode: The ``HTTP2ErrorCode`` representing the reason for closure of the stream.
     public static func streamClosed(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: String = #file, line: UInt = #line) -> StreamClosed {
         return StreamClosed(streamID: streamID, errorCode: errorCode, file: file, line: line)
     }
 
+    /// Creates a ``BadClientMagic`` error with appropriate source context.
     public static func badClientMagic(file: String = #file, line: UInt = #line) -> BadClientMagic {
         return BadClientMagic(file: file, line: line)
     }
 
+    /// Creates a ``BadStreamStateTransition`` error with appropriate source context
+    ///
+    /// - parameters
+    ///     - state: The ``NIOHTTP2StreamState`` representing the state of the stream from which we were trying to transition
     public static func badStreamStateTransition(from state: NIOHTTP2StreamState? = nil, file: String = #file, line: UInt = #line) -> BadStreamStateTransition {
         return BadStreamStateTransition(from: state, file: file, line: line)
     }
 
+    /// Creates an ``InvalidFlowControlWindowSize`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - delta: The change in the window size that was proposed in error
+    ///     - currentWindowSize: The current size of the stream flow control window
     public static func invalidFlowControlWindowSize(delta: Int, currentWindowSize: Int, file: String = #file, line: UInt = #line) -> InvalidFlowControlWindowSize {
         return InvalidFlowControlWindowSize(delta: delta, currentWindowSize: currentWindowSize, file: file, line: line)
     }
 
+    /// Creates a ``FlowControlViolation`` error with appropriate source context.
     public static func flowControlViolation(file: String = #file, line: UInt = #line) -> FlowControlViolation {
         return FlowControlViolation(file: file, line: line)
     }
 
+    /// Creates an ``InvalidSetting`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - setting: The invalid setting in question
     public static func invalidSetting(setting: HTTP2Setting, file: String = #file, line: UInt = #line) -> InvalidSetting {
         return InvalidSetting(setting: setting, file: file, line: line)
     }
 
+    /// Creates an ``IOOnClosedConnection`` error with appropriate source context.
     public static func ioOnClosedConnection(file: String = #file, line: UInt = #line) -> IOOnClosedConnection {
         return IOOnClosedConnection(file: file, line: line)
     }
 
+    /// Creates a ``ReceivedBadSettings`` error with appropriate source context.
     public static func receivedBadSettings(file: String = #file, line: UInt = #line) -> ReceivedBadSettings {
         return ReceivedBadSettings(file: file, line: line)
     }
 
+    /// Creates a ``MaxStreamsViolation`` error with appropriate source context.
     public static func maxStreamsViolation(file: String = #file, line: UInt = #line) -> MaxStreamsViolation {
         return MaxStreamsViolation(file: file, line: line)
     }
 
+    /// Creates a ``StreamIDTooSmall`` error with appropriate source context.
     public static func streamIDTooSmall(file: String = #file, line: UInt = #line) -> StreamIDTooSmall {
         return StreamIDTooSmall(file: file, line: line)
     }
 
+    /// Creates a ``MissingPreface`` error with appropriate source context.
     public static func missingPreface(file: String = #file, line: UInt = #line) -> MissingPreface {
         return MissingPreface(file: file, line: line)
     }
 
+    /// Creates a ``CreatedStreamAfterGoaway`` error with appropriate source context.
     public static func createdStreamAfterGoaway(file: String = #file, line: UInt = #line) -> CreatedStreamAfterGoaway {
         return CreatedStreamAfterGoaway(file: file, line: line)
     }
 
+    /// Creates a ``InvalidStreamIDForPeer`` error with appropriate source context.
     public static func invalidStreamIDForPeer(file: String = #file, line: UInt = #line) -> InvalidStreamIDForPeer {
         return InvalidStreamIDForPeer(file: file, line: line)
     }
 
+    /// Creates a ``RaisedGoawayLastStreamID`` error with appropriate source context.
     public static func raisedGoawayLastStreamID(file: String = #file, line: UInt = #line) -> RaisedGoawayLastStreamID {
         return RaisedGoawayLastStreamID(file: file, line: line)
     }
 
+    /// Creates a ``InvalidWindowIncrementSize`` error with appropriate source context.
     public static func invalidWindowIncrementSize(file: String = #file, line: UInt = #line) -> InvalidWindowIncrementSize {
         return InvalidWindowIncrementSize(file: file, line: line)
     }
 
+    /// Creates a ``PushInViolationOfSetting`` error with appropriate source context.
     public static func pushInViolationOfSetting(file: String = #file, line: UInt = #line) -> PushInViolationOfSetting {
         return PushInViolationOfSetting(file: file, line: line)
     }
 
+    /// Creates a ``Unsupported`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///      - info: Human-readable information describing _what_ is unsupported.
     public static func unsupported(info: String, file: String = #file, line: UInt = #line) -> Unsupported {
         return Unsupported(info: info, file: file, line: line)
     }
 
+    /// Creates a ``UnableToSerializeFrame`` error with appropriate source context.
     public static func unableToSerializeFrame(file: String = #file, line: UInt = #line) -> UnableToSerializeFrame {
         return UnableToSerializeFrame(file: file, line: line)
     }
 
+    /// Creates a ``UnableToParseFrame`` error with appropriate source context.
     public static func unableToParseFrame(file: String = #file, line: UInt = #line) -> UnableToParseFrame {
         return UnableToParseFrame(file: file, line: line)
     }
 
+    /// Creates a ``MissingPseudoHeader`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///      - name: The name of the pseudo-header that was missing from the header block.
     public static func missingPseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> MissingPseudoHeader {
         return MissingPseudoHeader(name, file: file, line: line)
     }
 
+    /// Creates a ``DuplicatePseudoHeader`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - name: The name of the pseudo-header that was duplicated within the header block.
     public static func duplicatePseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> DuplicatePseudoHeader {
         return DuplicatePseudoHeader(name, file: file, line: line)
     }
 
+    /// Creates a ``PseudoHeaderAfterRegularHeader`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - name: The name of the pseudo-header that appeared after a regular header in the header block.
     public static func pseudoHeaderAfterRegularHeader(_ name: String, file: String = #file, line: UInt = #line) -> PseudoHeaderAfterRegularHeader {
         return PseudoHeaderAfterRegularHeader(name, file: file, line: line)
     }
 
+    /// Creates a ``UnknownPseudoHeader`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - name: The name of the pseudo-header that was not recognised by ``NIOHTTP2``.
     public static func unknownPseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> UnknownPseudoHeader {
         return UnknownPseudoHeader(name, file: file, line: line)
     }
 
+    /// Creates a ``InvalidPseudoHeaders`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - block: The block of `HPACKHeaders` that contain the invalid pseudo headers.
     public static func invalidPseudoHeaders(_ block: HPACKHeaders, file: String = #file, line: UInt = #line) -> InvalidPseudoHeaders {
         return InvalidPseudoHeaders(block, file: file, line: line)
     }
 
+    /// Creates a ``MissingHostHeader`` error with appropriate source context.
     public static func missingHostHeader(file: String = #file, line: UInt = #line) -> MissingHostHeader {
         return MissingHostHeader(file: file, line: line)
     }
 
+    /// Creates a ``DuplicateHostHeader`` error with appropriate source context.
     public static func duplicateHostHeader(file: String = #file, line: UInt = #line) -> DuplicateHostHeader {
         return DuplicateHostHeader(file: file, line: line)
     }
 
+    /// Creates a ``EmptyPathHeader`` error with appropriate source context.
     public static func emptyPathHeader(file: String = #file, line: UInt = #line) -> EmptyPathHeader {
         return EmptyPathHeader(file: file, line: line)
     }
 
+    /// Creates a ``InvalidStatusValue`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - value: The value of the `:status` header that is invalid.
     public static func invalidStatusValue(_ value: String, file: String = #file, line: UInt = #line) -> InvalidStatusValue {
         return InvalidStatusValue(value, file: file, line: line)
     }
 
+    /// Creates a ``PriorityCycle`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - streamID: The ``HTTP2StreamID`` representing the stream that created the priority cycle.
     public static func priorityCycle(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> PriorityCycle {
         return PriorityCycle(streamID: streamID, file: file, line: line)
     }
 
+    /// Creates a ``TrailersWithoutEndStream`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - streamID: The ``HTTP2StreamID`` on which the `HEADERS` frame without `END_STREAM` was received.
     public static func trailersWithoutEndStream(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> TrailersWithoutEndStream {
         return TrailersWithoutEndStream(streamID: streamID, file: file, line: line)
     }
 
+    /// Creates a ``InvalidHTTP2HeaderFieldName`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - fieldName: The invalid HTTP/2 header field name
     public static func invalidHTTP2HeaderFieldName(_ fieldName: String, file: String = #file, line: UInt = #line) -> InvalidHTTP2HeaderFieldName {
         return InvalidHTTP2HeaderFieldName(fieldName, file: file, line: line)
     }
 
+    /// Creates a ``ForbiddenHeaderField`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - name: The field name for the forbidden header field
+    ///     - value: The field value for the forbidden header field
     public static func forbiddenHeaderField(name: String, value: String, file: String = #file, line: UInt = #line) -> ForbiddenHeaderField {
         return ForbiddenHeaderField(name: name, value: value, file: file, line: line)
     }
 
+    /// Creates a ``ContentLengthViolated`` error with appropriate source context.
     public static func contentLengthViolated(file: String = #file, line: UInt = #line) -> ContentLengthViolated {
         return ContentLengthViolated(file: file, line: line)
     }
 
+    /// Creates a ``ExcessiveEmptyDataFrames`` error with appropriate source context.
     public static func excessiveEmptyDataFrames(file: String = #file, line: UInt = #line) -> ExcessiveEmptyDataFrames {
         return ExcessiveEmptyDataFrames(file: file, line: line)
     }
 
+    /// Creates a ``ExcessivelyLargeHeaderBlock`` error with appropriate source context.
     public static func excessivelyLargeHeaderBlock(file: String = #file, line: UInt = #line) -> ExcessivelyLargeHeaderBlock {
         return ExcessivelyLargeHeaderBlock(file: file, line: line)
     }
 
+    /// Creates a ``NoStreamIDAvailable`` error with appropriate source context.
     public static func noStreamIDAvailable(file: String = #file, line: UInt = #line) -> NoStreamIDAvailable {
         return NoStreamIDAvailable(file: file, line: line)
     }
 
+    /// Creates a ``StreamError`` error with appropriate source context.
+    ///
+    /// - parameters:
+    ///     - streamID: The ``HTTP2StreamID`` on which this error was triggered
+    ///     - baseError: The underlying `Error` that was thrown.
     public static func streamError(streamID: HTTP2StreamID, baseError: Error) -> StreamError {
         return StreamError(streamID: streamID, baseError: baseError)
     }
@@ -233,7 +331,7 @@ public enum NIOHTTP2Errors {
 
     /// An attempt was made to issue a write on a stream that does not exist.
     public struct NoSuchStream: NIOHTTP2Error {
-        /// The stream ID that was used that does not exist.
+        /// The ``HTTP2StreamID`` that was used that does not exist.
         public var streamID: HTTP2StreamID
 
         /// The location where the error was thrown.
@@ -256,10 +354,10 @@ public enum NIOHTTP2Errors {
 
     /// A stream was closed.
     public struct StreamClosed: NIOHTTP2Error {
-        /// The stream ID that was closed.
+        /// The ``HTTP2StreamID`` that was closed.
         public var streamID: HTTP2StreamID
 
-        /// The error code associated with the closure.
+        /// The ``HTTP2ErrorCode`` associated with the closure.
         public var errorCode: HTTP2ErrorCode
 
         /// The file and line where the error was created.
@@ -281,6 +379,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
+    /// The expected "client magic" string that must be received first on a HTTP/2 connection was incorrect.
     public struct BadClientMagic: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -307,6 +406,7 @@ public enum NIOHTTP2Errors {
 
     /// A stream state transition was attempted that was not valid.
     public struct BadStreamStateTransition: NIOHTTP2Error, CustomStringConvertible {
+        /// The ``NIOHTTP2StreamState`` that we were trying to transition out of.
         public let fromState: NIOHTTP2StreamState?
 
         /// The location where the error was thrown.
@@ -333,7 +433,7 @@ public enum NIOHTTP2Errors {
     }
 
     /// An attempt was made to change the flow control window size, either via
-    /// SETTINGS or WINDOW_UPDATE, but this change would move the flow control
+    /// `SETTINGS` or `WINDOW_UPDATE`, but this change would move the flow control
     /// window size out of bounds.
     public struct InvalidFlowControlWindowSize: NIOHTTP2Error, CustomStringConvertible {
         private var storage: Storage
@@ -438,7 +538,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// A SETTINGS frame was sent or received with an invalid setting.
+    /// A `SETTINGS` frame was sent or received with an invalid setting.
     public struct InvalidSetting: NIOHTTP2Error {
         /// The invalid setting.
         public var setting: HTTP2Setting
@@ -486,7 +586,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// A SETTINGS frame was received that is invalid.
+    /// A `SETTINGS` frame was received that is invalid.
     public struct ReceivedBadSettings: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -511,7 +611,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// A violation of SETTINGS_MAX_CONCURRENT_STREAMS occurred.
+    /// A violation of `SETTINGS_MAX_CONCURRENT_STREAMS` occurred.
     public struct MaxStreamsViolation: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -586,7 +686,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// An attempt was made to create a stream after a GOAWAY frame has forbidden further
+    /// An attempt was made to create a stream after a `GOAWAY` frame has forbidden further
     /// stream creation.
     public struct CreatedStreamAfterGoaway: NIOHTTP2Error {
         private let file: String
@@ -637,7 +737,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// An attempt was made to send a new GOAWAY frame whose lastStreamID is higher than the previous value.
+    /// An attempt was made to send a new `GOAWAY` frame whose `lastStreamID` is higher than the previous value.
     public struct RaisedGoawayLastStreamID: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -722,6 +822,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// A human-readable description of what unsupported feature was used.
         public var info: String {
             get {
                 return self.storage.value
@@ -753,6 +854,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
+    /// A HTTP/2 frame could not be serialized.
     public struct UnableToSerializeFrame: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -777,6 +879,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
+    /// A HTTP/2 frame was unable to be parsed.
     public struct UnableToParseFrame: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -811,6 +914,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the missing pseudo-header field
         public var name: String {
             get {
                 return self.storage.value
@@ -852,6 +956,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the pseudo-header field that was duplicated
         public var name: String {
             get {
                 return self.storage.value
@@ -893,6 +998,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the pseudo-header that occurred after the regular header.
         public var name: String {
             get {
                 return self.storage.value
@@ -934,6 +1040,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the unrecognised pseudo-header field.
         public var name: String {
             get {
                 return self.storage.value
@@ -967,6 +1074,7 @@ public enum NIOHTTP2Errors {
 
     /// A header block was received with an invalid set of pseudo-headers for the block type.
     public struct InvalidPseudoHeaders: NIOHTTP2Error {
+        /// The header block containing the invalid set of pseudo-headers.
         public var headerBlock: HPACKHeaders
 
         /// The location where the error was thrown.
@@ -1062,7 +1170,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// A :status header was received with an invalid value.
+    /// A `:status` header was received with an invalid value.
     public struct InvalidStatusValue: NIOHTTP2Error, CustomStringConvertible {
         private var storage: StringAndLocationStorage
 
@@ -1072,6 +1180,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The invalid value of the `:status` header.
         public var value: String {
             get {
                 return self.storage.value
@@ -1103,7 +1212,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// A priority update was received that would create a PRIORITY cycle.
+    /// A priority update was received that would create a `PRIORITY` cycle.
     public struct PriorityCycle: NIOHTTP2Error {
         /// The affected stream ID.
         public var streamID: HTTP2StreamID
@@ -1126,7 +1235,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// An attempt was made to send trailers without setting END_STREAM on them.
+    /// An attempt was made to send trailers without setting `END_STREAM` on them.
     public struct TrailersWithoutEndStream: NIOHTTP2Error {
         /// The affected stream ID.
         public var streamID: HTTP2StreamID
@@ -1159,6 +1268,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the invalid header field.
         public var fieldName: String {
             get {
                 return self.storage.value
@@ -1227,6 +1337,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The name of the forbidden header field.
         public var name: String {
             get {
                 return self.storage.name
@@ -1237,6 +1348,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The value of the forbidden header field.
         public var value: String {
             get {
                 return self.storage.value
@@ -1293,7 +1405,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// The remote peer has sent an excessive number of empty DATA frames, which looks like a denial of service
+    /// The remote peer has sent an excessive number of empty `DATA` frames, which looks like a denial of service
     /// attempt, so the connection has been closed.
     public struct ExcessiveEmptyDataFrames: NIOHTTP2Error {
         private let file: String
@@ -1319,7 +1431,7 @@ public enum NIOHTTP2Errors {
         }
     }
 
-    /// The remote peer has sent a header block so large that NIO refuses to buffer any more data than that.
+    /// The remote peer has sent a header block so large that ``NIOHTTP2`` refuses to buffer any more data than that.
     public struct ExcessivelyLargeHeaderBlock: NIOHTTP2Error {
         private let file: String
         private let line: UInt
@@ -1372,7 +1484,7 @@ public enum NIOHTTP2Errors {
     /// A StreamError was hit during outbound frame processing.
     ///
     /// Stream errors are wrappers around another error of some other kind that occurred on a specific stream.
-    /// As they are a wrapper error, they carry a "real" error in the `baseError`. Additionally, they cannot
+    /// As they are a wrapper error, they carry a "real" error in ``baseError``. Additionally, they cannot
     /// meaningfully be `Equatable`, so they aren't. There's also no additional location information: that's
     /// provided by the base error.
     public struct StreamError: Error {
@@ -1401,6 +1513,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The underlying thrown error.
         public var baseError: Error {
             get {
                 return self.storage.baseError
@@ -1411,6 +1524,7 @@ public enum NIOHTTP2Errors {
             }
         }
 
+        /// The ``HTTP2StreamID`` on which the error was thrown.
         public var streamID: HTTP2StreamID {
             get {
                 return self.storage.streamID

--- a/Sources/NIOHTTP2/HTTP2ErrorCode.swift
+++ b/Sources/NIOHTTP2/HTTP2ErrorCode.swift
@@ -15,6 +15,9 @@
 import NIOCore
 
 /// An HTTP/2 error code.
+///
+/// HTTP/2 uses error codes to communicate to remote peers what went wrong on either a stream or
+/// a connection. This data type models that underlying representation.
 public struct HTTP2ErrorCode: NIOSendable {
     /// The underlying network representation of the error code.
     public var networkCode: Int {
@@ -29,18 +32,18 @@ public struct HTTP2ErrorCode: NIOSendable {
     /// The underlying network representation of the error code.
     fileprivate var _networkCode: UInt32
 
-    /// Create a HTTP/2 error code from the given network value.
+    /// Create a ``HTTP2ErrorCode`` from the given network value.
     public init(networkCode: Int) {
         self._networkCode = UInt32(networkCode)
     }
 
-    /// Create a `HTTP2ErrorCode` from the 32-bit integer it corresponds to.
+    /// Create a ``HTTP2ErrorCode`` from the 32-bit integer it corresponds to.
     internal init(_ networkInteger: UInt32) {
         self._networkCode = networkInteger
     }
 
     /// The associated condition is not a result of an error. For example,
-    /// a GOAWAY might include this code to indicate graceful shutdown of
+    /// a `GOAWAY` might include this code to indicate graceful shutdown of
     /// a connection.
     public static let noError = HTTP2ErrorCode(networkCode: 0x0)
 
@@ -55,7 +58,7 @@ public struct HTTP2ErrorCode: NIOSendable {
     /// protocol.
     public static let flowControlError = HTTP2ErrorCode(networkCode: 0x03)
 
-    /// The endpoint sent a SETTINGS frame but did not receive a
+    /// The endpoint sent a `SETTINGS` frame but did not receive a
     /// response in a timely manner.
     public static let settingsTimeout = HTTP2ErrorCode(networkCode: 0x04)
 
@@ -77,7 +80,7 @@ public struct HTTP2ErrorCode: NIOSendable {
     /// context for the connection.
     public static let compressionError = HTTP2ErrorCode(networkCode: 0x09)
 
-    /// The connection established in response to a CONNECT request
+    /// The connection established in response to a `CONNECT` request
     /// was reset or abnormally closed.
     public static let connectError = HTTP2ErrorCode(networkCode: 0x0a)
 
@@ -138,25 +141,25 @@ extension HTTP2ErrorCode: CustomDebugStringConvertible {
 }
 
 public extension UInt32 {
-    /// Create a 32-bit integer corresponding to the given `HTTP2ErrorCode`.
+    /// Create a 32-bit integer corresponding to the given ``HTTP2ErrorCode``.
     init(http2ErrorCode code: HTTP2ErrorCode) {
         self = code._networkCode
     }
 }
 
 public extension Int {
-    /// Create an integer corresponding to the given `HTTP2ErrorCode`.
+    /// Create an integer corresponding to the given ``HTTP2ErrorCode``.
     init(http2ErrorCode code: HTTP2ErrorCode) {
         self = code.networkCode
     }
 }
 
 public extension ByteBuffer {
-    /// Serializes a `HTTP2ErrorCode` into a `ByteBuffer` in the appropriate endianness
+    /// Serializes a ``HTTP2ErrorCode`` into a `ByteBuffer` in the appropriate endianness
     /// for use in HTTP/2.
     ///
     /// - parameters:
-    ///     - code: The `HTTP2ErrorCode` to serialize.
+    ///     - code: The ``HTTP2ErrorCode`` to serialize.
     /// - returns: The number of bytes written.
     mutating func write(http2ErrorCode code: HTTP2ErrorCode) -> Int {
         return self.writeInteger(UInt32(http2ErrorCode: code))

--- a/Sources/NIOHTTP2/HTTP2PingData.swift
+++ b/Sources/NIOHTTP2/HTTP2PingData.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-/// The opaque data contained in a HTTP/2 ping frame.
+/// The opaque data contained in a HTTP/2 `PING` frame.
 ///
 /// A HTTP/2 ping frame must contain 8 bytes of opaque data that is controlled entirely by the sender.
 /// This data type encapsulates those 8 bytes while providing a friendly interface for them.
@@ -22,7 +22,7 @@ public struct HTTP2PingData: NIOSendable {
     /// The underlying bytes to be sent to the wire. These are in network byte order.
     public var bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 
-    /// Exposes the `HTTP2PingData` as an unsigned 64-bit integer. This property will perform any
+    /// Exposes the ``HTTP2PingData`` as an unsigned 64-bit integer. This property will perform any
     /// endianness transition that is required, meaning that there is no need to byte swap the result
     /// or before setting this property.
     public var integer: UInt64 {
@@ -50,18 +50,18 @@ public struct HTTP2PingData: NIOSendable {
         }
     }
 
-    /// Create a new, blank, `HTTP2PingData`.
+    /// Create a new, blank, ``HTTP2PingData``.
     public init() {
         self.bytes = (0, 0, 0, 0, 0, 0, 0, 0)
     }
 
-    /// Create a `HTTP2PingData` containing the 64-bit integer provided in network byte order.
+    /// Create a ``HTTP2PingData`` containing the 64-bit integer provided in network byte order.
     public init(withInteger integer: UInt64) {
         self.init()
         self.integer = integer
     }
 
-    /// Create a `HTTP2PingData` from a tuple of bytes.
+    /// Create a ``HTTP2PingData`` from a tuple of bytes.
     public init(withTuple tuple: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
         self.bytes = tuple
     }

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -21,13 +21,15 @@ import NIOTLS
 /// can negotiate HTTP/2 on secure connections. For example, using swift-nio-ssl,
 /// you could configure the pipeline like this:
 ///
-///     let config = TLSConfiguration.forClient(applicationProtocols: NIOHTTP2SupportedALPNProtocols)
-///     let context = try SSLContext(configuration: config)
-///     channel.pipeline.add(handler: OpenSSLClientHandler(context: context, serverHostname: "example.com")).then {
-///         channel.pipeline.configureHTTP2SecureUpgrade(...)
-///     }
+/// ```swift
+/// let config = TLSConfiguration.forClient(applicationProtocols: NIOHTTP2SupportedALPNProtocols)
+/// let context = try SSLContext(configuration: config)
+/// channel.pipeline.add(handler: OpenSSLClientHandler(context: context, serverHostname: "example.com")).then {
+///     channel.pipeline.configureHTTP2SecureUpgrade(...)
+/// }
+/// ```
 ///
-/// Configuring for servers is very similar, but is left as an exercise for the reader.
+/// Configuring for servers is very similar.
 public let NIOHTTP2SupportedALPNProtocols = ["h2", "http/1.1"]
 
 extension ChannelPipeline {

--- a/Sources/NIOHTTP2/HTTP2Settings.swift
+++ b/Sources/NIOHTTP2/HTTP2Settings.swift
@@ -24,19 +24,19 @@ public typealias HTTP2Settings = [HTTP2Setting]
 public struct HTTP2SettingsParameter: NIOSendable {
     internal let networkRepresentation: UInt16
 
-    /// Create a `HTTP2SettingsParameter` that is not known to NIO.
+    /// Create a ``HTTP2SettingsParameter`` that is not known to NIO.
     ///
     /// If this is a known parameter, use one of the static values.
     public init(extensionSetting: Int) {
         self.networkRepresentation = UInt16(extensionSetting)
     }
 
-    /// Initialize a `HTTP2SettingsParameter` from nghttp2's representation.
+    /// Initialize a ``HTTP2SettingsParameter`` from nghttp2's representation.
     internal init(fromNetwork value: Int32) {
         self.networkRepresentation = UInt16(value)
     }
     
-    /// Initialize a `HTTP2SettingsParameter` from a network `UInt16`.
+    /// Initialize a ``HTTP2SettingsParameter`` from a network `UInt16`.
     internal init(fromPayload value: UInt16) {
         self.networkRepresentation = value
     }
@@ -46,25 +46,25 @@ public struct HTTP2SettingsParameter: NIOSendable {
         self.networkRepresentation = value
     }
 
-    /// Corresponds to SETTINGS_HEADER_TABLE_SIZE
+    /// Corresponds to `SETTINGS_HEADER_TABLE_SIZE`
     public static let headerTableSize = HTTP2SettingsParameter(1)
 
-    /// Corresponds to SETTINGS_ENABLE_PUSH.
+    /// Corresponds to `SETTINGS_ENABLE_PUSH`.
     public static let enablePush = HTTP2SettingsParameter(2)
 
-    /// Corresponds to SETTINGS_MAX_CONCURRENT_STREAMS
+    /// Corresponds to `SETTINGS_MAX_CONCURRENT_STREAMS`
     public static let maxConcurrentStreams = HTTP2SettingsParameter(3)
 
-    /// Corresponds to SETTINGS_INITIAL_WINDOW_SIZE
+    /// Corresponds to `SETTINGS_INITIAL_WINDOW_SIZE`
     public static let initialWindowSize = HTTP2SettingsParameter(4)
 
-    /// Corresponds to SETTINGS_MAX_FRAME_SIZE
+    /// Corresponds to `SETTINGS_MAX_FRAME_SIZE`
     public static let maxFrameSize = HTTP2SettingsParameter(5)
 
-    /// Corresponds to SETTINGS_MAX_HEADER_LIST_SIZE
+    /// Corresponds to `SETTINGS_MAX_HEADER_LIST_SIZE`
     public static let maxHeaderListSize = HTTP2SettingsParameter(6)
     
-    /// Corresponds to SETTINGS_ENABLE_CONNECT_PROTOCOL from RFC 8441.
+    /// Corresponds to `SETTINGS_ENABLE_CONNECT_PROTOCOL` from RFC 8441.
     public static let enableConnectProtocol = HTTP2SettingsParameter(8)
 }
 
@@ -72,7 +72,7 @@ extension HTTP2SettingsParameter: Equatable { }
 
 extension HTTP2SettingsParameter: Hashable { }
 
-/// A single setting for HTTP/2, a combination of a `HTTP2SettingsParameter` and its value.
+/// A single setting for HTTP/2, a combination of a ``HTTP2SettingsParameter`` and its value.
 public struct HTTP2Setting: NIOSendable {
     /// The settings parameter for this setting.
     public var parameter: HTTP2SettingsParameter
@@ -92,7 +92,7 @@ public struct HTTP2Setting: NIOSendable {
     /// property.
     internal var _value: UInt32
 
-    /// Create a new `HTTP2Setting`.
+    /// Create a new ``HTTP2Setting``.
     public init(parameter: HTTP2SettingsParameter, value: Int) {
         self.parameter = parameter
         self._value = UInt32(value)

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -21,11 +21,12 @@ import NIOConcurrencyHelpers
 ///
 /// Please note that some of NIO's regular `ChannelOptions` are valid on `HTTP2StreamChannel`s.
 public struct HTTP2StreamChannelOptions: NIOSendable {
-    /// - seealso: `StreamIDOption`.
+    /// See ``HTTP2StreamChannelOptions/Types/StreamIDOption``.
     public static let streamID: HTTP2StreamChannelOptions.Types.StreamIDOption = .init()
 }
 
 extension HTTP2StreamChannelOptions {
+    /// A namespace for the types used to represent HTTP/2 stream channel options.
     public enum Types {}
 }
 
@@ -33,7 +34,7 @@ extension HTTP2StreamChannelOptions {
 public typealias StreamIDOption = HTTP2StreamChannelOptions.Types.StreamIDOption
 
 extension HTTP2StreamChannelOptions.Types {
-    /// `StreamIDOption` allows users to query the stream ID for a given `HTTP2StreamChannel`.
+    /// ``StreamIDOption`` allows users to query the stream ID for a given `HTTP2StreamChannel`.
     ///
     /// On active `HTTP2StreamChannel`s, it is possible that a channel handler or user may need to know which
     /// stream ID the channel owns. This channel option allows that query. Please note that this channel option

--- a/Sources/NIOHTTP2/HTTP2StreamID.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamID.swift
@@ -50,19 +50,19 @@ public struct HTTP2StreamID: NIOSendable {
         return self.networkStreamID % 2 == 0 && self != .rootStream
     }
 
-    /// Create a `HTTP2StreamID` for a specific integer value.
+    /// Create a ``HTTP2StreamID`` for a specific integer value.
     public init(_ integerID: Int) {
         precondition(integerID >= 0 && integerID <= Int32.max, "\(integerID) is not a valid HTTP/2 stream ID value")
         self.networkStreamID = Int32(integerID)
     }
 
-    /// Create a `HTTP2StreamID` for a specific integer value.
+    /// Create a ``HTTP2StreamID`` for a specific integer value.
     public init(_ integerID: Int32) {
         precondition(integerID >= 0, "\(integerID) is not a valid HTTP/2 stream ID value")
         self.networkStreamID = integerID
     }
     
-    /// Create a `HTTP2StreamID` from a 32-bit value received as part of a frame.
+    /// Create a ``HTTP2StreamID`` from a 32-bit value received as part of a frame.
     ///
     /// This will ignore the most significant bit of the provided value.
     internal init(networkID: UInt32) {

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -19,8 +19,9 @@ import NIOCore
 /// In general in NIO applications it is helpful to consider each HTTP/2 stream as an
 /// independent stream of HTTP/2 frames. This multiplexer achieves this by creating a
 /// number of in-memory `HTTP2StreamChannel` objects, one for each stream. These operate
-/// on `HTTP2Frame` objects as their base communication atom, as opposed to the regular
-/// NIO `SelectableChannel` objects which use `ByteBuffer` and `IOData`.
+/// on ``HTTP2Frame`` or ``HTTP2Frame/FramePayload`` objects as their base communication
+/// atom, as opposed to the regular NIO `SelectableChannel` objects which use `ByteBuffer`
+/// and `IOData`.
 public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboundHandler {
     public typealias InboundIn = HTTP2Frame
     public typealias InboundOut = HTTP2Frame
@@ -224,17 +225,17 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
         context.writeAndFlush(self.wrapOutboundOut(frame), promise: nil)
     }
 
-    /// Create a new `HTTP2StreamMultiplexer`.
+    /// Create a new ``HTTP2StreamMultiplexer``.
     ///
     /// - parameters:
     ///     - mode: The mode of the HTTP/2 connection being used: server or client.
-    ///     - channel: The Channel to which this `HTTP2StreamMultiplexer` belongs.
+    ///     - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
     ///     - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
     ///     - inboundStreamStateInitializer: A block that will be invoked to configure each new child stream
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         `createStreamChannel`.
+    ///         ``createStreamChannel(promise:_:)-18bxc``.
     @available(*, deprecated, renamed: "init(mode:channel:targetWindowSize:outboundBufferSizeHighWatermark:outboundBufferSizeLowWatermark:inboundStreamInitializer:)")
     public convenience init(mode: NIOHTTP2Handler.ParserMode, channel: Channel, targetWindowSize: Int = 65535, inboundStreamStateInitializer: ((Channel, HTTP2StreamID) -> EventLoopFuture<Void>)? = nil) {
         // We default to an 8kB outbound buffer size: this is a good trade off for avoiding excessive buffering while ensuring that decent
@@ -247,11 +248,11 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                   inboundStreamStateInitializer: .includesStreamID(inboundStreamStateInitializer))
     }
 
-    /// Create a new `HTTP2StreamMultiplexer`.
+    /// Create a new ``HTTP2StreamMultiplexer``.
     ///
     /// - parameters:
     ///     - mode: The mode of the HTTP/2 connection being used: server or client.
-    ///     - channel: The Channel to which this `HTTP2StreamMultiplexer` belongs.
+    ///     - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
     ///     - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
     ///     - outboundBufferSizeHighWatermark: The high watermark for the number of bytes of writes that are
     ///         allowed to be un-sent on any child stream. This is broadly analogous to a regular socket send buffer.
@@ -263,7 +264,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         `createStreamChannel`.
+    ///         ``createStreamChannel(promise:_:)-18bxc``.
     public convenience init(mode: NIOHTTP2Handler.ParserMode,
                             channel: Channel,
                             targetWindowSize: Int = 65535,
@@ -278,7 +279,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                   inboundStreamStateInitializer: .excludesStreamID(inboundStreamInitializer))
     }
 
-    /// Create a new `HTTP2StreamMultiplexer`.
+    /// Create a new ``HTTP2StreamMultiplexer``.
     ///
     /// - parameters:
     ///     - mode: The mode of the HTTP/2 connection being used: server or client.
@@ -292,7 +293,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         `createStreamChannel`.
+    ///         ``createStreamChannel(promise:_:)-18bxc``.
     @available(*, deprecated, renamed: "init(mode:channel:targetWindowSize:outboundBufferSizeHighWatermark:outboundBufferSizeLowWatermark:inboundStreamInitializer:)")
     public convenience init(mode: NIOHTTP2Handler.ParserMode,
                             channel: Channel,
@@ -362,8 +363,7 @@ extension HTTP2StreamMultiplexer {
     /// This method is intended for situations where the NIO application is initiating the stream. For clients,
     /// this is for all request streams. For servers, this is for pushed streams.
     ///
-    /// - note:
-    /// Resources for the stream will be freed after it has been closed.
+    /// > Note: Resources for the stream will be freed after it has been closed.
     ///
     /// - parameters:
     ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
@@ -392,8 +392,7 @@ extension HTTP2StreamMultiplexer {
     /// This method is intended for situations where the NIO application is initiating the stream. For clients,
     /// this is for all request streams. For servers, this is for pushed streams.
     ///
-    /// - note:
-    /// Resources for the stream will be freed after it has been closed.
+    /// > Note: Resources for the stream will be freed after it has been closed.
     ///
     /// - parameters:
     ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or

--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -123,7 +123,7 @@ fileprivate struct BaseClientCodec {
 /// A simple channel handler that translates HTTP/2 concepts into HTTP/1 data types,
 /// and vice versa, for use on the client side.
 ///
-/// This channel handler should be used alongside the `HTTP2StreamMultiplexer` to
+/// This channel handler should be used alongside the ``HTTP2StreamMultiplexer`` to
 /// help provide a HTTP/1.1-like abstraction on top of a HTTP/2 multiplexed
 /// connection.
 @available(*, deprecated, renamed: "HTTP2FramePayloadToHTTP1ClientCodec")
@@ -140,10 +140,10 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
     private let streamID: HTTP2StreamID
     private var baseCodec: BaseClientCodec
 
-    /// Initializes a `HTTP2ToHTTP1ClientCodec` for the given `HTTP2StreamID`.
+    /// Initializes a ``HTTP2ToHTTP1ClientCodec`` for the given ``HTTP2StreamID``.
     ///
     /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this `HTTP2ToHTTP1ClientCodec` will be used for
+    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
     ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
     ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
@@ -155,10 +155,10 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
         self.baseCodec = BaseClientCodec(httpProtocol: httpProtocol, normalizeHTTPHeaders: normalizeHTTPHeaders)
     }
 
-    /// Initializes a `HTTP2ToHTTP1ClientCodec` for the given `HTTP2StreamID`.
+    /// Initializes a ``HTTP2ToHTTP1ClientCodec`` for the given ``HTTP2StreamID``.
     ///
     /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this `HTTP2ToHTTP1ClientCodec` will be used for
+    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
     ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
     public convenience init(streamID: HTTP2StreamID, httpProtocol: HTTPProtocol) {
         self.init(streamID: streamID, httpProtocol: httpProtocol, normalizeHTTPHeaders: true)
@@ -196,11 +196,11 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
 /// A simple channel handler that translates HTTP/2 concepts into HTTP/1 data types,
 /// and vice versa, for use on the client side.
 ///
-/// This channel handler should be used alongside the `HTTP2StreamMultiplexer` to
+/// This channel handler should be used alongside the ``HTTP2StreamMultiplexer`` to
 /// help provide a HTTP/1.1-like abstraction on top of a HTTP/2 multiplexed
 /// connection.
 ///
-/// This handler uses `HTTP2Frame.FramePayload` as its HTTP/2 currency type.
+/// This handler uses ``HTTP2Frame/FramePayload`` as its HTTP/2 currency type.
 public final class HTTP2FramePayloadToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutboundHandler {
     public typealias InboundIn = HTTP2Frame.FramePayload
     public typealias InboundOut = HTTPClientResponsePart
@@ -216,7 +216,7 @@ public final class HTTP2FramePayloadToHTTP1ClientCodec: ChannelInboundHandler, C
         case http
     }
 
-    /// Initializes a `HTTP2PayloadToHTTP1ClientCodec`.
+    /// Initializes a ``HTTP2FramePayloadToHTTP1ClientCodec``.
     ///
     /// - parameters:
     ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
@@ -328,7 +328,7 @@ fileprivate struct BaseServerCodec {
 /// A simple channel handler that translates HTTP/2 concepts into HTTP/1 data types,
 /// and vice versa, for use on the server side.
 ///
-/// This channel handler should be used alongside the `HTTP2StreamMultiplexer` to
+/// This channel handler should be used alongside the ``HTTP2StreamMultiplexer`` to
 /// help provide a HTTP/1.1-like abstraction on top of a HTTP/2 multiplexed
 /// connection.
 @available(*, deprecated, renamed: "HTTP2FramePayloadToHTTP1ServerCodec")
@@ -342,10 +342,10 @@ public final class HTTP2ToHTTP1ServerCodec: ChannelInboundHandler, ChannelOutbou
     private let streamID: HTTP2StreamID
     private var baseCodec: BaseServerCodec
 
-    /// Initializes a `HTTP2ToHTTP1ServerCodec` for the given `HTTP2StreamID`.
+    /// Initializes a ``HTTP2ToHTTP1ServerCodec`` for the given ``HTTP2StreamID``.
     ///
     /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this `HTTP2ToHTTP1ServerCodec` will be used for
+    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ServerCodec`` will be used for
     ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
@@ -387,11 +387,11 @@ public final class HTTP2ToHTTP1ServerCodec: ChannelInboundHandler, ChannelOutbou
 /// A simple channel handler that translates HTTP/2 concepts into HTTP/1 data types,
 /// and vice versa, for use on the server side.
 ///
-/// This channel handler should be used alongside the `HTTP2StreamMultiplexer` to
+/// This channel handler should be used alongside the ``HTTP2StreamMultiplexer`` to
 /// help provide a HTTP/1.1-like abstraction on top of a HTTP/2 multiplexed
 /// connection.
 ///
-/// This handler uses `HTTP2Frame.FramePayload` as its HTTP/2 currency type.
+/// This handler uses ``HTTP2Frame/FramePayload`` as its HTTP/2 currency type.
 public final class HTTP2FramePayloadToHTTP1ServerCodec: ChannelInboundHandler, ChannelOutboundHandler {
     public typealias InboundIn = HTTP2Frame.FramePayload
     public typealias InboundOut = HTTPServerRequestPart
@@ -401,7 +401,7 @@ public final class HTTP2FramePayloadToHTTP1ServerCodec: ChannelInboundHandler, C
 
     private var baseCodec: BaseServerCodec
 
-    /// Initializes a `HTTP2PayloadToHTTP1ServerCodec`.
+    /// Initializes a ``HTTP2FramePayloadToHTTP1ServerCodec``.
     ///
     /// - parameters:
     ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.

--- a/Sources/NIOHTTP2/HTTP2UserEvents.swift
+++ b/Sources/NIOHTTP2/HTTP2UserEvents.swift
@@ -14,19 +14,19 @@
 
 import NIOCore
 
-/// A `StreamClosedEvent` is fired whenever a stream is closed.
+/// A ``StreamClosedEvent`` is fired whenever a stream is closed.
 ///
-/// This event is fired whether the stream is closed normally, or via RST_STREAM,
-/// or via GOAWAY. Normal closure is indicated by having `reason` be `nil`. In the
-/// case of closure by GOAWAY the `reason` is always `.refusedStream`, indicating that
-/// the remote peer has not processed this stream. In the case of RST_STREAM,
-/// the `reason` contains the error code sent by the peer in the RST_STREAM frame.
+/// This event is fired whether the stream is closed normally, or via `RST_STREAM`,
+/// or via `GOAWAY`. Normal closure is indicated by having ``reason`` be `nil`. In the
+/// case of closure by `GOAWAY` the ``reason`` is always ``HTTP2ErrorCode/refusedStream``,
+/// indicating that the remote peer has not processed this stream. In the case of
+/// `RST_STREAM`, the ``reason`` contains the error code sent by the peer in the `RST_STREAM` frame.
 public struct StreamClosedEvent: NIOSendable {
     /// The stream ID of the stream that is closed.
     public let streamID: HTTP2StreamID
 
     /// The reason for the stream closure. `nil` if the stream was closed without
-    /// error. Otherwise, the error code indicating why the stream was closed.
+    /// error. Otherwise, ``HTTP2ErrorCode`` indicating why the stream was closed.
     public let reason: HTTP2ErrorCode?
 
     public init(streamID: HTTP2StreamID, reason: HTTP2ErrorCode?) {
@@ -38,11 +38,11 @@ public struct StreamClosedEvent: NIOSendable {
 extension StreamClosedEvent: Hashable { }
 
 
-/// A `NIOHTTP2WindowUpdatedEvent` is fired whenever a flow control window is changed.
+/// A ``NIOHTTP2WindowUpdatedEvent`` is fired whenever a flow control window is changed.
 /// This includes changes on the connection flow control window, which is signalled by
-/// this event having `streamID` set to `.rootStream`.
+/// this event having ``streamID`` set to ``HTTP2StreamID/rootStream``.
 public struct NIOHTTP2WindowUpdatedEvent {
-    /// The stream ID of the window that has been changed. May be .rootStream, in which
+    /// The stream ID of the window that has been changed. May be ``HTTP2StreamID/rootStream``, in which
     /// case the connection window has changed.
     public let streamID: HTTP2StreamID
 
@@ -86,8 +86,9 @@ public struct NIOHTTP2WindowUpdatedEvent {
 extension NIOHTTP2WindowUpdatedEvent: Hashable { }
 
 
-/// A `NIOHTTP2StreamCreatedEvent` is fired whenever a HTTP/2 stream is created.
+/// A ``NIOHTTP2StreamCreatedEvent`` is fired whenever a HTTP/2 stream is created.
 public struct NIOHTTP2StreamCreatedEvent {
+    /// The ``HTTP2StreamID`` of the created stream.
     public let streamID: HTTP2StreamID
 
     /// The initial local stream window size. May be nil if this stream may never have data sent on it.
@@ -105,9 +106,9 @@ public struct NIOHTTP2StreamCreatedEvent {
 
 extension NIOHTTP2StreamCreatedEvent: Hashable { }
 
-/// A `NIOHTTP2BulkStreamWindowChangeEvent` is fired whenever all of the remote flow control windows for a given stream have been changed.
+/// A ``NIOHTTP2BulkStreamWindowChangeEvent`` is fired whenever all of the remote flow control windows for a given stream have been changed.
 ///
-/// This occurs when an ACK to a SETTINGS frame is received that changes the value of SETTINGS_INITIAL_WINDOW_SIZE. This is only fired
+/// This occurs when an `ACK` to a `SETTINGS` frame is received that changes the value of `SETTINGS_INITIAL_WINDOW_SIZE`. This is only fired
 /// when the local peer has changed its settings.
 public struct NIOHTTP2BulkStreamWindowChangeEvent {
     /// The change in the remote stream window sizes.

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -1026,7 +1026,8 @@ private extension HPACKHeaders {
     }
 }
 
-/// A state of a `HTTP2StreamStateMachine`. This copy in effect mirrors `HTTP2StreamStateMachine.state` but without associated values.
+/// A state of a `HTTP2StreamStateMachine`. This copy in effect mirrors `HTTP2StreamStateMachine.state` but without associated values,
+/// and is used to provide detail in errors.
 public struct NIOHTTP2StreamState: Hashable, CustomStringConvertible, NIOSendable {
     private enum State {
         case idle

--- a/docker/docker-compose.1804.54.yaml
+++ b/docker/docker-compose.1804.54.yaml
@@ -13,6 +13,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:18.04-5.4
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio-http2:18.04-5.4
@@ -25,6 +26,7 @@ services:
 
   test:
     image: swift-nio-http2:18.04-5.4
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -12,6 +12,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.5
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.5
@@ -24,6 +25,7 @@ services:
 
   test:
     image: swift-nio-http2:20.04-5.5
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -12,7 +12,6 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.5
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.5
@@ -37,7 +36,6 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
-    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -12,6 +12,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.5
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.5
@@ -36,6 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -12,6 +12,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.6
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.6
@@ -36,6 +37,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -12,7 +12,6 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.6
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.6
@@ -37,7 +36,6 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -11,7 +11,6 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.7
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.7
@@ -36,7 +35,6 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.7

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -11,6 +11,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-5.7
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-5.7
@@ -35,6 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-5.7

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -11,7 +11,6 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-main
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-main
@@ -36,7 +35,6 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-main

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -11,6 +11,7 @@ services:
 
   unit-tests:
     image: swift-nio-http2:20.04-main
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     image: swift-nio-http2:20.04-main
@@ -35,6 +36,7 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
       - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   shell:
     image: swift-nio-http2:20.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   unit-tests:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     <<: *common
@@ -44,7 +44,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
 
   # util
 

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -71,7 +71,7 @@ for language in swift-or-c bash dtrace; do
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -name c_nio_http_parser.c -o -name c_nio_http_parser.h -o -name cpp_magic.h -o -name Package.swift -o -name c_nio_sha1.h -o -name c_nio_sha1.c)
+        exceptions=( -name c_nio_http_parser.c -o -name c_nio_http_parser.h -o -name cpp_magic.h -o -name Package.swift -o -name c_nio_sha1.h -o -name c_nio_sha1.c -o -name 'Package@swift*.swift')
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Motivation

Documentation is nice, and we can help support users by providing useful
clear docs.

Modifications

Add Docc to 5.6 and later builds
Make sure symbol references work
Add overview docs

Result

Nice rendering docs