### PR TITLE
Make FramePayload.Data class-backed

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Frame.swift
+++ b/Sources/NIOHTTP2/HTTP2Frame.swift
@@ -125,8 +125,8 @@ public struct HTTP2Frame: Sendable {
         /// The payload of a `DATA` frame.
         public struct Data {
             /// The application data carried within the `DATA` frame.
+            @inlinable
             public var data: IOData {
-                @inlinable
                 get {
                     return self._backing.data
                 }
@@ -137,8 +137,8 @@ public struct HTTP2Frame: Sendable {
             }
 
             /// The value of the `END_STREAM` flag on this frame.
+            @inlinable
             public var endStream: Bool {
-                @inlinable
                 get {
                     return self._backing.endStream
                 }
@@ -149,6 +149,7 @@ public struct HTTP2Frame: Sendable {
             }
 
             /// The number of padding bytes sent in this frame. If nil, this frame was not padded.
+            @inlinable
             public var paddingBytes: Int? {
                 get {
                     return self._backing.paddingBytes.map { Int($0) }
@@ -167,6 +168,7 @@ public struct HTTP2Frame: Sendable {
             @usableFromInline
             var _backing: _Backing
 
+            @inlinable
             public init(data: IOData, endStream: Bool = false, paddingBytes: Int? = nil) {
                 self._backing = _Backing(data: data, endStream: endStream, paddingBytes: paddingBytes.map { UInt8($0) })
             }

--- a/Sources/NIOHTTP2/HTTP2Frame.swift
+++ b/Sources/NIOHTTP2/HTTP2Frame.swift
@@ -37,7 +37,7 @@ public struct HTTP2Frame: Sendable {
         /// A `DATA` frame, containing raw bytes.
         ///
         /// See [RFC 7540 § 6.1](https://httpwg.org/specs/rfc7540.html#rfc.section.6.1).
-        indirect case data(FramePayload.Data)
+        case data(FramePayload.Data)
         
         /// A `HEADERS` frame, containing all headers or trailers associated with a request
         /// or response.
@@ -125,33 +125,86 @@ public struct HTTP2Frame: Sendable {
         /// The payload of a `DATA` frame.
         public struct Data {
             /// The application data carried within the `DATA` frame.
-            public var data: IOData
+            public var data: IOData {
+                @inlinable
+                get {
+                    return self._backing.data
+                }
+                set {
+                    self._copyIfNeeded()
+                    self._backing.data = newValue
+                }
+            }
 
             /// The value of the `END_STREAM` flag on this frame.
-            public var endStream: Bool
-
-            /// The underlying number of padding bytes. If nil, no padding is present.
-            internal private(set) var _paddingBytes: UInt8?
+            public var endStream: Bool {
+                @inlinable
+                get {
+                    return self._backing.endStream
+                }
+                set {
+                    self._copyIfNeeded()
+                    self._backing.endStream = newValue
+                }
+            }
 
             /// The number of padding bytes sent in this frame. If nil, this frame was not padded.
             public var paddingBytes: Int? {
                 get {
-                    return self._paddingBytes.map { Int($0) }
+                    return self._backing.paddingBytes.map { Int($0) }
                 }
                 set {
+                    self._copyIfNeeded()
                     if let newValue = newValue {
                         precondition(newValue >= 0 && newValue <= Int(UInt8.max), "Invalid padding byte length: \(newValue)")
-                        self._paddingBytes = UInt8(newValue)
+                        self._backing.paddingBytes = UInt8(newValue)
                     } else {
-                        self._paddingBytes = nil
+                        self._backing.paddingBytes = nil
                     }
                 }
             }
 
+            @usableFromInline
+            var _backing: _Backing
+
             public init(data: IOData, endStream: Bool = false, paddingBytes: Int? = nil) {
-                self.data = data
-                self.endStream = endStream
-                self.paddingBytes = paddingBytes
+                self._backing = _Backing(data: data, endStream: endStream, paddingBytes: paddingBytes.map { UInt8($0) })
+            }
+
+            @inlinable
+            init(_ backing: _Backing) {
+                self._backing = backing
+            }
+
+            @inlinable
+            mutating func _copyIfNeeded() {
+                if !isKnownUniquelyReferenced(&self._backing) {
+                    self._backing = self._backing.copy()
+                }
+            }
+
+            @usableFromInline
+            final class _Backing {
+                @usableFromInline
+                var data: IOData
+
+                @usableFromInline
+                var endStream: Bool
+
+                @usableFromInline
+                var paddingBytes: UInt8?
+
+                @inlinable
+                init(data: IOData, endStream: Bool, paddingBytes: UInt8?) {
+                    self.data = data
+                    self.endStream = endStream
+                    self.paddingBytes = paddingBytes
+                }
+
+                @inlinable
+                func copy() -> _Backing {
+                    return _Backing(data: self.data, endStream: self.endStream, paddingBytes: self.paddingBytes)
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

Using indirect cases makes unwrapping and rewrapping HTTP/2 frames more expensive than it needs to be. As FramePayload.Data is essentially always stuffed into a FramePayload enum, we may as well just class-back it and avoid the extra allocs.

Modifications:

Make FramePayload.Data class-backed

Result:

Fewer allocations in many use-cases