### PR TITLE
Better GoAWAY error

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -44,7 +44,7 @@ struct ConnectionStreamState {
     private var serverStreamCount: UInt32 = 0
 
     /// The highest stream ID opened or reserved by the client.
-    private var lastClientStreamID: HTTP2StreamID = .rootStream
+    private(set) var lastClientStreamID: HTTP2StreamID = .rootStream
 
     /// The highest stream ID opened or reserved by the server.
     private var lastServerStreamID: HTTP2StreamID = .rootStream

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
@@ -70,8 +70,9 @@ extension SendingHeadersState where Self: RemotelyQuiescingState {
     mutating func sendHeaders(streamID: HTTP2StreamID, headers: HPACKHeaders, isEndStreamSet endStream: Bool) -> StateMachineResultWithEffect {
         let validateHeaderBlock = self.headerBlockValidation == .enabled
         let validateContentLength = self.contentLengthValidation == .enabled
-        if streamID > self.streamState.lastClientStreamID &&
-            self.role == .client && streamID.mayBeInitiatedBy(.client) {
+        if streamID.mayBeInitiatedBy(.client) &&
+            self.role == .client &&
+            streamID > self.streamState.lastClientStreamID {
             let error = NIOHTTP2Errors.createdStreamAfterGoaway()
             return StateMachineResultWithEffect(result: .connectionError(underlyingError: error, type: .protocolError), effect: nil)
         }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingHeadersState.swift
@@ -70,7 +70,11 @@ extension SendingHeadersState where Self: RemotelyQuiescingState {
     mutating func sendHeaders(streamID: HTTP2StreamID, headers: HPACKHeaders, isEndStreamSet endStream: Bool) -> StateMachineResultWithEffect {
         let validateHeaderBlock = self.headerBlockValidation == .enabled
         let validateContentLength = self.contentLengthValidation == .enabled
-        
+        if streamID > self.streamState.lastClientStreamID &&
+            self.role == .client && streamID.mayBeInitiatedBy(.client) {
+            let error = NIOHTTP2Errors.createdStreamAfterGoaway()
+            return StateMachineResultWithEffect(result: .connectionError(underlyingError: error, type: .protocolError), effect: nil)
+        }
         let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: false) {
             $0.sendHeaders(headers: headers, validateHeaderBlock: validateHeaderBlock, validateContentLength: validateContentLength, isEndStreamSet: endStream)
         }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -955,6 +955,8 @@ class ConnectionStateMachineTests: XCTestCase {
         var temporaryClient = self.client!
 
         assertConnectionError(type: .protocolError, temporaryServer.sendPushPromise(originalStreamID: streamOne, childStreamID: streamFour, headers: ConnectionStateMachineTests.requestHeaders))
+        let error = assertConnectionError(type: .protocolError, temporaryClient.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        XCTAssertEqual(error as? NIOHTTP2Errors.CreatedStreamAfterGoaway, NIOHTTP2Errors.createdStreamAfterGoaway())
         assertIgnored(temporaryClient.receivePushPromise(originalStreamID: streamOne, childStreamID: streamFour, headers: ConnectionStateMachineTests.requestHeaders))
 
         // And the client cannot initiate a new stream with headers.

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -955,14 +955,13 @@ class ConnectionStateMachineTests: XCTestCase {
         var temporaryClient = self.client!
 
         assertConnectionError(type: .protocolError, temporaryServer.sendPushPromise(originalStreamID: streamOne, childStreamID: streamFour, headers: ConnectionStateMachineTests.requestHeaders))
-        let error = assertConnectionError(type: .protocolError, temporaryClient.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
-        XCTAssertEqual(error as? NIOHTTP2Errors.CreatedStreamAfterGoaway, NIOHTTP2Errors.createdStreamAfterGoaway())
         assertIgnored(temporaryClient.receivePushPromise(originalStreamID: streamOne, childStreamID: streamFour, headers: ConnectionStateMachineTests.requestHeaders))
 
         // And the client cannot initiate a new stream with headers.
         temporaryServer = self.server!
         temporaryClient = self.client!
-        assertConnectionError(type: .protocolError, temporaryClient.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        let error = assertConnectionError(type: .protocolError, temporaryClient.sendHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        XCTAssertEqual(error as? NIOHTTP2Errors.CreatedStreamAfterGoaway, NIOHTTP2Errors.createdStreamAfterGoaway())
         assertIgnored(temporaryServer.receiveHeaders(streamID: streamThree, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
 
         XCTAssertFalse(self.server.fullyQuiesced)


### PR DESCRIPTION
Motivation:

Improve error messages

Modifications:

Replaced no such stream error with correct createdStreamAfterGoaway error