### PR TITLE
Point docs to Swift Package Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SwiftNIO HTTP/2
 
-This project contains HTTP/2 support for Swift projects using [SwiftNIO](https://github.com/apple/swift-nio). To get started, check the [API docs](https://apple.github.io/swift-nio-http2/docs/current/NIOHTTP2/index.html).
+This project contains HTTP/2 support for Swift projects using [SwiftNIO](https://github.com/apple/swift-nio). To get started, check the [API docs](https://swiftpackageindex.com/apple/swift-nio-http2/main/documentation/niohttp2).
 
 ## Building
 


### PR DESCRIPTION
Motivation:

The NIO docs are now published on the Swift Package Index but the README still refers to GitHub pages.

Modifications:

- Update README and other docs to point to Swift Package Index.

Result:

Documentation links work