### PR TITLE
Expose a functional `NIOHTTP2StreamDelegate`

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -34,6 +34,7 @@ internal struct InlineStreamMultiplexer {
             streamChannelOutboundBytesLowWatermark: streamChannelOutboundBytesLowWatermark
         )
         self.outboundView = outboundView
+        self.streamDelegate = streamDelegate
     }
 }
 
@@ -48,11 +49,15 @@ extension InlineStreamMultiplexer: HTTP2InboundStreamMultiplexer {
     }
 
     func streamCreated(event: NIOHTTP2StreamCreatedEvent) {
-        self.commonStreamMultiplexer.streamCreated(event: event)
+        if let childChannel = self.commonStreamMultiplexer.streamCreated(event: event) {
+            self.streamDelegate?.streamCreated(event.streamID, channel: childChannel)
+        }
     }
 
     func streamClosed(event: StreamClosedEvent) {
-        self.commonStreamMultiplexer.streamClosed(event: event)
+        if let childChannel = self.commonStreamMultiplexer.streamClosed(event: event) {
+            self.streamDelegate?.streamClosed(event.streamID, channel: childChannel)
+        }
     }
 
     func streamWindowUpdated(event: NIOHTTP2WindowUpdatedEvent) {

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -113,14 +113,22 @@ extension HTTP2CommonInboundStreamMultiplexer {
         context.fireErrorCaught(streamError.baseError)
     }
 
-    func streamCreated(event: NIOHTTP2StreamCreatedEvent) {
+    func streamCreated(event: NIOHTTP2StreamCreatedEvent) -> Channel? {
         self.channel.eventLoop.preconditionInEventLoop()
-        self.streams[event.streamID]?.networkActivationReceived()
+        if let channel = self.streams[event.streamID] {
+            channel.networkActivationReceived()
+            return channel.baseChannel
+        }
+        return nil
     }
 
-    func streamClosed(event: StreamClosedEvent) {
+    func streamClosed(event: StreamClosedEvent) -> Channel? {
         self.channel.eventLoop.preconditionInEventLoop()
-        self.streams[event.streamID]?.receiveStreamClosed(event.reason)
+        if let channel = self.streams[event.streamID] {
+            channel.receiveStreamClosed(event.reason)
+            return channel.baseChannel
+        }
+        return nil
     }
 
     func newConnectionWindowSize(_ newSize: Int) -> Int? {

--- a/Sources/NIOHTTP2/HTTP2StreamDelegate.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamDelegate.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// A delegate which can be used with the ``NIOHTTP2Handler`` and its multiplexer.
 ///
 /// Delegates are called when the multiplexer creates or closes HTTP/2 streams.
-public protocol NIOHTTP2StreamDelegate {
+public protocol NIOHTTP2StreamDelegate: Sendable {
     /// A new HTTP/2 stream was created with the given ID.
     func streamCreated(_ id: HTTP2StreamID, channel: Channel)
 

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -91,7 +91,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         switch event {
         case let evt as StreamClosedEvent:
-            self.commonStreamMultiplexer.streamClosed(event: evt)
+            _ = self.commonStreamMultiplexer.streamClosed(event: evt)
         case let evt as NIOHTTP2WindowUpdatedEvent where evt.streamID == .rootStream:
             // This force-unwrap is safe: we always have a connection window.
             self.newConnectionWindowSize(newSize: evt.inboundWindowSize!, context: context)
@@ -100,7 +100,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
         case let evt as NIOHTTP2BulkStreamWindowChangeEvent:
             self.commonStreamMultiplexer.initialStreamWindowChanged(event: evt)
         case let evt as NIOHTTP2StreamCreatedEvent:
-            self.commonStreamMultiplexer.streamCreated(event: evt)
+            _ = self.commonStreamMultiplexer.streamCreated(event: evt)
         default:
             break
         }

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -24,7 +24,7 @@ import NIOCore
 /// Note that while this is a `struct`, this `struct` has _reference semantics_.
 /// The implementation of `Equatable` & `Hashable` on this type reinforces that requirement.
 struct MultiplexerAbstractChannel {
-    private var baseChannel: HTTP2StreamChannel
+    private(set) var baseChannel: HTTP2StreamChannel
 
     init(allocator: ByteBufferAllocator,
          parent: Channel,

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests+XCTest.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests+XCTest.swift
@@ -72,6 +72,8 @@ extension HTTP2InlineStreamMultiplexerTests {
                 ("testStreamChannelSupportsSyncOptions", testStreamChannelSupportsSyncOptions),
                 ("testStreamErrorIsDeliveredToChannel", testStreamErrorIsDeliveredToChannel),
                 ("testPendingReadsAreFlushedEvenWithoutUnsatisfiedReadOnChannelInactive", testPendingReadsAreFlushedEvenWithoutUnsatisfiedReadOnChannelInactive),
+                ("testDelegateReceivesCreationAndCloseNotifications", testDelegateReceivesCreationAndCloseNotifications),
+                ("testDelegateReceivesOutboundCreationAndCloseNotifications", testDelegateReceivesOutboundCreationAndCloseNotifications),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

Allow handlers in the pipeline to be notified when an HTTP2 stream is created or closed.

Modifications:

Store an instance of a `NIOHTTP2StreamDelegate` on the `NIOHTTP2Handler` and `InlineStreamMultiplexer` so that it may be called when streams are created or closed.

Added tests.

Result:

`NIOHTTP2Handler`s init'd with a `streamDelegate` will now call into that delegate's `streamCreated` and `streamClosed` functions.