### PR TITLE
Remove `#if compiler(>=5.5)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ To depend on `swift-nio-http2`, put the following in the `dependencies` of your 
 
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.2"),
 
-The most recent versions of SwiftNIO HTTP/2 support Swift 5.5 and newer. The minimum Swift version supported for SwiftNIO HTTP/2 releases are detailed below:
+The most recent versions of SwiftNIO HTTP/2 support Swift 5.5.2 and newer. The minimum Swift version supported for SwiftNIO HTTP/2 releases are detailed below:
 
 SwiftNIO HTTP/2     | Minimum Swift Version
 --------------------|----------------------
 `1.0.0 ..< 1.18.0`  | 5.0
 `1.18.0 ..< 1.21.0` | 5.2
 `1.21.0 ..< 1.23.0` | 5.4
-`1.24.0 ...`        | 5.5
+`1.24.0 ...`        | 5.5.2
 
 
 ### `swift-nio-http2` 0.x

--- a/Sources/NIOHPACK/HPACKEncoder.swift
+++ b/Sources/NIOHPACK/HPACKEncoder.swift
@@ -330,9 +330,4 @@ public struct HPACKEncoder {
     }
 }
 
-// The `@unchecked` is needed because at the time of writing `NIOCore` didn't have `Sendable` support.
-#if swift(>=5.5) && canImport(_Concurrency)
-extension HPACKEncoder: @unchecked Sendable {
-
-}
-#endif
+extension HPACKEncoder: Sendable {}

--- a/Sources/NIOHPACK/HeaderTables.swift
+++ b/Sources/NIOHPACK/HeaderTables.swift
@@ -205,8 +205,6 @@ extension HeaderTableStorage : CustomStringConvertible {
 }
 
 // The `@unchecked` is needed because at the time of writing `NIOCore` didn't have `Sendable` support.
-#if swift(>=5.5) && canImport(_Concurrency)
-extension HeaderTableStorage: @unchecked Sendable {
 
-}
-#endif
+extension HeaderTableStorage: Sendable {}
+

--- a/Sources/NIOHPACK/IndexedHeaderTable.swift
+++ b/Sources/NIOHPACK/IndexedHeaderTable.swift
@@ -191,9 +191,5 @@ public struct IndexedHeaderTable {
     }
 }
 
-// The `@unchecked` is needed because at the time of writing `NIOCore` didn't have `Sendable` support.
-#if swift(>=5.5) && canImport(_Concurrency)
-extension IndexedHeaderTable: @unchecked Sendable {
 
-}
-#endif
+extension IndexedHeaderTable: Sendable {}

--- a/Sources/NIOHTTP2/HTTP2Frame.swift
+++ b/Sources/NIOHTTP2/HTTP2Frame.swift
@@ -295,12 +295,9 @@ extension HTTP2Frame.FramePayload {
     }
 }
 
-// The `@unchecked` is needed because at the time of writing `NIOCore` didn't have `Sendable` support.
-#if swift(>=5.5) && canImport(_Concurrency)
-extension HTTP2Frame.FramePayload: @unchecked Sendable {
+/// ``HTTP2Frame/FramePayload/Data`` and therefore ``HTTP2Frame/FramePayload`` and ``HTTP2Frame`` are actually **not** `Sendable`,
+/// because ``HTTP2Frame/FramePayload/Data/data`` stores `IOData` which is not and can not be `Sendable`.
+/// Marking them non-Sendable would sadly be API breaking.
+extension HTTP2Frame.FramePayload: @unchecked Sendable {}
+extension HTTP2Frame.FramePayload.Data: @unchecked Sendable {}
 
-}
-extension HTTP2Frame.FramePayload.Data: @unchecked Sendable {
-
-}
-#endif


### PR DESCRIPTION
### Motivation
We only support Swift 5.5.2+. 

### Modification
Remove all `#if swift(>=5.5)` conditional compilation blocks.

### Result
less branching
