### PR TITLE
Replace NIOSendable with Sendable

### DIFF
--- a/Sources/NIOHPACK/DynamicHeaderTable.swift
+++ b/Sources/NIOHPACK/DynamicHeaderTable.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// Implements the dynamic part of the HPACK header table, as defined in
 /// [RFC 7541 § 2.3](https://httpwg.org/specs/rfc7541.html#dynamic.table).
 @usableFromInline
-struct DynamicHeaderTable: NIOSendable {
+struct DynamicHeaderTable: Sendable {
     public static let defaultSize = 4096
     
     /// The actual table, with items looked up by index.

--- a/Sources/NIOHPACK/HPACKDecoder.swift
+++ b/Sources/NIOHPACK/HPACKDecoder.swift
@@ -25,7 +25,7 @@ import NIOCore
 ///
 /// - note: This type is not thread-safe. It is designed to be owned and operated
 /// by a single HTTP/2 stream, operating on a single NIO `EventLoop`.
-public struct HPACKDecoder: NIOSendable {
+public struct HPACKDecoder: Sendable {
     public static var maxDynamicTableSize: Int {
         return DynamicHeaderTable.defaultSize
     }

--- a/Sources/NIOHPACK/HPACKEncoder.swift
+++ b/Sources/NIOHPACK/HPACKEncoder.swift
@@ -27,7 +27,7 @@ public struct HPACKEncoder {
     public static var defaultDynamicTableSize: Int { return DynamicHeaderTable.defaultSize }
     private static let defaultDataBufferSize = 128
     
-    public struct HeaderDefinition: NIOSendable {
+    public struct HeaderDefinition: Sendable {
         var name: String
         var value: String
         var indexing: HPACKIndexing

--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -17,7 +17,7 @@ import NIOHTTP1
 
 /// Very similar to `NIOHTTP1.HTTPHeaders`, but with extra data for storing indexing
 /// information.
-public struct HPACKHeaders: ExpressibleByDictionaryLiteral, NIOSendable {
+public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
     /// The maximum size of the canonical connection header value array to use when removing
     /// connection headers during `HTTPHeaders` normalisation. When using an array the removal
     /// is O(H·C) where H is the length of headers to noramlize and C is the length of the
@@ -464,7 +464,7 @@ extension HPACKHeaders: Hashable {
 
 /// Defines the types of indexing and rewriting operations a decoder may take with
 /// regard to this header.
-public enum HPACKIndexing: CustomStringConvertible, NIOSendable {
+public enum HPACKIndexing: CustomStringConvertible, Sendable {
     /// Header may be written into the dynamic index table or may be rewritten by
     /// proxy servers.
     case indexable
@@ -488,7 +488,7 @@ public enum HPACKIndexing: CustomStringConvertible, NIOSendable {
 }
 
 @usableFromInline
-internal struct HPACKHeader: NIOSendable {
+internal struct HPACKHeader: Sendable {
     @usableFromInline
     var indexing: HPACKIndexing
 

--- a/Sources/NIOHPACK/HeaderTables.swift
+++ b/Sources/NIOHPACK/HeaderTables.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-internal struct HeaderTableEntry: NIOSendable {
+internal struct HeaderTableEntry: Sendable {
     var name: String
 
     var value: String

--- a/Sources/NIOHTTP2/HTTP2ErrorCode.swift
+++ b/Sources/NIOHTTP2/HTTP2ErrorCode.swift
@@ -18,7 +18,7 @@ import NIOCore
 ///
 /// HTTP/2 uses error codes to communicate to remote peers what went wrong on either a stream or
 /// a connection. This data type models that underlying representation.
-public struct HTTP2ErrorCode: NIOSendable {
+public struct HTTP2ErrorCode: Sendable {
     /// The underlying network representation of the error code.
     public var networkCode: Int {
         get {

--- a/Sources/NIOHTTP2/HTTP2Frame.swift
+++ b/Sources/NIOHTTP2/HTTP2Frame.swift
@@ -17,7 +17,7 @@ import NIOHTTP1
 import NIOHPACK
 
 /// A representation of a single HTTP/2 frame.
-public struct HTTP2Frame: NIOSendable {
+public struct HTTP2Frame: Sendable {
 
     /// The ID representing the stream on which this frame is sent.
     public var streamID: HTTP2StreamID
@@ -26,7 +26,7 @@ public struct HTTP2Frame: NIOSendable {
     public var payload: FramePayload
 
     /// Stream priority data, used in PRIORITY frames and optionally in HEADERS frames.
-    public struct StreamPriorityData: Equatable, Hashable, NIOSendable {
+    public struct StreamPriorityData: Equatable, Hashable, Sendable {
         public var exclusive: Bool
         public var dependency: HTTP2StreamID
         public var weight: UInt8
@@ -156,7 +156,7 @@ public struct HTTP2Frame: NIOSendable {
         }
 
         /// The payload of a `HEADERS` frame.
-        public struct Headers: NIOSendable {
+        public struct Headers: Sendable {
             /// The decoded header block belonging to this `HEADERS` frame.
             public var headers: HPACKHeaders
 
@@ -193,7 +193,7 @@ public struct HTTP2Frame: NIOSendable {
         }
 
         /// The payload of a `SETTINGS` frame.
-        public enum Settings: NIOSendable {
+        public enum Settings: Sendable {
             /// This `SETTINGS` frame contains new `SETTINGS`.
             case settings(HTTP2Settings)
 
@@ -202,7 +202,7 @@ public struct HTTP2Frame: NIOSendable {
         }
 
         /// The payload of a `PUSH_PROMISE` frame.
-        public struct PushPromise: NIOSendable {
+        public struct PushPromise: Sendable {
             /// The pushed stream ID.
             public var pushedStreamID: HTTP2StreamID
 

--- a/Sources/NIOHTTP2/HTTP2PingData.swift
+++ b/Sources/NIOHTTP2/HTTP2PingData.swift
@@ -18,7 +18,7 @@ import NIOCore
 ///
 /// A HTTP/2 ping frame must contain 8 bytes of opaque data that is controlled entirely by the sender.
 /// This data type encapsulates those 8 bytes while providing a friendly interface for them.
-public struct HTTP2PingData: NIOSendable {
+public struct HTTP2PingData: Sendable {
     /// The underlying bytes to be sent to the wire. These are in network byte order.
     public var bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 

--- a/Sources/NIOHTTP2/HTTP2Settings.swift
+++ b/Sources/NIOHTTP2/HTTP2Settings.swift
@@ -21,7 +21,7 @@ public typealias HTTP2Settings = [HTTP2Setting]
 
 /// A HTTP/2 settings parameter that allows representing both known and unknown HTTP/2
 /// settings parameters.
-public struct HTTP2SettingsParameter: NIOSendable {
+public struct HTTP2SettingsParameter: Sendable {
     internal let networkRepresentation: UInt16
 
     /// Create a ``HTTP2SettingsParameter`` that is not known to NIO.
@@ -73,7 +73,7 @@ extension HTTP2SettingsParameter: Equatable { }
 extension HTTP2SettingsParameter: Hashable { }
 
 /// A single setting for HTTP/2, a combination of a ``HTTP2SettingsParameter`` and its value.
-public struct HTTP2Setting: NIOSendable {
+public struct HTTP2Setting: Sendable {
     /// The settings parameter for this setting.
     public var parameter: HTTP2SettingsParameter
 

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 /// The various channel options specific to `HTTP2StreamChannel`s.
 ///
 /// Please note that some of NIO's regular `ChannelOptions` are valid on `HTTP2StreamChannel`s.
-public struct HTTP2StreamChannelOptions: NIOSendable {
+public struct HTTP2StreamChannelOptions: Sendable {
     /// See ``HTTP2StreamChannelOptions/Types/StreamIDOption``.
     public static let streamID: HTTP2StreamChannelOptions.Types.StreamIDOption = .init()
 }

--- a/Sources/NIOHTTP2/HTTP2StreamID.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamID.swift
@@ -23,7 +23,7 @@ import NIOCore
 ///
 /// For this reason, SwiftNIO encapsulates the idea of this type into the HTTP2StreamID
 /// structure.
-public struct HTTP2StreamID: NIOSendable {
+public struct HTTP2StreamID: Sendable {
     /// The stream ID as a 32 bit integer that will be sent on the network. This will
     /// always be positive.
     internal var networkStreamID: Int32

--- a/Sources/NIOHTTP2/HTTP2UserEvents.swift
+++ b/Sources/NIOHTTP2/HTTP2UserEvents.swift
@@ -21,7 +21,7 @@ import NIOCore
 /// case of closure by `GOAWAY` the ``reason`` is always ``HTTP2ErrorCode/refusedStream``,
 /// indicating that the remote peer has not processed this stream. In the case of
 /// `RST_STREAM`, the ``reason`` contains the error code sent by the peer in the `RST_STREAM` frame.
-public struct StreamClosedEvent: NIOSendable {
+public struct StreamClosedEvent: Sendable {
     /// The stream ID of the stream that is closed.
     public let streamID: HTTP2StreamID
 

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -1028,7 +1028,7 @@ private extension HPACKHeaders {
 
 /// A state of a `HTTP2StreamStateMachine`. This copy in effect mirrors `HTTP2StreamStateMachine.state` but without associated values,
 /// and is used to provide detail in errors.
-public struct NIOHTTP2StreamState: Hashable, CustomStringConvertible, NIOSendable {
+public struct NIOHTTP2StreamState: Hashable, CustomStringConvertible, Sendable {
     private enum State {
         case idle
         case reservedRemote


### PR DESCRIPTION
Motivation:

NIOSendable was deprecated in https://github.com/apple/swift-nio/pull/2291 as the earliest supported Swift version in NIO land is now 5.5.

Modifications:

- s/NIOSendable/Sendable

Result:

Avoids deprecation warnings when the above patch is released.