### PR TITLE
Add no-op NIOHTTP2ConnectionDemultiplexer

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+ConnectionDemultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+ConnectionDemultiplexer.swift
@@ -23,16 +23,16 @@ internal protocol NIOHTTP2ConnectionDemultiplexer {
     func streamError(streamID: HTTP2StreamID, error: Error)
 
     /// A new HTTP/2 stream was created with the given ID.
-    func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?)
+    func streamCreated(event: NIOHTTP2StreamCreatedEvent)
 
     /// An HTTP/2 stream with the given ID was closed.
-    func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?)
+    func streamClosed(event: StreamClosedEvent)
 
     /// The flow control windows of the HTTP/2 stream changed.
-    func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?)
+    func streamWindowUpdated(event: NIOHTTP2WindowUpdatedEvent)
 
     /// The initial stream window for all streams changed by the given amount.
-    func initialStreamWindowChanged(by delta: Int)
+    func initialStreamWindowChanged(event: NIOHTTP2BulkStreamWindowChangeEvent)
 }
 
 extension NIOHTTP2Handler {
@@ -61,37 +61,37 @@ extension NIOHTTP2Handler {
             }
         }
 
-        func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?) {
+        func streamCreated(event: NIOHTTP2StreamCreatedEvent) {
             switch self {
             case .legacy(let demultiplexer):
-                demultiplexer.streamCreated(id, localInitialWindowSize: localInitialWindowSize, remoteInitialWindowSize: remoteInitialWindowSize)
+                demultiplexer.streamCreated(event: event)
             case .new:
                 fatalError("Not yet implemented.")
             }
         }
 
-        func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?) {
+        func streamClosed(event: StreamClosedEvent) {
             switch self {
             case .legacy(let demultiplexer):
-                demultiplexer.streamClosed(id, reason: reason)
+                demultiplexer.streamClosed(event: event)
             case .new:
                 fatalError("Not yet implemented.")
             }
         }
 
-        func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?) {
+        func streamWindowUpdated(event: NIOHTTP2WindowUpdatedEvent) {
             switch self {
             case .legacy(let demultiplexer):
-                demultiplexer.streamWindowUpdated(id, inboundWindowSize: inboundWindowSize, outboundWindowSize: outboundWindowSize)
+                demultiplexer.streamWindowUpdated(event: event)
             case .new:
                 fatalError("Not yet implemented.")
             }
         }
 
-        func initialStreamWindowChanged(by delta: Int) {
+        func initialStreamWindowChanged(event: NIOHTTP2BulkStreamWindowChangeEvent) {
             switch self {
             case .legacy(let demultiplexer):
-                demultiplexer.initialStreamWindowChanged(by: delta)
+                demultiplexer.initialStreamWindowChanged(event: event)
             case .new:
                 fatalError("Not yet implemented.")
             }
@@ -115,19 +115,19 @@ extension LegacyHTTP2ConnectionDemultiplexer: NIOHTTP2ConnectionDemultiplexer {
         self.context.fireErrorCaught(NIOHTTP2Errors.streamError(streamID: streamID, baseError: error))
     }
 
-    func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?) {
-        self.context.fireUserInboundEventTriggered(NIOHTTP2StreamCreatedEvent(streamID: id, localInitialWindowSize: localInitialWindowSize, remoteInitialWindowSize: remoteInitialWindowSize))
+    func streamCreated(event: NIOHTTP2StreamCreatedEvent) {
+        self.context.fireUserInboundEventTriggered(event)
     }
 
-    func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?) {
-        self.context.fireUserInboundEventTriggered(StreamClosedEvent(streamID: id, reason: reason))
+    func streamClosed(event: StreamClosedEvent) {
+        self.context.fireUserInboundEventTriggered(event)
     }
 
-    func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?) {
-        self.context.fireUserInboundEventTriggered(NIOHTTP2WindowUpdatedEvent(streamID: id, inboundWindowSize: inboundWindowSize, outboundWindowSize: outboundWindowSize))
+    func streamWindowUpdated(event: NIOHTTP2WindowUpdatedEvent) {
+        self.context.fireUserInboundEventTriggered(event)
     }
 
-    func initialStreamWindowChanged(by delta: Int) {
-        self.context.fireUserInboundEventTriggered(NIOHTTP2BulkStreamWindowChangeEvent(delta: delta))
+    func initialStreamWindowChanged(event: NIOHTTP2BulkStreamWindowChangeEvent) {
+        self.context.fireUserInboundEventTriggered(event)
     }
 }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+ConnectionDemultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+ConnectionDemultiplexer.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// Demultiplexes inbound HTTP/2 frames on a connection into HTTP/2 streams.
+internal protocol NIOHTTP2ConnectionDemultiplexer {
+    /// An HTTP/2 frame has been received from the remote peer.
+    func receivedFrame(_ frame: HTTP2Frame)
+
+    /// A stream error was thrown when trying to send an outbound frame.
+    func streamError(streamID: HTTP2StreamID, error: Error)
+
+    /// A new HTTP/2 stream was created with the given ID.
+    func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?)
+
+    /// An HTTP/2 stream with the given ID was closed.
+    func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?)
+
+    /// The flow control windows of the HTTP/2 stream changed.
+    func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?)
+
+    /// The initial stream window for all streams changed by the given amount.
+    func initialStreamWindowChanged(by delta: Int)
+}
+
+extension NIOHTTP2Handler {
+    /// Abstracts over the integrated stream multiplexing (new) and the chained channel handler (legacy) multiplexing approaches.
+    ///
+    /// We use an enum for this purpose since we can't use a generic (for API compatibility reasons) and it allows us to avoid the cost of using an existential.
+    internal enum ConnectionDemultiplexer: NIOHTTP2ConnectionDemultiplexer {
+        case legacy(LegacyHTTP2ConnectionDemultiplexer)
+        case new
+
+        func receivedFrame(_ frame: HTTP2Frame) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.receivedFrame(frame)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func streamError(streamID: HTTP2StreamID, error: Error) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.streamError(streamID: streamID, error: error)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.streamCreated(id, localInitialWindowSize: localInitialWindowSize, remoteInitialWindowSize: remoteInitialWindowSize)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.streamClosed(id, reason: reason)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.streamWindowUpdated(id, inboundWindowSize: inboundWindowSize, outboundWindowSize: outboundWindowSize)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func initialStreamWindowChanged(by delta: Int) {
+            switch self {
+            case .legacy(let demultiplexer):
+                demultiplexer.initialStreamWindowChanged(by: delta)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+    }
+}
+
+/// Provides a 'demultiplexer' interface for legacy compatibility.
+///
+/// This doesn't actually do any demultiplexing but communicates with the `HTTP2StreamChannel` which does - mostly via `UserInboundEvent`s.
+internal struct LegacyHTTP2ConnectionDemultiplexer {
+    let context: ChannelHandlerContext
+}
+
+extension LegacyHTTP2ConnectionDemultiplexer: NIOHTTP2ConnectionDemultiplexer {
+    func receivedFrame(_ frame: HTTP2Frame) {
+        self.context.fireChannelRead(NIOAny(frame))
+    }
+
+    func streamError(streamID: HTTP2StreamID, error: Error) {
+        self.context.fireErrorCaught(NIOHTTP2Errors.streamError(streamID: streamID, baseError: error))
+    }
+
+    func streamCreated(_ id: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?) {
+        self.context.fireUserInboundEventTriggered(NIOHTTP2StreamCreatedEvent(streamID: id, localInitialWindowSize: localInitialWindowSize, remoteInitialWindowSize: remoteInitialWindowSize))
+    }
+
+    func streamClosed(_ id: HTTP2StreamID, reason: HTTP2ErrorCode?) {
+        self.context.fireUserInboundEventTriggered(StreamClosedEvent(streamID: id, reason: reason))
+    }
+
+    func streamWindowUpdated(_ id: HTTP2StreamID, inboundWindowSize: Int?, outboundWindowSize: Int?) {
+        self.context.fireUserInboundEventTriggered(NIOHTTP2WindowUpdatedEvent(streamID: id, inboundWindowSize: inboundWindowSize, outboundWindowSize: outboundWindowSize))
+    }
+
+    func initialStreamWindowChanged(by delta: Int) {
+        self.context.fireUserInboundEventTriggered(NIOHTTP2BulkStreamWindowChangeEvent(delta: delta))
+    }
+}

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -514,13 +514,13 @@ extension NIOHTTP2Handler.ConnectionDemultiplexer {
     func process(event: InboundEventBuffer.BufferedHTTP2UserEvent) {
         switch event {
         case .streamCreated(let event):
-            self.streamCreated(event.streamID, localInitialWindowSize: event.localInitialWindowSize, remoteInitialWindowSize: event.remoteInitialWindowSize)
+            self.streamCreated(event: event)
         case .initialStreamWindowChanged(let event):
-            self.initialStreamWindowChanged(by: event.delta)
+            self.initialStreamWindowChanged(event: event)
         case .streamWindowUpdated(let event):
-            self.streamWindowUpdated(event.streamID, inboundWindowSize: event.inboundWindowSize, outboundWindowSize: event.outboundWindowSize)
+            self.streamWindowUpdated(event: event)
         case .streamClosed(let event):
-            self.streamClosed(event.streamID, reason: event.reason)
+            self.streamClosed(event: event)
         }
     }
 }
@@ -694,8 +694,8 @@ extension NIOHTTP2Handler {
             self.outboundBuffer.streamCreated(streamCreatedData.streamID, initialWindowSize: streamCreatedData.localStreamWindowSize.map(UInt32.init) ?? 0)
             self.inboundEventBuffer.pendingUserEvent(
                 NIOHTTP2StreamCreatedEvent(streamID: streamCreatedData.streamID,
-                                                          localInitialWindowSize: streamCreatedData.localStreamWindowSize.map(UInt32.init),
-                                                          remoteInitialWindowSize: streamCreatedData.remoteStreamWindowSize.map(UInt32.init)))
+                                           localInitialWindowSize: streamCreatedData.localStreamWindowSize.map(UInt32.init),
+                                           remoteInitialWindowSize: streamCreatedData.remoteStreamWindowSize.map(UInt32.init)))
         case .bulkStreamClosure(let streamClosureData):
             for droppedStream in streamClosureData.closedStreams {
                 self.inboundEventBuffer.pendingUserEvent(StreamClosedEvent(streamID: droppedStream, reason: .cancel))

--- a/Sources/NIOHTTP2/HTTP2UserEvents.swift
+++ b/Sources/NIOHTTP2/HTTP2UserEvents.swift
@@ -95,12 +95,18 @@ public struct NIOHTTP2StreamCreatedEvent {
     public let localInitialWindowSize: UInt32?
 
     /// The initial remote stream window size. May be nil if this stream may never have data received on it.
-    public let remoteInitialWidowSize: UInt32?
+    @available(*, deprecated, renamed: "remoteInitialWindowSize")
+    public var remoteInitialWidowSize: UInt32? {
+        self.remoteInitialWindowSize
+    }
+
+    /// The initial remote stream window size. May be nil if this stream has never had data received on it.
+    public let remoteInitialWindowSize: UInt32?
 
     public init(streamID: HTTP2StreamID, localInitialWindowSize: UInt32?, remoteInitialWindowSize: UInt32?) {
         self.streamID = streamID
         self.localInitialWindowSize = localInitialWindowSize
-        self.remoteInitialWidowSize = remoteInitialWindowSize
+        self.remoteInitialWindowSize = remoteInitialWindowSize
     }
 }
 

--- a/Sources/NIOHTTP2/InboundEventBuffer.swift
+++ b/Sources/NIOHTTP2/InboundEventBuffer.swift
@@ -26,13 +26,25 @@ import NIOCore
 class InboundEventBuffer {
     fileprivate var buffer: CircularBuffer<BufferedHTTP2UserEvent> = CircularBuffer(initialCapacity: 8)
 
-    func pendingUserEvent(_ event: BufferedHTTP2UserEvent) {
-        self.buffer.append(event)
+    func pendingUserEvent(_ event: NIOHTTP2StreamCreatedEvent) {
+        self.buffer.append(.streamCreated(event))
+    }
+
+    func pendingUserEvent(_ event: StreamClosedEvent) {
+        self.buffer.append(.streamClosed(event))
+    }
+
+    func pendingUserEvent(_ event: NIOHTTP2WindowUpdatedEvent) {
+        self.buffer.append(.streamWindowUpdated(event))
+    }
+
+    func pendingUserEvent(_ event: NIOHTTP2BulkStreamWindowChangeEvent) {
+        self.buffer.append(.initialStreamWindowChanged(event))
     }
 
     /// Wraps user event types.
     ///
-    /// This allows us to buffer and pass around the events without making use of a generic.
+    /// This allows us to buffer and pass around the events without making use of an existential.
     enum BufferedHTTP2UserEvent {
         case streamCreated(NIOHTTP2StreamCreatedEvent)
         case streamClosed(StreamClosedEvent)


### PR DESCRIPTION
Motivation:

This change prepares for future work to embed the connection demultiplexer within the `HTTP2ChannelHandler` which will improve performance by removing the need for passing expensive `InboundUserEvent`s.

Modifications:

This first step defines a new protocol (`NIOHTTP2ConnectionDemultiplexer`) which will later be used to abstract over the embedded and legacy separate demultiplexer code but at the moment should not change the logic.

Result:

Behaviour should be unchanged.