### PR TITLE
make soundness check aware of 2023

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][78901]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
Motivation:

Soundness check currently fails for copyright statements including 2023 as the year

Modifications:

add '3' to the checking regex

Result:

Soundness checks should not fail for documents created this year