### PR TITLE
Correctly respect changes to HEADER_TABLE_SIZE

### DIFF
--- a/Sources/NIOHPACK/HPACKEncoder.swift
+++ b/Sources/NIOHPACK/HPACKEncoder.swift
@@ -65,6 +65,9 @@ public struct HPACKEncoder {
     /// SETTINGS frame.
     public var maximumDynamicTableSize: Int {
         get { return self.headerIndexTable.maxDynamicTableLength }
+
+        // This should have been private, but we messed up. Nevermind.
+        @available(*, deprecated, message: "Setting the dynamic table length on the HPACK encoder doesn't have the intended effect.", renamed: "setDynamicTableSize(_:)")
         set { self.headerIndexTable.maxDynamicTableLength = newValue }
     }
     
@@ -75,9 +78,6 @@ public struct HPACKEncoder {
     /// - Throws: If the encoder is currently in use, or if the requested size
     ///           exceeds the maximum value negotiated with the peer.
     public mutating func setDynamicTableSize(_ size: Int) throws {
-        guard size <= self.maximumDynamicTableSize else {
-            throw NIOHPACKErrors.InvalidDynamicTableSize(requestedSize: size, allowedSize: self.maximumDynamicTableSize)
-        }
         guard size != self.allowedDynamicTableSize else {
             // no need to change anything
             return
@@ -98,6 +98,7 @@ public struct HPACKEncoder {
         }
         
         // set the new size on our dynamic table
+        self.headerIndexTable.maxDynamicTableLength = size
         self.allowedDynamicTableSize = size
     }
     

--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
@@ -26,7 +26,7 @@ protocol HasLocalSettings {
 }
 
 extension HasLocalSettings {
-    mutating func receiveSettingsAck(frameEncoder: inout HTTP2FrameEncoder) -> StateMachineResultWithEffect {
+    mutating func receiveSettingsAck(frameDecoder: inout HTTP2FrameDecoder) -> StateMachineResultWithEffect {
         // We do a little switcheroo here to avoid problems with overlapping accesses to
         // self. It's a little more complex than normal because HTTP2SettingsState has
         // two CoWable objects, and we don't want to CoW either of them, so we shove a dummy
@@ -49,7 +49,7 @@ extension HasLocalSettings {
                         self.streamState.maxClientInitiatedStreams = newValue
                     }
                 case .headerTableSize:
-                    frameEncoder.headerEncoder.maximumDynamicTableSize = Int(newValue)
+                    frameDecoder.headerDecoder.maxDynamicTableLength = Int(newValue)
                 case .initialWindowSize:
                     // We default the value of SETTINGS_INITIAL_WINDOW_SIZE, so originalValue mustn't be nil.
                     // The max value of SETTINGS_INITIAL_WINDOW_SIZE is Int32.max, so we can safely fit it into that here.

--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
@@ -26,7 +26,7 @@ protocol HasRemoteSettings {
 }
 
 extension HasRemoteSettings {
-    mutating func receiveSettingsChange(_ settings: HTTP2Settings, frameDecoder: inout HTTP2FrameDecoder) -> (StateMachineResultWithEffect, PostFrameOperation) {
+    mutating func receiveSettingsChange(_ settings: HTTP2Settings, frameEncoder: inout HTTP2FrameEncoder) -> (StateMachineResultWithEffect, PostFrameOperation) {
         // We do a little switcheroo here to avoid problems with overlapping accesses to
         // self. It's a little more complex than normal because HTTP2SettingsState has
         // two CoWable objects, and we don't want to CoW either of them, so we shove a dummy
@@ -50,7 +50,7 @@ extension HasRemoteSettings {
                     }
                     effect.newMaxConcurrentStreams = newValue
                 case .headerTableSize:
-                    frameDecoder.headerDecoder.maxDynamicTableLength = Int(newValue)
+                    try frameEncoder.headerEncoder.setDynamicTableSize(Int(newValue))
                 case .initialWindowSize:
                     // We default the value of SETTINGS_INITIAL_WINDOW_SIZE, so originalValue mustn't be nil.
                     // The max value of SETTINGS_INITIAL_WINDOW_SIZE is Int32.max, so we can safely fit it into that here.

--- a/Tests/NIOHPACKTests/HPACKCodingTests.swift
+++ b/Tests/NIOHPACKTests/HPACKCodingTests.swift
@@ -491,20 +491,11 @@ class HPACKCodingTests: XCTestCase {
         // NB: current size is 81 bytes.
         encoder.headerIndexTable.dynamicTable.clear()
 
-        XCTAssertThrowsError(try encoder.setDynamicTableSize(8192)) { error in
-            guard let err = error as? NIOHPACKErrors.InvalidDynamicTableSize else {
-                XCTFail()
-                return
-            }
-            XCTAssertEqual(err.requestedSize, 8192)
-            XCTAssertEqual(err.allowedSize, 4096)
-        }
-
         XCTAssertThrowsError(try decoder.decodeHeaders(from: &request3)) {error in
             XCTAssertTrue(error is NIOHPACKErrors.InvalidDynamicTableSize)
         }
 
-        // 5 - Decoder will not accept a table size update unless it appears at the start of a header block.
+        // 4 - Decoder will not accept a table size update unless it appears at the start of a header block.
         decoder.headerTable.dynamicTable.clear()
 
         XCTAssertThrowsError(try decoder.decodeHeaders(from: &request4)) {error in

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -37,6 +37,10 @@ extension SimpleClientServerTests {
                 ("testWritingFromChannelActiveIsntReordered", testWritingFromChannelActiveIsntReordered),
                 ("testChannelActiveAfterAddingToActivePipelineDoesntError", testChannelActiveAfterAddingToActivePipelineDoesntError),
                 ("testImpossibleStateTransitionsThrowErrors", testImpossibleStateTransitionsThrowErrors),
+                ("testDynamicHeaderFieldsArentEmittedWithZeroTableSize", testDynamicHeaderFieldsArentEmittedWithZeroTableSize),
+                ("testDynamicHeaderFieldsArentToleratedWithZeroTableSize", testDynamicHeaderFieldsArentToleratedWithZeroTableSize),
+                ("testSettingTableSizeToZeroAfterStartEvictsHeaders", testSettingTableSizeToZeroAfterStartEvictsHeaders),
+                ("testSettingTableSizeToZeroEvictsHeadersAndRefusesToDecodeThem", testSettingTableSizeToZeroEvictsHeadersAndRefusesToDecodeThem),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When remote peers set the value of HEADER_TABLE_SIZE to any non-default value, or when we update it, we should respect that value when we're emitting headers.

Unfortunately, right now we don't. In particular, we manage to update the wrong setting: when the peer sets HEADER_TABLE_SIZE we bound the maximum size of the dynamic table _they_ can use, not the maximum size _we_ can use. That's incorrect by the spec, which says:

> This setting allows the sender to inform the remote endpoint of the
> maximum size of the compression table used to decode field blocks,
> in units of octets. The encoder can select any size equal to or less
> than this value by using signaling specific to the compression
> format inside a field block (see [COMPRESSION]).

If a peer sent us SETTINGS_HEADER_TABLE_SIZE with a value of 0, we'd restrict _them_ to only using a maximum table size of 0, instead of us. This is wrong.

Additionally, when we updated the encoder we used the wrong method, so the encoder would never send dynamic table size changes. This was also incorrect!

In general this managed to get missed because, as RFC 9113 notes:

> Implementers are advised that reducing the value of
> SETTINGS_HEADER_TABLE_SIZE is not widely interoperable. Use of the
> connection preface to reduce the value below the initial value of
> 4,096 is somewhat better supported, but this might fail with some
> implementations.

It turns out one of those implementations this might fail with is us! The result, however, is that very few implementations actually try to reduce the value of the header table size, so we rarely ran into this issue. nginx does actually try this in some cases, however, which is how we found this problem.

Modifications:

- Correctly invert the application of the value of SETTINGS_HEADER_TABLE_SIZE
- Correctly use `setDynamicTableSize` on HPACKEncoder instead of just setting the field manually.
- Deprecate the invalid method of setting the field on HPACKEncoder.
- Add some HTTP/2-level tests that ensure we correctly handle these changes.

Result:

Vastly better handling of peers reducing the value of SETTINGS_HEADER_TABLE_SIZE.