### PR TITLE
Content length verifier negative check

### DIFF
--- a/Sources/NIOHTTP2/ContentLengthVerifier.swift
+++ b/Sources/NIOHTTP2/ContentLengthVerifier.swift
@@ -57,7 +57,15 @@ extension ContentLengthVerifier {
         guard contentLengths.dropFirst().allSatisfy({ $0 == first }) else {
             throw NIOHTTP2Errors.contentLengthHeadersMismatch()
         }
+
         self.expectedContentLength = Int(first, radix: 10)
+
+        guard let expectedLength = self.expectedContentLength else {
+            throw NIOHTTP2Errors.contentLengthHeaderMalformedValue()
+        }
+        if expectedLength < 0 {
+            throw NIOHTTP2Errors.contentLengthHeaderNegative()
+        }
     }
 
     /// The verifier for use when content length verification is disabled.

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -256,6 +256,16 @@ public enum NIOHTTP2Errors {
         return ContentLengthHeadersMismatch(file: file, line: line)
     }
 
+    /// Creates a ``ContentLengthHeaderNegative`` error with appropriate source context.
+    public static func contentLengthHeaderNegative(file: String = #fileID, line: UInt = #line) -> ContentLengthHeaderNegative {
+        return ContentLengthHeaderNegative(file: file, line: line)
+    }
+
+    /// Creates a ``ContentLengthHeaderMalformedValue`` error with appropriate source context.
+    public static func contentLengthHeaderMalformedValue(file: String = #fileID, line: UInt = #line) -> ContentLengthHeaderMalformedValue {
+        return ContentLengthHeaderMalformedValue(file: file, line: line)
+    }
+
     /// Creates a ``ExcessiveEmptyDataFrames`` error with appropriate source context.
     public static func excessiveEmptyDataFrames(file: String = #fileID, line: UInt = #line) -> ExcessiveEmptyDataFrames {
         return ExcessiveEmptyDataFrames(file: file, line: line)
@@ -1426,6 +1436,47 @@ public enum NIOHTTP2Errors {
         }
 
         public static func ==(lhs: ContentLengthHeadersMismatch, rhs: ContentLengthHeadersMismatch) -> Bool {
+            return true
+        }
+    }
+
+    /// A request header block contains a content length header with a negative value
+    public struct ContentLengthHeaderNegative: NIOHTTP2Error {
+        private let file: String
+        private let line: UInt
+
+        /// The location where the error was thrown.
+        public var location: String {
+            return _location(file: self.file, line: self.line)
+        }
+
+        fileprivate init(file: String, line: UInt) {
+            self.file = file
+            self.line = line
+        }
+
+        public static func ==(lhs: ContentLengthHeaderNegative, rhs: ContentLengthHeaderNegative) -> Bool {
+            return true
+        }
+    }
+
+    /// A request header block contains a content length header with a malformed value
+    /// e.g. an unparsable string or an integer which cannot be represented by an Int
+    public struct ContentLengthHeaderMalformedValue: NIOHTTP2Error {
+        private let file: String
+        private let line: UInt
+
+        /// The location where the error was thrown.
+        public var location: String {
+            return _location(file: self.file, line: self.line)
+        }
+
+        fileprivate init(file: String, line: UInt) {
+            self.file = file
+            self.line = line
+        }
+
+        public static func ==(lhs: ContentLengthHeaderMalformedValue, rhs: ContentLengthHeaderMalformedValue) -> Bool {
             return true
         }
     }

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests+XCTest.swift
@@ -30,6 +30,10 @@ extension ContentLengthVerifierTests {
                 ("testDuplicatedLengthHeadersPermitted", testDuplicatedLengthHeadersPermitted),
                 ("testDuplicatedConflictingLengthHeadersThrow", testDuplicatedConflictingLengthHeadersThrow),
                 ("testNumericallyEquivalentButConflictingLengthHeadersThrow", testNumericallyEquivalentButConflictingLengthHeadersThrow),
+                ("testNegativeLengthHeaderThrows", testNegativeLengthHeaderThrows),
+                ("testMinIntLengthHeaderDoesntPanic", testMinIntLengthHeaderDoesntPanic),
+                ("testMaxIntLengthHeaderDoesntPanic", testMaxIntLengthHeaderDoesntPanic),
+                ("testInvalidLengthHeaderValuesThrow", testInvalidLengthHeaderValuesThrow),
            ]
    }
 }


### PR DESCRIPTION
`ContentLengthVerifier` `init` throws on negative values

### Motivation:

We discovered that this code path can result in an arithmetic overflow in the case where the content-length header has `INT_MIN` value. Since negative content-lengths don't have any meaning anyway we may as well throw if we encounter one so the decoding can be aborted.

### Modifications:

* ContentLengthVerifier init throws a `ContentLengthHeaderNegative` error when the decoded value is < 0.
* ContentLengthVerifier init throws a `ContentLengthHeaderMalformedValue` error when the value cannot be decoded, e.g. it is out of bounds for Int or is an invalid string.

### Result:

We will no longer panic for `INT_MIN` content-lengths and will fail decoding if one of various invalid values is encountered.
