### PR TITLE
Update allocation limits

### DIFF
--- a/docker/docker-compose.1804.54.yaml
+++ b/docker/docker-compose.1804.54.yaml
@@ -30,15 +30,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=309050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=313050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=277050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303350
 
   shell:
     image: swift-nio-http2:18.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -29,15 +29,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=309050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=313050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=277050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=42050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303350
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -27,15 +27,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=303050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=307050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=41050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293350
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -26,15 +26,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=303050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=307050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=41050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293350
 
   shell:
     image: swift-nio-http2:20.04-5.7

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -26,15 +26,15 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=303050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=307050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=273050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=41050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293350
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:
    
NIO 2.42.0 was just released and some alloc tests have regressed. These
come from EmbeddedChannelCore adding atomics.
    
Modifications:
    
- Update alloc limits
    
Result:
    
CI passes
