### PR TITLE
Better handle writes issued with already completed promises

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests+XCTest.swift
@@ -78,6 +78,7 @@ extension SimpleClientServerFramePayloadStreamTests {
                 ("testHTTP2HandlerDoesNotFlushExcessively", testHTTP2HandlerDoesNotFlushExcessively),
                 ("testHTTPHandlerIgnoresInboundAltServiceFrames", testHTTPHandlerIgnoresInboundAltServiceFrames),
                 ("testHTTPHandlerIgnoresInboundOriginFrames", testHTTPHandlerIgnoresInboundOriginFrames),
+                ("testWriteWithAlreadyCompletedPromise", testWriteWithAlreadyCompletedPromise),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The stream channel updates its writability manager when issuing a write to the parent channel and when the write promise has been succeeded. If the write promise has already been succeeded then the writability manager can be updated in the wrong order which can lead to underflow.

Modifications:

- Use signed arithmetic in the writability manager and allow pending
  bytes to become (briefly) negative.

Result:

The writability manager's pending bytes shouldn't underflow.