### PR TITLE
Add multiplexer protocol abstraction in http2 stream channel

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel+OutboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel+OutboundStreamMultiplexer.swift
@@ -18,7 +18,7 @@ import NIOCore
 internal protocol HTTP2OutboundStreamMultiplexer {
   /// Write the frame into the HTTP/2 connection. Stream ID is included in the
   /// frame.
-  func writeStream(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?)
+  func writeFrame(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?)
 
   /// Flush the stream with the given ID.
   func flushStream(_ id: HTTP2StreamID)
@@ -45,10 +45,10 @@ extension HTTP2StreamChannel {
         case legacy(LegacyOutboundStreamMultiplexer)
         case new
 
-        func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
+        func writeFrame(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
             switch self {
             case .legacy(let multiplexer):
-                multiplexer.writeStream(frame, promise: promise)
+                multiplexer.writeFrame(frame, promise: promise)
             case .new:
                 fatalError("Not yet implemented.")
             }
@@ -100,7 +100,7 @@ internal struct LegacyOutboundStreamMultiplexer {
 }
 
 extension LegacyOutboundStreamMultiplexer: HTTP2OutboundStreamMultiplexer {
-    func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
+    func writeFrame(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
         self.multiplexer.childChannelWrite(frame, promise: promise)
     }
 

--- a/Sources/NIOHTTP2/HTTP2StreamChannel+OutboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel+OutboundStreamMultiplexer.swift
@@ -15,7 +15,7 @@ import NIOCore
 
 /// Multiplexes outbound HTTP/2 frames from an HTTP/2 stream into an HTTP/2
 /// connection.
-internal protocol HTTP2StreamChannelMultiplexer {
+internal protocol HTTP2OutboundStreamMultiplexer {
   /// Write the frame into the HTTP/2 connection. Stream ID is included in the
   /// frame.
   func writeStream(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?)
@@ -41,8 +41,8 @@ extension HTTP2StreamChannel {
     /// Abstracts over the integrated stream multiplexing (new) and the chained channel handler (legacy) multiplexing approaches.
     ///
     /// We use an enum for this purpose since we can't use a generic (for API compatibility reasons) and it allows us to avoid the cost of using an existential.
-    internal enum StreamMultiplexer: HTTP2StreamChannelMultiplexer {
-        case legacy(LegacyMultiplexer)
+    internal enum OutboundStreamMultiplexer: HTTP2OutboundStreamMultiplexer {
+        case legacy(LegacyOutboundStreamMultiplexer)
         case new
 
         func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
@@ -95,11 +95,11 @@ extension HTTP2StreamChannel {
 /// Provides a 'multiplexer' interface for legacy compatibility.
 ///
 /// This doesn't actually do any multiplexing but delegates it to the `HTTP2StreamMultiplexer` which does.
-internal struct LegacyMultiplexer {
+internal struct LegacyOutboundStreamMultiplexer {
     let multiplexer: HTTP2StreamMultiplexer
 }
 
-extension LegacyMultiplexer: HTTP2StreamChannelMultiplexer {
+extension LegacyOutboundStreamMultiplexer: HTTP2OutboundStreamMultiplexer {
     func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
         self.multiplexer.childChannelWrite(frame, promise: promise)
     }

--- a/Sources/NIOHTTP2/HTTP2StreamChannel+StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel+StreamMultiplexer.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+/// Multiplexes outbound HTTP/2 frames from an HTTP/2 stream into an HTTP/2
+/// connection.
+internal protocol HTTP2StreamChannelMultiplexer {
+  /// Write the frame into the HTTP/2 connection. Stream ID is included in the
+  /// frame.
+  func writeStream(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?)
+
+  /// Flush the stream with the given ID.
+  func flushStream(_ id: HTTP2StreamID)
+
+  /// Request a stream ID for the given channel.
+  ///
+  /// Required to lazily assign a stream ID to a channel on first write.
+  func requestStreamID(forChannel: Channel) -> HTTP2StreamID
+
+  /// Notify the multiplexer that the channel with the given ID closed.
+  ///
+  /// Required as a channel may not have a stream ID when it closes.
+  func streamClosed(channelID: ObjectIdentifier)
+
+  /// Notify the multiplexer that the stream with the given ID closed.
+  func streamClosed(id: HTTP2StreamID)
+}
+
+extension HTTP2StreamChannel {
+    /// Abstracts over the integrated stream multiplexing (new) and the chained channel handler (legacy) multiplexing approaches.
+    ///
+    /// We use an enum for this purpose since we can't use a generic (for API compatibility reasons) and it allows us to avoid the cost of using an existential.
+    internal enum StreamMultiplexer: HTTP2StreamChannelMultiplexer {
+        case legacy(LegacyMultiplexer)
+        case new
+
+        func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
+            switch self {
+            case .legacy(let multiplexer):
+                multiplexer.writeStream(frame, promise: promise)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func flushStream(_ id: HTTP2StreamID) {
+            switch self {
+            case .legacy(let multiplexer):
+                multiplexer.flushStream(id)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func requestStreamID(forChannel: NIOCore.Channel) -> HTTP2StreamID {
+            switch self {
+            case .legacy(let multiplexer):
+                return multiplexer.requestStreamID(forChannel: forChannel)
+            case .new:
+                fatalError("Not yet implemented")
+            }
+        }
+
+        func streamClosed(channelID: ObjectIdentifier) {
+            switch self {
+            case .legacy(let multiplexer):
+                multiplexer.streamClosed(channelID: channelID)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+
+        func streamClosed(id: HTTP2StreamID) {
+            switch self {
+            case .legacy(let multiplexer):
+                multiplexer.streamClosed(id: id)
+            case .new:
+                fatalError("Not yet implemented.")
+            }
+        }
+    }
+}
+
+/// Provides a 'multiplexer' interface for legacy compatibility.
+///
+/// This doesn't actually do any multiplexing but delegates it to the `HTTP2StreamMultiplexer` which does.
+internal struct LegacyMultiplexer {
+    let multiplexer: HTTP2StreamMultiplexer
+}
+
+extension LegacyMultiplexer: HTTP2StreamChannelMultiplexer {
+    func writeStream(_ frame: HTTP2Frame, promise: NIOCore.EventLoopPromise<Void>?) {
+        self.multiplexer.childChannelWrite(frame, promise: promise)
+    }
+
+    func flushStream(_ id: HTTP2StreamID) {
+        self.multiplexer.childChannelFlush()
+    }
+
+    func requestStreamID(forChannel: NIOCore.Channel) -> HTTP2StreamID {
+        self.multiplexer.requestStreamID(forChannel: forChannel)
+    }
+
+    func streamClosed(channelID: ObjectIdentifier) {
+        self.multiplexer.childChannelClosed(channelID: channelID)
+    }
+
+    func streamClosed(id: HTTP2StreamID) {
+        self.multiplexer.childChannelClosed(streamID: id)
+    }
+}
+

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -164,7 +164,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         self.parent = parent
         self.eventLoop = parent.eventLoop
         self.streamID = streamID
-        self.multiplexer = .legacy(LegacyMultiplexer(multiplexer: multiplexer))
+        self.multiplexer = .legacy(LegacyOutboundStreamMultiplexer(multiplexer: multiplexer))
         self.windowManager = InboundWindowManager(targetSize: Int32(targetWindowSize))
         self._isActiveAtomic = .init(false)
         self._isWritable = .init(true)
@@ -329,7 +329,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
 
     private let closePromise: EventLoopPromise<()>
 
-    private let multiplexer: StreamMultiplexer
+    private let multiplexer: OutboundStreamMultiplexer
 
     public var closeFuture: EventLoopFuture<Void> {
         return self.closePromise.futureResult

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -803,7 +803,7 @@ internal extension HTTP2StreamChannel {
             self.errorEncountered(error: error)
             return
         }
-        self.multiplexer.writeStream(frame, promise: promise)
+        self.multiplexer.writeFrame(frame, promise: promise)
     }
 
     /// Called when a stream closure is received from the network.


### PR DESCRIPTION
### Motivation:

This change prepares for future work to embed the connection multiplexer within the `HTTP2ChannelHandler` which will improve performance by removing the need for passing expensive `InboundUserEvent`s.

### Modifications:

* Define a new protocol (`OutboundStreamMultiplexer `; named such to avoid confusion with the legacy handler, `HTTP2StreamMultiplexer`) which will later be used to abstract over the inline and legacy multiplexer code but at the moment should not change the logic.
* Rename `NIOHTTP2ConnectionDemultiplexer` -> `InboundStreamMultiplexer`


### Result:

Behaviour should be unchanged.