### PR TITLE
Ensure that we fire channelActive and channelInactive in order

### DIFF
--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -1622,6 +1622,25 @@ public enum NIOHTTP2Errors {
             self.storage = .init(streamID: streamID, baseError: baseError)
         }
     }
+
+    public struct ActivationError: NIOHTTP2Error, CustomStringConvertible {
+        private let state: NIOHTTP2Handler.ActivationState
+
+        private var activating: Bool
+
+        init(state: NIOHTTP2Handler.ActivationState, activating: Bool) {
+            self.state = state
+            self.activating = activating
+        }
+
+        public var description: String {
+            if self.activating {
+                return "Error during activation: in state \(self.state)"
+            } else {
+                return "Error during inactivation: in state \(self.state)"
+            }
+        }
+    }
 }
 
 

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests.swift
@@ -2067,7 +2067,7 @@ final class HTTP2FramePayloadStreamMultiplexerTests: XCTestCase {
     }
 }
 
-private final class ErrorRecorder: ChannelInboundHandler {
+final class ErrorRecorder: ChannelInboundHandler {
     typealias InboundIn = Any
 
     var errors: [Error] = []

--- a/Tests/NIOHTTP2Tests/ReentrancyTests.swift
+++ b/Tests/NIOHTTP2Tests/ReentrancyTests.swift
@@ -149,7 +149,6 @@ final class ReentrancyTests: XCTestCase {
         try self.serverChannel.assertReceivedFrame().assertFrameMatches(this: settingsFrame)
 
         XCTAssertNoThrow(try self.clientChannel.finish())
-        XCTAssertNoThrow(try self.serverChannel.finish())
     }
 
     func testReenterReadEOFOnRead() throws {

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -33,6 +33,10 @@ extension SimpleClientServerTests {
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromServer", testNoStreamWindowUpdateOnEndStreamFrameFromServer),
                 ("testNoStreamWindowUpdateOnEndStreamFrameFromClient", testNoStreamWindowUpdateOnEndStreamFrameFromClient),
                 ("testStreamCreationOrder", testStreamCreationOrder),
+                ("testHandlingChannelInactiveDuringActive", testHandlingChannelInactiveDuringActive),
+                ("testWritingFromChannelActiveIsntReordered", testWritingFromChannelActiveIsntReordered),
+                ("testChannelActiveAfterAddingToActivePipelineDoesntError", testChannelActiveAfterAddingToActivePipelineDoesntError),
+                ("testImpossibleStateTransitionsThrowErrors", testImpossibleStateTransitionsThrowErrors),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

channelActive must always precede channelInactive. Unfortunately, this isn't guaranteed right now: if we happen to get channelInactive as a result of our writing the preamble we'll fire them in the wrong order. Many systems can tolerate this, but we should avoid doing this anyway.

Modifications:

- Added a state enum to keep track of the state we're in
- Use that state enum to ensure we deliver active/inactive in the right order
- Additionally police other unexpected active/inactive behaviours

Result:

We'll appropriately police the state.