### PR TITLE
ContentLengthVerifier Update

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -77,7 +77,7 @@ struct ConnectionStreamState {
     /// - parameters:
     ///     - streamID: The ID of the pushed stream.
     ///     - remoteInitialWindowSize: The initial window size of the remote peer.
-    ///     - requestVerb: HTTP Request Method used for different purposes with a web server
+    ///     - requestVerb: the HTTP method used on the request
     /// - throws: If the stream ID is invalid.
     mutating func createRemotelyPushedStream(streamID: HTTP2StreamID, remoteInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -77,11 +77,11 @@ struct ConnectionStreamState {
     /// - parameters:
     ///     - streamID: The ID of the pushed stream.
     ///     - remoteInitialWindowSize: The initial window size of the remote peer.
+    ///     - requestVerb: HTTP Request Method used for different purposes with a web server
     /// - throws: If the stream ID is invalid.
     mutating func createRemotelyPushedStream(streamID: HTTP2StreamID, remoteInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)
-//        let requestVerb = self.getPseudoHeader(name: ":method")
-        let streamState = HTTP2StreamStateMachine(receivedPushPromiseCreatingStreamID: streamID, remoteInitialWindowSize: remoteInitialWindowSize,requestVerb: requestVerb)
+        let streamState = HTTP2StreamStateMachine(receivedPushPromiseCreatingStreamID: streamID, remoteInitialWindowSize: remoteInitialWindowSize, requestVerb: requestVerb)
         self.activeStreams.insert(streamState)
     }
 

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -78,9 +78,10 @@ struct ConnectionStreamState {
     ///     - streamID: The ID of the pushed stream.
     ///     - remoteInitialWindowSize: The initial window size of the remote peer.
     /// - throws: If the stream ID is invalid.
-    mutating func createRemotelyPushedStream(streamID: HTTP2StreamID, remoteInitialWindowSize: UInt32) throws {
+    mutating func createRemotelyPushedStream(streamID: HTTP2StreamID, remoteInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)
-        let streamState = HTTP2StreamStateMachine(receivedPushPromiseCreatingStreamID: streamID, remoteInitialWindowSize: remoteInitialWindowSize)
+//        let requestVerb = self.getPseudoHeader(name: ":method")
+        let streamState = HTTP2StreamStateMachine(receivedPushPromiseCreatingStreamID: streamID, remoteInitialWindowSize: remoteInitialWindowSize,requestVerb: requestVerb)
         self.activeStreams.insert(streamState)
     }
 
@@ -93,9 +94,9 @@ struct ConnectionStreamState {
     ///     - streamID: The ID of the pushed stream.
     ///     - localInitialWindowSize: Our initial window size..
     /// - throws: If the stream ID is invalid.
-    mutating func createLocallyPushedStream(streamID: HTTP2StreamID, localInitialWindowSize: UInt32) throws {
+    mutating func createLocallyPushedStream(streamID: HTTP2StreamID, localInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)
-        let streamState = HTTP2StreamStateMachine(sentPushPromiseCreatingStreamID: streamID, localInitialWindowSize: localInitialWindowSize)
+        let streamState = HTTP2StreamStateMachine(sentPushPromiseCreatingStreamID: streamID, localInitialWindowSize: localInitialWindowSize, requestVerb: requestVerb)
         self.activeStreams.insert(streamState)
     }
 

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
@@ -50,10 +50,10 @@ extension ReceivingPushPromiseState {
         }
 
         let validateHeaderBlock = self.headerBlockValidation == .enabled
-
+        let requestVerb = headers.getPseudoHeader(name: ":method")
         do {
             try self.streamState.createRemotelyPushedStream(streamID: childStreamID,
-                                                            remoteInitialWindowSize: self.remoteInitialWindowSize)
+                                                            remoteInitialWindowSize: self.remoteInitialWindowSize,requestVerb: requestVerb)
 
             let result = self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: true) {
                 $0.receivePushPromise(headers: headers, validateHeaderBlock: validateHeaderBlock)

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingPushPromiseState.swift
@@ -50,10 +50,10 @@ extension ReceivingPushPromiseState {
         }
 
         let validateHeaderBlock = self.headerBlockValidation == .enabled
-        let requestVerb = headers.getPseudoHeader(name: ":method")
+        let requestVerb = headers.first(name: ":method")
         do {
             try self.streamState.createRemotelyPushedStream(streamID: childStreamID,
-                                                            remoteInitialWindowSize: self.remoteInitialWindowSize,requestVerb: requestVerb)
+                                                            remoteInitialWindowSize: self.remoteInitialWindowSize, requestVerb: requestVerb)
 
             let result = self.streamState.modifyStreamState(streamID: originalStreamID, ignoreRecentlyReset: true) {
                 $0.receivePushPromise(headers: headers, validateHeaderBlock: validateHeaderBlock)

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
@@ -59,7 +59,7 @@ extension SendingPushPromiseState {
             guard case .succeed = result.result else {
                 return result
             }
-            let requestVerb = headers.getPseudoHeader(name: ":method")
+            let requestVerb = headers.first(name: ":method")
             try self.streamState.createLocallyPushedStream(streamID: childStreamID, localInitialWindowSize: self.localInitialWindowSize, requestVerb: requestVerb)
             return result
         } catch {

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameSendingStates/SendingPushPromiseState.swift
@@ -59,8 +59,8 @@ extension SendingPushPromiseState {
             guard case .succeed = result.result else {
                 return result
             }
-
-            try self.streamState.createLocallyPushedStream(streamID: childStreamID, localInitialWindowSize: self.localInitialWindowSize)
+            let requestVerb = headers.getPseudoHeader(name: ":method")
+            try self.streamState.createLocallyPushedStream(streamID: childStreamID, localInitialWindowSize: self.localInitialWindowSize, requestVerb: requestVerb)
             return result
         } catch {
             return StateMachineResultWithEffect(result: .connectionError(underlyingError: error, type: .protocolError), effect: nil)

--- a/Sources/NIOHTTP2/ContentLengthVerifier.swift
+++ b/Sources/NIOHTTP2/ContentLengthVerifier.swift
@@ -48,7 +48,17 @@ extension ContentLengthVerifier {
 }
 
 extension ContentLengthVerifier {
-    internal init(_ headers: HPACKHeaders) throws {
+    internal init(_ headers: HPACKHeaders, requestMethod: String?) throws {
+         if requestMethod != nil {
+            if let status = headers.getPseudoHeader(name: ":status"), status == "304" {
+                self.expectedContentLength = 0
+                return
+            }
+            else if requestMethod == "HEAD" {
+                self.expectedContentLength = 0
+                return
+            }
+        }
         let contentLengths = headers.values(forHeader: "content-length", canonicalForm: true)
         var iterator = contentLengths.makeIterator()
         guard let first = iterator.next() else {
@@ -80,5 +90,16 @@ extension ContentLengthVerifier {
 extension ContentLengthVerifier: CustomStringConvertible {
     var description: String {
         return "ContentLengthVerifier(length: \(String(describing: self.expectedContentLength)))"
+    }
+}
+
+extension HPACKHeaders {
+    func getPseudoHeader(name: String) -> String? {
+        for (fieldName, fieldValue, _) in self {
+            if name == fieldName {
+                return fieldValue
+            }
+        }
+        return nil
     }
 }

--- a/Sources/NIOHTTP2/ContentLengthVerifier.swift
+++ b/Sources/NIOHTTP2/ContentLengthVerifier.swift
@@ -49,12 +49,11 @@ extension ContentLengthVerifier {
 
 extension ContentLengthVerifier {
     internal init(_ headers: HPACKHeaders, requestMethod: String?) throws {
-         if requestMethod != nil {
-            if let status = headers.getPseudoHeader(name: ":status"), status == "304" {
+         if let requestMethod = requestMethod {
+            if let status = headers.first(name: ":status"), status == "304" {
                 self.expectedContentLength = 0
                 return
-            }
-            else if requestMethod == "HEAD" {
+            } else if requestMethod == "HEAD" {
                 self.expectedContentLength = 0
                 return
             }
@@ -93,13 +92,3 @@ extension ContentLengthVerifier: CustomStringConvertible {
     }
 }
 
-extension HPACKHeaders {
-    func getPseudoHeader(name: String) -> String? {
-        for (fieldName, fieldValue, _) in self {
-            if name == fieldName {
-                return fieldValue
-            }
-        }
-        return nil
-    }
-}

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -145,6 +145,12 @@ extension ConnectionStateMachineTests {
                 ("testWeTolerateOneStreamBeingResetTwice", testWeTolerateOneStreamBeingResetTwice),
                 ("testReceivedAltServiceFramesAreIgnored", testReceivedAltServiceFramesAreIgnored),
                 ("testReceivedOriginFramesAreIgnored", testReceivedOriginFramesAreIgnored),
+                ("testContentLengthForStatus304", testContentLengthForStatus304),
+                ("testContentLengthForStatus304Failure", testContentLengthForStatus304Failure),
+                ("testContentLengthForMethodHead", testContentLengthForMethodHead),
+                ("testContentLengthForHeadFailure", testContentLengthForHeadFailure),
+                ("testPushHeadRequestFailure", testPushHeadRequestFailure),
+                ("testPushHeadRequest", testPushHeadRequest),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -3004,8 +3004,7 @@ class ConnectionStateMachineTests: XCTestCase {
 
     func testContentLengthForStatus304() {
         let streamOne = HTTP2StreamID(1)
-        
-        // Override the setup with validation disabled.
+
         self.server = .init(role: .server)
         self.client = .init(role: .client)
         
@@ -3026,11 +3025,9 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.client.receiveData(streamID: streamOne, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
     }
 
-    ///when the status is 304 and we send bytes through
     func testContentLengthForStatus304Failure() {
         let streamOne = HTTP2StreamID(1)
 
-        // Override the setup with validation disabled.
         self.server = .init(role: .server)
         self.client = .init(role: .client)
 
@@ -3054,7 +3051,6 @@ class ConnectionStateMachineTests: XCTestCase {
     func testContentLengthForMethodHead() {
         let streamOne = HTTP2StreamID(1)
 
-        // Override the setup with validation disabled.
         self.server = .init(role: .server)
         self.client = .init(role: .client)
 
@@ -3079,7 +3075,6 @@ class ConnectionStateMachineTests: XCTestCase {
     func testContentLengthForHeadFailure() {
         let streamOne = HTTP2StreamID(1)
 
-        // Override the setup with validation disabled.
         self.server = .init(role: .server)
         self.client = .init(role: .client)
 
@@ -3101,7 +3096,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertStreamError(type: HTTP2ErrorCode.protocolError, self.client.receiveData(streamID: streamOne, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
     }
 
-    func testSimpleServerPush_forPushHeadRequestFailure() {
+    func testPushHeadRequestFailure() {
         let streamOne = HTTP2StreamID(1)
         let streamTwo = HTTP2StreamID(2)
         
@@ -3109,8 +3104,7 @@ class ConnectionStateMachineTests: XCTestCase {
         
         let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
         let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
-        
-        
+
         assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
         assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
         
@@ -3127,7 +3121,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertStreamError(type: HTTP2ErrorCode.protocolError, self.client.receiveData(streamID: streamTwo, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
     }
 
-    func testSimpleServerPush_forPushHeadRequest() {
+    func testPushHeadRequest() {
         let streamOne = HTTP2StreamID(1)
         let streamTwo = HTTP2StreamID(2)
 
@@ -3135,7 +3129,6 @@ class ConnectionStateMachineTests: XCTestCase {
 
         let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
         let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
-
 
         assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
         assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
@@ -3148,7 +3141,7 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.server.sendHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
         assertSucceeds(self.client.receiveHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
 
-        // Send in 0 bytea over one frame
+        // Send in 0 bytes over one frame
         assertSucceeds(self.client.receiveData(streamID: streamTwo, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
     }
 }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -3001,6 +3001,156 @@ class ConnectionStateMachineTests: XCTestCase {
         assertIgnored(self.client.receiveOrigin(origins: ["one", "two"]))
         assertIgnored(self.server.receiveOrigin(origins: ["one", "two"]))
     }
+
+    func testContentLengthForStatus304() {
+        let streamOne = HTTP2StreamID(1)
+        
+        // Override the setup with validation disabled.
+        self.server = .init(role: .server)
+        self.client = .init(role: .client)
+        
+        self.exchangePreamble()
+        
+        let responseHeaders = HPACKHeaders([(":status", "304"), ("content-length", "25")])
+        
+        // Set up the connection
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+        
+        // Send in 0 bytes over two sets
+        assertSucceeds(self.server.sendData(streamID: streamOne, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
+        assertSucceeds(self.client.receiveData(streamID: streamOne, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
+    }
+
+    ///when the status is 304 and we send bytes through
+    func testContentLengthForStatus304Failure() {
+        let streamOne = HTTP2StreamID(1)
+
+        // Override the setup with validation disabled.
+        self.server = .init(role: .server)
+        self.client = .init(role: .client)
+
+        self.exchangePreamble()
+
+        let responseHeaders = HPACKHeaders([(":status", "304"), ("content-length", "25")])
+
+        // Set up the connection
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+
+        // Send in 1 byte over one frame
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.server.sendData(streamID: streamOne, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.client.receiveData(streamID: streamOne, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+    }
+
+    func testContentLengthForMethodHead() {
+        let streamOne = HTTP2StreamID(1)
+
+        // Override the setup with validation disabled.
+        self.server = .init(role: .server)
+        self.client = .init(role: .client)
+
+        self.exchangePreamble()
+
+        let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
+
+        // Set up the connection
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: requestHeaders, isEndStreamSet: true))
+
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+
+        // Send in 0 bytes over one frame
+        assertSucceeds(self.server.sendData(streamID: streamOne, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
+        assertSucceeds(self.client.receiveData(streamID: streamOne, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
+    }
+
+    func testContentLengthForHeadFailure() {
+        let streamOne = HTTP2StreamID(1)
+
+        // Override the setup with validation disabled.
+        self.server = .init(role: .server)
+        self.client = .init(role: .client)
+
+        self.exchangePreamble()
+
+        let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
+
+        // Set up the connection
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: requestHeaders, isEndStreamSet: true))
+
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamOne, headers: responseHeaders, isEndStreamSet: false))
+
+        // Send in 1 byte over 1 frame
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.server.sendData(streamID: streamOne, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.client.receiveData(streamID: streamOne, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+    }
+
+    func testSimpleServerPush_forPushHeadRequestFailure() {
+        let streamOne = HTTP2StreamID(1)
+        let streamTwo = HTTP2StreamID(2)
+        
+        self.exchangePreamble()
+        
+        let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
+        
+        
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        
+        // Server can push right away
+        assertSucceeds(self.server.sendPushPromise(originalStreamID: streamOne, childStreamID: streamTwo, headers: requestHeaders))
+        assertSucceeds(self.client.receivePushPromise(originalStreamID: streamOne, childStreamID: streamTwo, headers: requestHeaders))
+
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
+
+        // Send in 1 byte over one frame
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.server.sendData(streamID: streamTwo, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+        assertStreamError(type: HTTP2ErrorCode.protocolError, self.client.receiveData(streamID: streamTwo, contentLength: 1, flowControlledBytes: 1, isEndStreamSet: true))
+    }
+
+    func testSimpleServerPush_forPushHeadRequest() {
+        let streamOne = HTTP2StreamID(1)
+        let streamTwo = HTTP2StreamID(2)
+
+        self.exchangePreamble()
+
+        let requestHeaders = HPACKHeaders([(":method", "HEAD"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
+        let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "25")])
+
+
+        assertSucceeds(self.client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+        assertSucceeds(self.server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: true))
+
+        // Server can push right away
+        assertSucceeds(self.server.sendPushPromise(originalStreamID: streamOne, childStreamID: streamTwo, headers: requestHeaders))
+        assertSucceeds(self.client.receivePushPromise(originalStreamID: streamOne, childStreamID: streamTwo, headers: requestHeaders))
+
+        // The server responds
+        assertSucceeds(self.server.sendHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
+        assertSucceeds(self.client.receiveHeaders(streamID: streamTwo, headers: responseHeaders, isEndStreamSet: false))
+
+        // Send in 0 bytea over one frame
+        assertSucceeds(self.client.receiveData(streamID: streamTwo, contentLength: 0, flowControlledBytes: 0, isEndStreamSet: true))
+    }
 }
 
 

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests+XCTest.swift
@@ -34,6 +34,8 @@ extension ContentLengthVerifierTests {
                 ("testMinIntLengthHeaderDoesntPanic", testMinIntLengthHeaderDoesntPanic),
                 ("testMaxIntLengthHeaderDoesntPanic", testMaxIntLengthHeaderDoesntPanic),
                 ("testInvalidLengthHeaderValuesThrow", testInvalidLengthHeaderValuesThrow),
+                ("testContentLengthVerifier_whenResponseStatusIs304", testContentLengthVerifier_whenResponseStatusIs304),
+                ("testContentLengthVerifier_whenRequestMethodIsHead", testContentLengthVerifier_whenRequestMethodIsHead),
            ]
    }
 }

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
@@ -99,9 +99,8 @@ class ContentLengthVerifierTests: XCTestCase {
         }
     }
 
-    func testContentLengthVerifier_whenRequestMethodIs304() throws {
+    func testContentLengthVerifier_whenResponseStatusIs304() throws {
         let headers = HPACKHeaders([(":status", "304"), ("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "GET"))
         let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "GET"))
         XCTAssertEqual(0, verifier.expectedContentLength)
     }
@@ -109,7 +108,6 @@ class ContentLengthVerifierTests: XCTestCase {
 
     func testContentLengthVerifier_whenRequestMethodIsHead() throws {
         let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
         let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
         XCTAssertEqual(0, verifier.expectedContentLength)
     }

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
@@ -19,83 +19,121 @@ import NIOHPACK
 class ContentLengthVerifierTests: XCTestCase {
     func testDuplicatedLengthHeadersPermitted() throws {
         var headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertNoThrow(try ContentLengthVerifier(headers))
-        var verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: nil))
+        var verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
 
         headers.add(contentsOf: [("content-length", "1834")])
-        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
 
         headers.add(contentsOf: [("content-length", "1834")])
-        XCTAssertNoThrow(try ContentLengthVerifier(headers))
-        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: nil))
+        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
 
         headers.add(contentsOf: [("Content-Length", "1834")])
-        XCTAssertNoThrow(try ContentLengthVerifier(headers))
-        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: nil))
+        verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
     }
 
     func testDuplicatedConflictingLengthHeadersThrow() throws {
         var headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
-        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
 
         headers.add(contentsOf: [("Content-Length", "4381")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeadersMismatch)
         }
     }
 
     func testNumericallyEquivalentButConflictingLengthHeadersThrow() throws {
         var headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
-        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(1834, verifier.expectedContentLength)
 
         headers.add(contentsOf: [("Content-Length", "01834")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeadersMismatch)
         }
     }
 
     func testNegativeLengthHeaderThrows() throws {
         let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "-1"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeaderNegative)
         }
     }
 
     func testMinIntLengthHeaderDoesntPanic() throws {
         let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", String(Int.min)), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeaderNegative)
         }
     }
 
     func testMaxIntLengthHeaderDoesntPanic() throws {
         let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", String(Int.max)), ("User-Agent", "myCoolClient/1.0")])
-        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers))
+        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: nil))
         XCTAssertEqual(Int.max, verifier.expectedContentLength)
     }
 
     func testInvalidLengthHeaderValuesThrow() throws {
         var headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "0xFF"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeaderMalformedValue)
         }
 
         // Int.min - 1
         headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "-9223372036854775809"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeaderMalformedValue)
         }
 
         // Int.max + 1
         headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "9223372036854775809"), ("User-Agent", "myCoolClient/1.0")])
-        XCTAssertThrowsError(try ContentLengthVerifier(headers)) { error in
+        XCTAssertThrowsError(try ContentLengthVerifier(headers, requestMethod: nil)) { error in
             XCTAssertTrue(error is NIOHTTP2Errors.ContentLengthHeaderMalformedValue)
         }
     }
+
+    func testContentLengthVerifier_whenRequestMethod() throws {
+        let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0"), (":status", "304")])
+        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "GET"))
+        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "GET"))
+        XCTAssertEqual(0, verifier.expectedContentLength)
+    }
+
+
+    func testContentLengthVerifier_whenRequestMethodofHead() throws {
+        let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
+        XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
+        let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
+        XCTAssertEqual(0, verifier.expectedContentLength)
+    }
+
+
+
+//    want top to bottom testing
+//    want to confirm it does the right thing wiht the right inputs
+
+//    when we are running the whole stack, everyone is keeping track of what the correct content length is
+
+//    function in the radar that doesn't work 
+//    func testHeadAsVerb() throws {
+//        let client = HTTPClient(eventLoopGroupProvider: .shared(group))
+//        defer { try! client.syncShutdown() }
+//        do {
+//            var req = HTTPClientRequest(url: "https://service.results.apple.com/api/v0/result/test")
+//
+//            // ### This is the important bit ####
+//            req.method = .HEAD
+//
+//            _ = try await client.execute(req, timeout: .seconds(10))
+//        } catch {
+//            XCTFail(">\(error)")
+//        }
+//    }
 }

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
@@ -99,15 +99,15 @@ class ContentLengthVerifierTests: XCTestCase {
         }
     }
 
-    func testContentLengthVerifier_whenRequestMethod() throws {
-        let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0"), (":status", "304")])
+    func testContentLengthVerifier_whenRequestMethodIs304() throws {
+        let headers = HPACKHeaders([(":status", "304"), ("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
         XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "GET"))
         let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "GET"))
         XCTAssertEqual(0, verifier.expectedContentLength)
     }
 
 
-    func testContentLengthVerifier_whenRequestMethodofHead() throws {
+    func testContentLengthVerifier_whenRequestMethodIsHead() throws {
         let headers = HPACKHeaders([("Host", "apple.com"), ("content-length", "1834"), ("User-Agent", "myCoolClient/1.0")])
         XCTAssertNoThrow(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
         let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "HEAD"))

--- a/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
+++ b/Tests/NIOHTTP2Tests/ContentLengthVerifierTests.swift
@@ -113,27 +113,4 @@ class ContentLengthVerifierTests: XCTestCase {
         let verifier = try assertNoThrowWithValue(try ContentLengthVerifier(headers, requestMethod: "HEAD"))
         XCTAssertEqual(0, verifier.expectedContentLength)
     }
-
-
-
-//    want top to bottom testing
-//    want to confirm it does the right thing wiht the right inputs
-
-//    when we are running the whole stack, everyone is keeping track of what the correct content length is
-
-//    function in the radar that doesn't work 
-//    func testHeadAsVerb() throws {
-//        let client = HTTPClient(eventLoopGroupProvider: .shared(group))
-//        defer { try! client.syncShutdown() }
-//        do {
-//            var req = HTTPClientRequest(url: "https://service.results.apple.com/api/v0/result/test")
-//
-//            // ### This is the important bit ####
-//            req.method = .HEAD
-//
-//            _ = try await client.execute(req, timeout: .seconds(10))
-//        } catch {
-//            XCTFail(">\(error)")
-//        }
-//    }
 }


### PR DESCRIPTION
Motivation:
Currently, swift-nio-http2 ignores content length when handling a response to a HEAD request and handling a 304 response.

Modifications:
Changing ContentLengthVerifier and any functions called 