### PR TITLE
Content-Length errors shouldn't crash

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -18,6 +18,9 @@ import NIOHPACK
 /// Users are recommended not to implement this protocol with their own types.
 public protocol NIOHTTP2Error: Equatable, Error { }
 
+/// An internal marker-protocol for errors to do with content-length.
+protocol InvalidContentLengthError: NIOHTTP2Error { }
+
 /// Errors that ``NIOHTTP2`` raises when handling HTTP/2 connections.
 public enum NIOHTTP2Errors {
     /// Creates an ``ExcessiveOutboundFrameBuffering`` error with appropriate source context.
@@ -1396,7 +1399,7 @@ public enum NIOHTTP2Errors {
     }
 
     /// A request or response has violated the expected content length, either exceeding or falling beneath it.
-    public struct ContentLengthViolated: NIOHTTP2Error {
+    public struct ContentLengthViolated: NIOHTTP2Error, InvalidContentLengthError {
         private let file: String
         private let line: UInt
 
@@ -1421,7 +1424,7 @@ public enum NIOHTTP2Errors {
     }
 
     /// A request header block contains multiple content length headers with disagreeing values
-    public struct ContentLengthHeadersMismatch: NIOHTTP2Error {
+    public struct ContentLengthHeadersMismatch: NIOHTTP2Error, InvalidContentLengthError {
         private let file: String
         private let line: UInt
 
@@ -1441,7 +1444,7 @@ public enum NIOHTTP2Errors {
     }
 
     /// A request header block contains a content length header with a negative value
-    public struct ContentLengthHeaderNegative: NIOHTTP2Error {
+    public struct ContentLengthHeaderNegative: NIOHTTP2Error, InvalidContentLengthError {
         private let file: String
         private let line: UInt
 
@@ -1462,7 +1465,7 @@ public enum NIOHTTP2Errors {
 
     /// A request header block contains a content length header with a malformed value
     /// e.g. an unparsable string or an integer which cannot be represented by an Int
-    public struct ContentLengthHeaderMalformedValue: NIOHTTP2Error {
+    public struct ContentLengthHeaderMalformedValue: NIOHTTP2Error, InvalidContentLengthError {
         private let file: String
         private let line: UInt
 

--- a/Sources/NIOHTTP2/StreamStateMachine.swift
+++ b/Sources/NIOHTTP2/StreamStateMachine.swift
@@ -389,7 +389,7 @@ extension HTTP2StreamStateMachine {
             case .reservedRemote, .halfClosedLocalPeerIdle, .halfClosedLocalPeerActive:
                 return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.badStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
-        } catch let error where error is NIOHTTP2Errors.ContentLengthViolated {
+        } catch let error where error is InvalidContentLengthError {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .protocolError), effect: nil)
         } catch {
             preconditionFailure("Unexpected error: \(error)")
@@ -521,7 +521,7 @@ extension HTTP2StreamStateMachine {
             case .reservedLocal, .halfClosedRemoteLocalIdle, .halfClosedRemoteLocalActive:
                 return .init(result: .streamError(streamID: self.streamID, underlyingError: NIOHTTP2Errors.badStreamStateTransition(from: NIOHTTP2StreamState.get(self.state)), type: .protocolError), effect: nil)
             }
-        } catch let error where error is NIOHTTP2Errors.ContentLengthViolated {
+        } catch let error where error is InvalidContentLengthError {
             return .init(result: .streamError(streamID: self.streamID, underlyingError: error, type: .protocolError), effect: nil)
         } catch {
             preconditionFailure("Unexpected error: \(error)")

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests+XCTest.swift
@@ -151,6 +151,9 @@ extension ConnectionStateMachineTests {
                 ("testContentLengthForHeadFailure", testContentLengthForHeadFailure),
                 ("testPushHeadRequestFailure", testPushHeadRequestFailure),
                 ("testPushHeadRequest", testPushHeadRequest),
+                ("testNegativeContentLengthHeader", testNegativeContentLengthHeader),
+                ("testInvalidContentLengthHeader", testInvalidContentLengthHeader),
+                ("testContentLengthHeadersMismatch", testContentLengthHeadersMismatch),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When we added new content length verification and new errors, we didn't update the places that were handling the old error. This code updates that logic to ensure that we don't crash.

Modifications:

Add new internal protocol to which the content length validation errors conform.
Catch that protocol instead.

Result:

No crashes on invalid content-length