### PR TITLE
Soften errors when seeing inactive before active

### DIFF
--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests+XCTest.swift
@@ -36,6 +36,7 @@ extension SimpleClientServerTests {
                 ("testHandlingChannelInactiveDuringActive", testHandlingChannelInactiveDuringActive),
                 ("testWritingFromChannelActiveIsntReordered", testWritingFromChannelActiveIsntReordered),
                 ("testChannelActiveAfterAddingToActivePipelineDoesntError", testChannelActiveAfterAddingToActivePipelineDoesntError),
+                ("testChannelInactiveThenChannelActiveErrorsButDoesntTrap", testChannelInactiveThenChannelActiveErrorsButDoesntTrap),
                 ("testImpossibleStateTransitionsThrowErrors", testImpossibleStateTransitionsThrowErrors),
                 ("testDynamicHeaderFieldsArentEmittedWithZeroTableSize", testDynamicHeaderFieldsArentEmittedWithZeroTableSize),
                 ("testDynamicHeaderFieldsArentToleratedWithZeroTableSize", testDynamicHeaderFieldsArentToleratedWithZeroTableSize),


### PR DESCRIPTION
Motivation:

When we started checking active/inactive ordering, we added code that rejected some channel pipeline state transitions. That code was too strict: it is absolutely possible to see channelInactive before channelActive in well-functioning programs.

We'll still call this an error, but we don't need to crash in debug mode when we see it.

Modifications:

- Made channelInactive before channelActive tolerated.

Result:

More reliable code

Resolves #375 