### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -638,7 +638,7 @@ extension NIOHTTP2Handler {
     private func failDroppedPromises(_ promises: CompoundOutboundBuffer.DroppedPromisesCollection,
                                      streamID: HTTP2StreamID,
                                      errorCode: HTTP2ErrorCode,
-                                     file: String = #file, line: UInt = #line) {
+                                     file: String = #fileID, line: UInt = #line) {
         // 'NIOHTTP2Errors.streamClosed' always allocates, if there are no promises then there's no
         // need to create the error.
         guard promises.contains(where: { $0 != nil }) else {

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -21,12 +21,12 @@ public protocol NIOHTTP2Error: Equatable, Error { }
 /// Errors that ``NIOHTTP2`` raises when handling HTTP/2 connections.
 public enum NIOHTTP2Errors {
     /// Creates an ``ExcessiveOutboundFrameBuffering`` error with appropriate source context.
-    public static func excessiveOutboundFrameBuffering(file: String = #file, line: UInt = #line) -> ExcessiveOutboundFrameBuffering {
+    public static func excessiveOutboundFrameBuffering(file: String = #fileID, line: UInt = #line) -> ExcessiveOutboundFrameBuffering {
         return ExcessiveOutboundFrameBuffering(file: file, line: line)
     }
 
     /// Creates an ``InvalidALPNToken`` error with appropriate source context
-    public static func invalidALPNToken(file: String = #file, line: UInt = #line) -> InvalidALPNToken {
+    public static func invalidALPNToken(file: String = #fileID, line: UInt = #line) -> InvalidALPNToken {
         return InvalidALPNToken(file: file, line: line)
     }
 
@@ -34,7 +34,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - streamID: The ``HTTP2StreamID`` for the stream that does not exist.
-    public static func noSuchStream(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> NoSuchStream {
+    public static func noSuchStream(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> NoSuchStream {
         return NoSuchStream(streamID: streamID, file: file, line: line)
     }
 
@@ -43,12 +43,12 @@ public enum NIOHTTP2Errors {
     /// - parameters:
     ///     - streamID: The ``HTTP2StreamID`` for the stream that is or has been closed
     ///     - errorCode: The ``HTTP2ErrorCode`` representing the reason for closure of the stream.
-    public static func streamClosed(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: String = #file, line: UInt = #line) -> StreamClosed {
+    public static func streamClosed(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: String = #fileID, line: UInt = #line) -> StreamClosed {
         return StreamClosed(streamID: streamID, errorCode: errorCode, file: file, line: line)
     }
 
     /// Creates a ``BadClientMagic`` error with appropriate source context.
-    public static func badClientMagic(file: String = #file, line: UInt = #line) -> BadClientMagic {
+    public static func badClientMagic(file: String = #fileID, line: UInt = #line) -> BadClientMagic {
         return BadClientMagic(file: file, line: line)
     }
 
@@ -56,7 +56,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters
     ///     - state: The ``NIOHTTP2StreamState`` representing the state of the stream from which we were trying to transition
-    public static func badStreamStateTransition(from state: NIOHTTP2StreamState? = nil, file: String = #file, line: UInt = #line) -> BadStreamStateTransition {
+    public static func badStreamStateTransition(from state: NIOHTTP2StreamState? = nil, file: String = #fileID, line: UInt = #line) -> BadStreamStateTransition {
         return BadStreamStateTransition(from: state, file: file, line: line)
     }
 
@@ -65,12 +65,12 @@ public enum NIOHTTP2Errors {
     /// - parameters:
     ///     - delta: The change in the window size that was proposed in error
     ///     - currentWindowSize: The current size of the stream flow control window
-    public static func invalidFlowControlWindowSize(delta: Int, currentWindowSize: Int, file: String = #file, line: UInt = #line) -> InvalidFlowControlWindowSize {
+    public static func invalidFlowControlWindowSize(delta: Int, currentWindowSize: Int, file: String = #fileID, line: UInt = #line) -> InvalidFlowControlWindowSize {
         return InvalidFlowControlWindowSize(delta: delta, currentWindowSize: currentWindowSize, file: file, line: line)
     }
 
     /// Creates a ``FlowControlViolation`` error with appropriate source context.
-    public static func flowControlViolation(file: String = #file, line: UInt = #line) -> FlowControlViolation {
+    public static func flowControlViolation(file: String = #fileID, line: UInt = #line) -> FlowControlViolation {
         return FlowControlViolation(file: file, line: line)
     }
 
@@ -78,57 +78,57 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - setting: The invalid setting in question
-    public static func invalidSetting(setting: HTTP2Setting, file: String = #file, line: UInt = #line) -> InvalidSetting {
+    public static func invalidSetting(setting: HTTP2Setting, file: String = #fileID, line: UInt = #line) -> InvalidSetting {
         return InvalidSetting(setting: setting, file: file, line: line)
     }
 
     /// Creates an ``IOOnClosedConnection`` error with appropriate source context.
-    public static func ioOnClosedConnection(file: String = #file, line: UInt = #line) -> IOOnClosedConnection {
+    public static func ioOnClosedConnection(file: String = #fileID, line: UInt = #line) -> IOOnClosedConnection {
         return IOOnClosedConnection(file: file, line: line)
     }
 
     /// Creates a ``ReceivedBadSettings`` error with appropriate source context.
-    public static func receivedBadSettings(file: String = #file, line: UInt = #line) -> ReceivedBadSettings {
+    public static func receivedBadSettings(file: String = #fileID, line: UInt = #line) -> ReceivedBadSettings {
         return ReceivedBadSettings(file: file, line: line)
     }
 
     /// Creates a ``MaxStreamsViolation`` error with appropriate source context.
-    public static func maxStreamsViolation(file: String = #file, line: UInt = #line) -> MaxStreamsViolation {
+    public static func maxStreamsViolation(file: String = #fileID, line: UInt = #line) -> MaxStreamsViolation {
         return MaxStreamsViolation(file: file, line: line)
     }
 
     /// Creates a ``StreamIDTooSmall`` error with appropriate source context.
-    public static func streamIDTooSmall(file: String = #file, line: UInt = #line) -> StreamIDTooSmall {
+    public static func streamIDTooSmall(file: String = #fileID, line: UInt = #line) -> StreamIDTooSmall {
         return StreamIDTooSmall(file: file, line: line)
     }
 
     /// Creates a ``MissingPreface`` error with appropriate source context.
-    public static func missingPreface(file: String = #file, line: UInt = #line) -> MissingPreface {
+    public static func missingPreface(file: String = #fileID, line: UInt = #line) -> MissingPreface {
         return MissingPreface(file: file, line: line)
     }
 
     /// Creates a ``CreatedStreamAfterGoaway`` error with appropriate source context.
-    public static func createdStreamAfterGoaway(file: String = #file, line: UInt = #line) -> CreatedStreamAfterGoaway {
+    public static func createdStreamAfterGoaway(file: String = #fileID, line: UInt = #line) -> CreatedStreamAfterGoaway {
         return CreatedStreamAfterGoaway(file: file, line: line)
     }
 
     /// Creates a ``InvalidStreamIDForPeer`` error with appropriate source context.
-    public static func invalidStreamIDForPeer(file: String = #file, line: UInt = #line) -> InvalidStreamIDForPeer {
+    public static func invalidStreamIDForPeer(file: String = #fileID, line: UInt = #line) -> InvalidStreamIDForPeer {
         return InvalidStreamIDForPeer(file: file, line: line)
     }
 
     /// Creates a ``RaisedGoawayLastStreamID`` error with appropriate source context.
-    public static func raisedGoawayLastStreamID(file: String = #file, line: UInt = #line) -> RaisedGoawayLastStreamID {
+    public static func raisedGoawayLastStreamID(file: String = #fileID, line: UInt = #line) -> RaisedGoawayLastStreamID {
         return RaisedGoawayLastStreamID(file: file, line: line)
     }
 
     /// Creates a ``InvalidWindowIncrementSize`` error with appropriate source context.
-    public static func invalidWindowIncrementSize(file: String = #file, line: UInt = #line) -> InvalidWindowIncrementSize {
+    public static func invalidWindowIncrementSize(file: String = #fileID, line: UInt = #line) -> InvalidWindowIncrementSize {
         return InvalidWindowIncrementSize(file: file, line: line)
     }
 
     /// Creates a ``PushInViolationOfSetting`` error with appropriate source context.
-    public static func pushInViolationOfSetting(file: String = #file, line: UInt = #line) -> PushInViolationOfSetting {
+    public static func pushInViolationOfSetting(file: String = #fileID, line: UInt = #line) -> PushInViolationOfSetting {
         return PushInViolationOfSetting(file: file, line: line)
     }
 
@@ -136,17 +136,17 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///      - info: Human-readable information describing _what_ is unsupported.
-    public static func unsupported(info: String, file: String = #file, line: UInt = #line) -> Unsupported {
+    public static func unsupported(info: String, file: String = #fileID, line: UInt = #line) -> Unsupported {
         return Unsupported(info: info, file: file, line: line)
     }
 
     /// Creates a ``UnableToSerializeFrame`` error with appropriate source context.
-    public static func unableToSerializeFrame(file: String = #file, line: UInt = #line) -> UnableToSerializeFrame {
+    public static func unableToSerializeFrame(file: String = #fileID, line: UInt = #line) -> UnableToSerializeFrame {
         return UnableToSerializeFrame(file: file, line: line)
     }
 
     /// Creates a ``UnableToParseFrame`` error with appropriate source context.
-    public static func unableToParseFrame(file: String = #file, line: UInt = #line) -> UnableToParseFrame {
+    public static func unableToParseFrame(file: String = #fileID, line: UInt = #line) -> UnableToParseFrame {
         return UnableToParseFrame(file: file, line: line)
     }
 
@@ -154,7 +154,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///      - name: The name of the pseudo-header that was missing from the header block.
-    public static func missingPseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> MissingPseudoHeader {
+    public static func missingPseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> MissingPseudoHeader {
         return MissingPseudoHeader(name, file: file, line: line)
     }
 
@@ -162,7 +162,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - name: The name of the pseudo-header that was duplicated within the header block.
-    public static func duplicatePseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> DuplicatePseudoHeader {
+    public static func duplicatePseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> DuplicatePseudoHeader {
         return DuplicatePseudoHeader(name, file: file, line: line)
     }
 
@@ -170,7 +170,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - name: The name of the pseudo-header that appeared after a regular header in the header block.
-    public static func pseudoHeaderAfterRegularHeader(_ name: String, file: String = #file, line: UInt = #line) -> PseudoHeaderAfterRegularHeader {
+    public static func pseudoHeaderAfterRegularHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> PseudoHeaderAfterRegularHeader {
         return PseudoHeaderAfterRegularHeader(name, file: file, line: line)
     }
 
@@ -178,7 +178,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - name: The name of the pseudo-header that was not recognised by ``NIOHTTP2``.
-    public static func unknownPseudoHeader(_ name: String, file: String = #file, line: UInt = #line) -> UnknownPseudoHeader {
+    public static func unknownPseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> UnknownPseudoHeader {
         return UnknownPseudoHeader(name, file: file, line: line)
     }
 
@@ -186,22 +186,22 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - block: The block of `HPACKHeaders` that contain the invalid pseudo headers.
-    public static func invalidPseudoHeaders(_ block: HPACKHeaders, file: String = #file, line: UInt = #line) -> InvalidPseudoHeaders {
+    public static func invalidPseudoHeaders(_ block: HPACKHeaders, file: String = #fileID, line: UInt = #line) -> InvalidPseudoHeaders {
         return InvalidPseudoHeaders(block, file: file, line: line)
     }
 
     /// Creates a ``MissingHostHeader`` error with appropriate source context.
-    public static func missingHostHeader(file: String = #file, line: UInt = #line) -> MissingHostHeader {
+    public static func missingHostHeader(file: String = #fileID, line: UInt = #line) -> MissingHostHeader {
         return MissingHostHeader(file: file, line: line)
     }
 
     /// Creates a ``DuplicateHostHeader`` error with appropriate source context.
-    public static func duplicateHostHeader(file: String = #file, line: UInt = #line) -> DuplicateHostHeader {
+    public static func duplicateHostHeader(file: String = #fileID, line: UInt = #line) -> DuplicateHostHeader {
         return DuplicateHostHeader(file: file, line: line)
     }
 
     /// Creates a ``EmptyPathHeader`` error with appropriate source context.
-    public static func emptyPathHeader(file: String = #file, line: UInt = #line) -> EmptyPathHeader {
+    public static func emptyPathHeader(file: String = #fileID, line: UInt = #line) -> EmptyPathHeader {
         return EmptyPathHeader(file: file, line: line)
     }
 
@@ -209,7 +209,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - value: The value of the `:status` header that is invalid.
-    public static func invalidStatusValue(_ value: String, file: String = #file, line: UInt = #line) -> InvalidStatusValue {
+    public static func invalidStatusValue(_ value: String, file: String = #fileID, line: UInt = #line) -> InvalidStatusValue {
         return InvalidStatusValue(value, file: file, line: line)
     }
 
@@ -217,7 +217,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - streamID: The ``HTTP2StreamID`` representing the stream that created the priority cycle.
-    public static func priorityCycle(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> PriorityCycle {
+    public static func priorityCycle(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> PriorityCycle {
         return PriorityCycle(streamID: streamID, file: file, line: line)
     }
 
@@ -225,7 +225,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - streamID: The ``HTTP2StreamID`` on which the `HEADERS` frame without `END_STREAM` was received.
-    public static func trailersWithoutEndStream(streamID: HTTP2StreamID, file: String = #file, line: UInt = #line) -> TrailersWithoutEndStream {
+    public static func trailersWithoutEndStream(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> TrailersWithoutEndStream {
         return TrailersWithoutEndStream(streamID: streamID, file: file, line: line)
     }
 
@@ -233,7 +233,7 @@ public enum NIOHTTP2Errors {
     ///
     /// - parameters:
     ///     - fieldName: The invalid HTTP/2 header field name
-    public static func invalidHTTP2HeaderFieldName(_ fieldName: String, file: String = #file, line: UInt = #line) -> InvalidHTTP2HeaderFieldName {
+    public static func invalidHTTP2HeaderFieldName(_ fieldName: String, file: String = #fileID, line: UInt = #line) -> InvalidHTTP2HeaderFieldName {
         return InvalidHTTP2HeaderFieldName(fieldName, file: file, line: line)
     }
 
@@ -242,27 +242,27 @@ public enum NIOHTTP2Errors {
     /// - parameters:
     ///     - name: The field name for the forbidden header field
     ///     - value: The field value for the forbidden header field
-    public static func forbiddenHeaderField(name: String, value: String, file: String = #file, line: UInt = #line) -> ForbiddenHeaderField {
+    public static func forbiddenHeaderField(name: String, value: String, file: String = #fileID, line: UInt = #line) -> ForbiddenHeaderField {
         return ForbiddenHeaderField(name: name, value: value, file: file, line: line)
     }
 
     /// Creates a ``ContentLengthViolated`` error with appropriate source context.
-    public static func contentLengthViolated(file: String = #file, line: UInt = #line) -> ContentLengthViolated {
+    public static func contentLengthViolated(file: String = #fileID, line: UInt = #line) -> ContentLengthViolated {
         return ContentLengthViolated(file: file, line: line)
     }
 
     /// Creates a ``ExcessiveEmptyDataFrames`` error with appropriate source context.
-    public static func excessiveEmptyDataFrames(file: String = #file, line: UInt = #line) -> ExcessiveEmptyDataFrames {
+    public static func excessiveEmptyDataFrames(file: String = #fileID, line: UInt = #line) -> ExcessiveEmptyDataFrames {
         return ExcessiveEmptyDataFrames(file: file, line: line)
     }
 
     /// Creates a ``ExcessivelyLargeHeaderBlock`` error with appropriate source context.
-    public static func excessivelyLargeHeaderBlock(file: String = #file, line: UInt = #line) -> ExcessivelyLargeHeaderBlock {
+    public static func excessivelyLargeHeaderBlock(file: String = #fileID, line: UInt = #line) -> ExcessivelyLargeHeaderBlock {
         return ExcessivelyLargeHeaderBlock(file: file, line: line)
     }
 
     /// Creates a ``NoStreamIDAvailable`` error with appropriate source context.
-    public static func noStreamIDAvailable(file: String = #file, line: UInt = #line) -> NoStreamIDAvailable {
+    public static func noStreamIDAvailable(file: String = #fileID, line: UInt = #line) -> NoStreamIDAvailable {
         return NoStreamIDAvailable(file: file, line: line)
     }
 
@@ -290,7 +290,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "excessiveOutboundFrameBuffering")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -316,7 +316,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidALPNToken")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -339,7 +339,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "noSuchStream")
         public init(streamID: HTTP2StreamID) {
-            self.init(streamID: streamID, file: #file, line: #line)
+            self.init(streamID: streamID, file: #fileID, line: #line)
         }
 
         fileprivate init(streamID: HTTP2StreamID, file: String, line: UInt) {
@@ -365,7 +365,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "streamClosed")
         public init(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode) {
-            self.init(streamID: streamID, errorCode: errorCode, file: #file, line: #line)
+            self.init(streamID: streamID, errorCode: errorCode, file: #fileID, line: #line)
         }
 
         fileprivate init(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: String, line: UInt) {
@@ -391,7 +391,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "badClientMagic")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -424,7 +424,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "badStreamStateTransition")
         public init() {
-            self.init(from: nil, file: #file, line: #line)
+            self.init(from: nil, file: #fileID, line: #line)
         }
 
         public static func ==(lhs: BadStreamStateTransition, rhs: BadStreamStateTransition) -> Bool {
@@ -505,7 +505,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidFlowControlWindowSize")
         public init(delta: Int, currentWindowSize: Int) {
-            self.init(delta: delta, currentWindowSize: currentWindowSize, file: #file, line: #line)
+            self.init(delta: delta, currentWindowSize: currentWindowSize, file: #fileID, line: #line)
         }
 
         fileprivate init(delta: Int, currentWindowSize: Int, file: String, line: UInt) {
@@ -525,7 +525,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "flowControlViolation")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -548,7 +548,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidSetting")
         public init(setting: HTTP2Setting) {
-            self.init(setting: setting, file: #file, line: #line)
+            self.init(setting: setting, file: #fileID, line: #line)
         }
 
         fileprivate init(setting: HTTP2Setting, file: String, line: UInt) {
@@ -573,7 +573,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "ioOnClosedConnection")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -598,7 +598,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "receivedBadSettings")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -623,7 +623,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "maxStreamsViolation")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -648,7 +648,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "streamIDTooSmall")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -673,7 +673,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "missingPreface")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -699,7 +699,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "createdStreamAfterGoaway")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -724,7 +724,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidStreamIDForPeer")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -749,7 +749,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "raisedGoawayLastStreamID")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -774,7 +774,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidWindowIncrementSize")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -799,7 +799,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "pushInViolationOfSetting")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -846,7 +846,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "unsupported")
         public init(info: String) {
-            self.init(info: info, file: #file, line: #line)
+            self.init(info: info, file: #fileID, line: #line)
         }
 
         fileprivate init(info: String, file: String, line: UInt) {
@@ -866,7 +866,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "unableToSerializeFrame")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -891,7 +891,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "unableToParseFrame")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -938,7 +938,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "missingPseudoHeader")
         public init(_ name: String) {
-            self.init(name, file: #file, line: #line)
+            self.init(name, file: #fileID, line: #line)
         }
 
         fileprivate init(_ name: String, file: String, line: UInt) {
@@ -980,7 +980,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "duplicatePseudoHeader")
         public init(_ name: String) {
-            self.init(name, file: #file, line: #line)
+            self.init(name, file: #fileID, line: #line)
         }
 
         fileprivate init(_ name: String, file: String, line: UInt) {
@@ -1022,7 +1022,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "pseudoHeaderAfterRegularHeader")
         public init(_ name: String) {
-            self.init(name, file: #file, line: #line)
+            self.init(name, file: #fileID, line: #line)
         }
 
         fileprivate init(_ name: String, file: String, line: UInt) {
@@ -1064,7 +1064,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "unknownPseudoHeader")
         public init(_ name: String) {
-            self.init(name, file: #file, line: #line)
+            self.init(name, file: #fileID, line: #line)
         }
 
         fileprivate init(_ name: String, file: String, line: UInt) {
@@ -1082,7 +1082,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidPseudoHeaders")
         public init(_ block: HPACKHeaders) {
-            self.init(block, file: #file, line: #line)
+            self.init(block, file: #fileID, line: #line)
         }
 
         fileprivate init(_ block: HPACKHeaders, file: String, line: UInt) {
@@ -1107,7 +1107,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "missingHostHeader")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1132,7 +1132,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "duplicateHostHeader")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1157,7 +1157,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "emptyPathHeader")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1204,7 +1204,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidStatusValue")
         public init(_ value: String) {
-            self.init(value, file: #file, line: #line)
+            self.init(value, file: #fileID, line: #line)
         }
 
         fileprivate init(_ value: String, file: String, line: UInt) {
@@ -1222,7 +1222,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "priorityCycle")
         public init(streamID: HTTP2StreamID) {
-            self.init(streamID: streamID, file: #file, line: #line)
+            self.init(streamID: streamID, file: #fileID, line: #line)
         }
 
         fileprivate init(streamID: HTTP2StreamID, file: String, line: UInt) {
@@ -1245,7 +1245,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "trailersWithoutEndStream")
         public init(streamID: HTTP2StreamID) {
-            self.init(streamID: streamID, file: #file, line: #line)
+            self.init(streamID: streamID, file: #fileID, line: #line)
         }
 
         fileprivate init(streamID: HTTP2StreamID, file: String, line: UInt) {
@@ -1292,7 +1292,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "invalidHTTP2HeaderFieldName")
         public init(_ name: String) {
-            self.init(name, file: #file, line: #line)
+            self.init(name, file: #fileID, line: #line)
         }
 
         fileprivate init(_ name: String, file: String, line: UInt) {
@@ -1372,7 +1372,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "forbiddenHeaderField")
         public init(name: String, value: String) {
-            self.init(name: name, value: value, file: #file, line: #line)
+            self.init(name: name, value: value, file: #fileID, line: #line)
         }
 
         fileprivate init(name: String, value: String, file: String, line: UInt) {
@@ -1392,7 +1392,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "contentLengthViolated")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1418,7 +1418,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "excessiveEmptyDataFrames")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1443,7 +1443,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "excessivelyLargeHeaderBlock")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1468,7 +1468,7 @@ public enum NIOHTTP2Errors {
 
         @available(*, deprecated, renamed: "noStreamIDAvailable")
         public init() {
-            self.init(file: #file, line: #line)
+            self.init(file: #fileID, line: #line)
         }
 
         fileprivate init(file: String, line: UInt) {
@@ -1555,7 +1555,7 @@ internal enum InternalError: Error {
 
     // Used to record that an impossible situation occured. Crashes in debug mode, errors in
     // release mode.
-    static func impossibleSituation(file: StaticString = #file, line: UInt = #line) -> InternalError {
+    static func impossibleSituation(file: StaticString = #fileID, line: UInt = #line) -> InternalError {
         assertionFailure(file: file, line: line)
         return .codecError(code: .internalError)
     }

--- a/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
@@ -95,7 +95,7 @@ extension Array where Element == UInt8 {
     }()
 
     // The location of the test fixtures.
-    private static let fixtureDirectoryURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Tests").appendingPathComponent("NIOHPACKTests").appendingPathComponent("Fixtures").absoluteURL
+    private static let fixtureDirectoryURL = URL(fileURLWithPath: #fileID).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Tests").appendingPathComponent("NIOHPACKTests").appendingPathComponent("Fixtures").absoluteURL
 }
 
 

--- a/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
+++ b/Sources/NIOHTTP2PerformanceTester/HuffmanDecodingBenchmark.swift
@@ -95,7 +95,7 @@ extension Array where Element == UInt8 {
     }()
 
     // The location of the test fixtures.
-    private static let fixtureDirectoryURL = URL(fileURLWithPath: #fileID).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Tests").appendingPathComponent("NIOHPACKTests").appendingPathComponent("Fixtures").absoluteURL
+    private static let fixtureDirectoryURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Tests").appendingPathComponent("NIOHPACKTests").appendingPathComponent("Fixtures").absoluteURL
 }
 
 

--- a/Tests/NIOHPACKTests/HPACKIntegrationTests.swift
+++ b/Tests/NIOHPACKTests/HPACKIntegrationTests.swift
@@ -17,9 +17,8 @@ import NIOCore
 @testable import NIOHPACK
 
 class HPACKIntegrationTests : XCTestCase {
-    
     private let hpackTestsURL: URL = {
-        let myURL = URL(fileURLWithPath: #file, isDirectory: false)
+        let myURL = URL(fileURLWithPath: #filePath, isDirectory: false)
         let result: URL
         if #available(OSX 10.11, iOS 9.0, *) {
             result = URL(fileURLWithPath: "../hpack-test-case", isDirectory: true, relativeTo: myURL).absoluteURL

--- a/Tests/NIOHPACKTests/HeaderTableTests.swift
+++ b/Tests/NIOHPACKTests/HeaderTableTests.swift
@@ -19,7 +19,7 @@ import NIOCore
 func XCTAssertEqualTuple<T1: Equatable, T2: Equatable>(_ expression1: @autoclosure () throws -> (T1, T2)?,
                                                        _ expression2: @autoclosure () throws -> (T1, T2)?,
                                                        _ message: @autoclosure () -> String = "",
-                                                       file: StaticString = #file, line: UInt = #line) {
+                                                       file: StaticString = #filePath, line: UInt = #line) {
     let ex1: (T1, T2)?
     let ex2: (T1, T2)?
     do {

--- a/Tests/NIOHPACKTests/HuffmanCodingTests.swift
+++ b/Tests/NIOHPACKTests/HuffmanCodingTests.swift
@@ -23,7 +23,7 @@ class HuffmanCodingTests: XCTestCase {
     
     // MARK: - Helper Methods
     
-    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = #file, line: UInt = #line) {
+    func assertEqualContents(_ buffer: ByteBuffer, _ array: [UInt8], file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(buffer.readableBytes, array.count, "Buffer and array are different sizes", file: (file), line: line)
         buffer.withUnsafeReadableBytes { bufPtr in
             array.withUnsafeBytes { arrayPtr in
@@ -32,7 +32,7 @@ class HuffmanCodingTests: XCTestCase {
         }
     }
     
-    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = #file, line: UInt = #line) throws {
+    func verifyHuffmanCoding(_ string: String, _ bytes: [UInt8], file: StaticString = #filePath, line: UInt = #line) throws {
         self.scratchBuffer.clear()
         
         let utf8 = string.utf8

--- a/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/CompoundOutboundBufferTest.swift
@@ -368,7 +368,7 @@ extension CompoundOutboundBufferTest {
 }
 
 extension CompoundOutboundBuffer {
-    fileprivate mutating func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
+    fileprivate mutating func receivedFrames(file: StaticString = #filePath, line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         loop: while true {
@@ -389,14 +389,14 @@ extension CompoundOutboundBuffer {
 }
 
 extension CompoundOutboundBuffer.FlushedWritableFrameResult {
-    internal func assertNoFrame(file: StaticString = #file, line: UInt = #line) {
+    internal func assertNoFrame(file: StaticString = #filePath, line: UInt = #line) {
         guard case .noFrame = self else {
             XCTFail("Expected .noFrame, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = #file, line: UInt = #line) {
+    internal func assertError<ErrorType: Error & Equatable>(_ error: ErrorType, file: StaticString = #filePath, line: UInt = #line) {
         guard case .error(let promise, let thrownError) = self else {
             XCTFail("Expected .error, got \(self)", file: (file), line: line)
             return

--- a/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
+++ b/Tests/NIOHTTP2Tests/ConcurrentStreamBufferTest.swift
@@ -25,21 +25,21 @@ struct TestCaseError: Error { }
 // We need these to work around the fact that neither EventLoopPromise or MarkedCircularBuffer have equatable
 // conformances.
 extension OutboundFrameAction {
-    internal func assertForward(file: StaticString = #file, line: UInt = #line) {
+    internal func assertForward(file: StaticString = #filePath, line: UInt = #line) {
         guard case .forward = self else {
             XCTFail("Expected .forward, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertNothing(file: StaticString = #file, line: UInt = #line) {
+    internal func assertNothing(file: StaticString = #filePath, line: UInt = #line) {
         guard case .nothing = self else {
             XCTFail("Expected .nothing, got \(self)", file: (file), line: line)
             return
         }
     }
 
-    internal func assertForwardAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertForwardAndDrop(file: StaticString = #filePath, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .forwardAndDrop(let promises, let error) = self else {
             XCTFail("Expected .forwardAndDrop, got \(self)", file: (file), line: line)
             throw TestCaseError()
@@ -48,7 +48,7 @@ extension OutboundFrameAction {
         return (promises, error)
     }
 
-    internal func assertSucceedAndDrop(file: StaticString = #file, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
+    internal func assertSucceedAndDrop(file: StaticString = #filePath, line: UInt = #line) throws -> (MarkedCircularBuffer<(HTTP2Frame, EventLoopPromise<Void>?)>, NIOHTTP2Errors.StreamClosed) {
         guard case .succeedAndDrop(let promises, let error) = self else {
             XCTFail("Expected .succeedAndDrop, got \(self)", file: (file), line: line)
             throw TestCaseError()

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -18,7 +18,7 @@ import NIOCore
 import NIOHPACK
 @testable import NIOHTTP2
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #filePath, line: UInt = #line) {
     switch body() {
     case .succeed:
         return
@@ -28,7 +28,7 @@ func assertSucceeds(_ body: @autoclosure () -> StateMachineResult, file: StaticS
 }
 
 @discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #filePath, line: UInt = #line) -> Error? {
     switch body() {
     case .connectionError(underlyingError: let error, type: type):
         return error
@@ -39,7 +39,7 @@ func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> Stat
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResult, file: StaticString = #filePath, line: UInt = #line) -> Error? {
     switch body() {
     case .streamError(streamID: _, underlyingError: let error, type: type):
         return error
@@ -50,7 +50,7 @@ func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMac
 }
 
 @discardableResult
-func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
+func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #filePath, line: UInt = #line) -> NIOHTTP2Errors.BadStreamStateTransition? {
     let error: NIOHTTP2Errors.BadStreamStateTransition
 
     switch body().result {
@@ -68,7 +68,7 @@ func assertBadStreamStateTransition(type: NIOHTTP2StreamState, _ body: @autoclos
     return error
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #file, line: UInt = #line) {
+func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticString = #filePath, line: UInt = #line) {
     switch body() {
     case .ignoreFrame:
         return
@@ -77,39 +77,39 @@ func assertIgnored(_ body: @autoclosure () -> StateMachineResult, file: StaticSt
     }
 }
 
-func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #filePath, line: UInt = #line) {
     return assertSucceeds(body().0, file: (file), line: line)
 }
 
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #file, line: UInt = #line) {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> (StateMachineResultWithEffect, PostFrameOperation), file: StaticString = #filePath, line: UInt = #line) {
     assertConnectionError(type: type, body().0, file: (file), line: line)
 }
 
-func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
+func assertSucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #filePath, line: UInt = #line) {
     return assertSucceeds(body().result, file: (file), line: line)
 }
 
 @discardableResult
-func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertConnectionError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #filePath, line: UInt = #line) -> Error? {
     // Errors must always lead to noChange.
     let result = body()
     return assertConnectionError(type: type, result.result, file: (file), line: line)
 }
 
 @discardableResult
-func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) -> Error? {
+func assertStreamError(type: HTTP2ErrorCode, _ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #filePath, line: UInt = #line) -> Error? {
     // Errors must always lead to noChange.
     let result = body()
     return assertStreamError(type: type, result.result, file: (file), line: line)
 }
 
-func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #file, line: UInt = #line) {
+func assertIgnored(_ body: @autoclosure () -> StateMachineResultWithEffect, file: StaticString = #filePath, line: UInt = #line) {
     // Ignored frames must always lead to noChange.
     let result = body()
     assertIgnored(result.result, file: (file), line: line)
 }
 
-func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+func assertGoawaySucceeds(_ body: @autoclosure () -> StateMachineResultWithEffect, droppingStreams: [HTTP2StreamID]?, file: StaticString = #filePath, line: UInt = #line) {
     let result = body()
 
     if case .some(.bulkStreamClosure(let closedStreamsEvent)) = result.effect {
@@ -166,7 +166,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.server.receiveSettings(.ack, frameEncoder: &self.serverEncoder, frameDecoder: &self.serverDecoder))
     }
 
-    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+    private func setupServerGoaway(streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #filePath, line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens streams.
@@ -180,7 +180,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertGoawaySucceeds(self.client.receiveGoaway(lastStreamID: lastStreamID), droppingStreams: expectedToClose, file: (file), line: line)
     }
 
-    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #file, line: UInt = #line) {
+    private func setupClientGoaway(clientStreamID: HTTP2StreamID, streamsToOpen: [HTTP2StreamID], lastStreamID: HTTP2StreamID, expectedToClose: [HTTP2StreamID]?, file: StaticString = #filePath, line: UInt = #line) {
         self.exchangePreamble()
 
         // Client opens its stream, server sends response.
@@ -1317,7 +1317,7 @@ class ConnectionStateMachineTests: XCTestCase {
         self.exchangePreamble()
 
         // WindowUpdate frames are valid in a wide range of states. This test validates them in all of them, including proving that errors are correctly reported.
-        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = #file, line: UInt = #line) {
+        func assertCanWindowUpdate(client: HTTP2ConnectionStateMachine, server: HTTP2ConnectionStateMachine, file: StaticString = #filePath, line: UInt = #line) {
             var client = client
             var server = server
 

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
@@ -44,7 +44,7 @@ class HTTP2FrameParserTests: XCTestCase {
     }
     
     private func assertEqualFrames(_ frame1: HTTP2Frame, _ frame2: HTTP2Frame,
-                                   file: StaticString = #file, line: UInt = #line) {
+                                   file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(frame1.streamID, frame2.streamID, "StreamID mismatch: \(frame1.streamID) != \(frame2.streamID)",
             file: (file), line: line)
         
@@ -113,7 +113,7 @@ class HTTP2FrameParserTests: XCTestCase {
     
     private func assertReadsFrame(from bytes: ByteBuffer, matching expectedFrame: HTTP2Frame,
                                   expectedFlowControlledLength: Int = 0,
-                                  file: StaticString = #file, line: UInt = #line) throws {
+                                  file: StaticString = #filePath, line: UInt = #line) throws {
         let totalFrameSize = bytes.readableBytes
         
         var decoder = HTTP2FrameDecoder(allocator: self.allocator, expectClientMagic: false)

--- a/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ToHTTP1CodecTests.swift
@@ -22,7 +22,7 @@ import NIOHTTP1
 
 extension EmbeddedChannel {
     /// Assert that we received a request head.
-    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = #file, line: UInt = #line) {
+    func assertReceivedServerRequestPart(_ part: HTTPServerRequestPart, file: StaticString = #filePath, line: UInt = #line) {
         guard let actualPart: HTTPServerRequestPart = try? assertNoThrowWithValue(self.readInbound()) else {
             XCTFail("No data received", file: (file), line: line)
             return
@@ -31,7 +31,7 @@ extension EmbeddedChannel {
         XCTAssertEqual(actualPart, part, file: (file), line: line)
     }
 
-    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = #file, line: UInt = #line) {
+    func assertReceivedClientResponsePart(_ part: HTTPClientResponsePart, file: StaticString = #filePath, line: UInt = #line) {
         guard let actualPart: HTTPClientResponsePart = try? assertNoThrowWithValue(self.readInbound()) else {
             XCTFail("No data received", file: (file), line: line)
             return

--- a/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
+++ b/Tests/NIOHTTP2Tests/OutboundFlowControlBufferTests.swift
@@ -39,7 +39,7 @@ class OutboundFlowControlBufferTests: XCTestCase {
         return self.loop.makePromise()
     }
 
-    private func receivedFrames(file: StaticString = #file, line: UInt = #line) -> [HTTP2Frame] {
+    private func receivedFrames(file: StaticString = #filePath, line: UInt = #line) -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
         while let (bufferedFrame, promise) = self.buffer.nextFlushedWritableFrame() {


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on situation
