### PR TITLE
Allocation tests for direct stream multiplexing

### DIFF
--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/run-nio-http2-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/run-nio-http2-alloc-counter-tests.sh
@@ -50,6 +50,7 @@ fi
     -m NIOPosix \
     -m NIOHTTP1 \
     -m NIOHTTP2 \
+    -s "$here/shared.swift" \
     -t "$tmp_dir" \
     -d <( echo '.package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),' ) \
     "${tests_to_run[@]}"

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/shared.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020-2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+import NIOHTTP2
+
+/// Test use only. Allows abstracting over the two multiplexer implementations to write common testing code
+internal protocol MultiplexerChannelCreator {
+    func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping NIOHTTP2Handler.StreamInitializer)
+}
+
+extension HTTP2StreamMultiplexer: MultiplexerChannelCreator { }
+extension NIOHTTP2Handler.StreamMultiplexer: MultiplexerChannelCreator { }
+
+/// Have two `EmbeddedChannel` objects send and receive data from each other until
+/// they make no forward progress.
+func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel) throws {
+    var operated: Bool
+
+    func readBytesFromChannel(_ channel: EmbeddedChannel) throws -> ByteBuffer? {
+        return try channel.readOutbound(as: ByteBuffer.self)
+    }
+
+    repeat {
+        operated = false
+        first.embeddedEventLoop.run()
+
+        if let data = try readBytesFromChannel(first) {
+            operated = true
+            try second.writeInbound(data)
+        }
+        if let data = try readBytesFromChannel(second) {
+            operated = true
+            try first.writeInbound(data)
+        }
+    } while operated
+}

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/shared.swift
@@ -27,6 +27,7 @@ extension NIOHTTP2Handler.StreamMultiplexer: MultiplexerChannelCreator { }
 /// Have two `EmbeddedChannel` objects send and receive data from each other until
 /// they make no forward progress.
 func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel) throws {
+    precondition(first.eventLoop === second.eventLoop, "interactInMemory assumes both channels are on the same event loop.")
     var operated: Bool
 
     func readBytesFromChannel(_ channel: EmbeddedChannel) throws -> ByteBuffer? {

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
@@ -221,7 +221,7 @@ func run(identifier: String) {
     noninterleaved.tearDown()
 
     //
-    //MARK: - Inline HTTP2 multiplexer tests
+    // MARK: - Inline HTTP2 multiplexer tests
     var inlineInterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100) { channel in
         _ = try channel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { streamChannel -> EventLoopFuture<Void> in
             return streamChannel.pipeline.addHandler(TestServer())

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_1k_requests.swift
@@ -108,13 +108,11 @@ struct ServerOnly1KRequestsBenchmark {
         return settingsCopy
     }
 
-    init(concurrentStreams: Int) throws {
+    init(concurrentStreams: Int, pipelineConfigurator: (Channel) throws -> ()) throws {
         self.concurrentStreams = concurrentStreams
 
         self.channel = EmbeddedChannel()
-        _ = try self.channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
-            return streamChannel.pipeline.addHandler(TestServer())
-        }.wait()
+        try pipelineConfigurator(self.channel)
 
         try self.channel.connect(to: .init(unixDomainSocketPath: "/fake"), promise: nil)
 
@@ -198,7 +196,11 @@ fileprivate class TestServer: ChannelInboundHandler {
 }
 
 func run(identifier: String) {
-    var interleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100)
+    var interleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100) { channel in
+        _ = try channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+    }
 
     measure(identifier: identifier + "_interleaved") {
         return try! interleaved.run()
@@ -206,11 +208,41 @@ func run(identifier: String) {
 
     interleaved.tearDown()
 
-    var noninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1)
+    var noninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1) { channel in
+        _ = try channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+    }
 
     measure(identifier: identifier + "_noninterleaved") {
         return try! noninterleaved.run()
     }
 
     noninterleaved.tearDown()
+
+    //
+    //MARK: - Inline HTTP2 multiplexer tests
+    var inlineInterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 100) { channel in
+        _ = try channel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+    }
+
+    measure(identifier: identifier + "_inline_interleaved") {
+        return try! inlineInterleaved.run()
+    }
+
+    inlineInterleaved.tearDown()
+
+    var inlineNoninterleaved = try! ServerOnly1KRequestsBenchmark(concurrentStreams: 1) { channel in
+        _ = try channel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { streamChannel -> EventLoopFuture<Void> in
+            return streamChannel.pipeline.addHandler(TestServer())
+        }.wait()
+    }
+
+    measure(identifier: identifier + "_inline_noninterleaved") {
+        return try! inlineNoninterleaved.run()
+    }
+
+    inlineNoninterleaved.tearDown()
 }

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
@@ -62,7 +62,7 @@ func run(identifier: String) {
     }
 
     //
-    //MARK: - Inline HTTP2 multiplexer tests
+    // MARK: - Inline HTTP2 multiplexer tests
     testRun(identifier: identifier + "_inline") { clientChannel in
         return try! clientChannel.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
             return channel.eventLoop.makeSucceededVoidFuture()

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_h1_request_response.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,30 +17,6 @@ import NIOEmbedded
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
-
-/// Have two `EmbeddedChannel` objects send and receive data from each other until
-/// they make no forward progress.
-func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel) throws {
-    var operated: Bool
-
-    func readBytesFromChannel(_ channel: EmbeddedChannel) throws -> ByteBuffer? {
-        return try channel.readOutbound(as: ByteBuffer.self)
-    }
-
-    repeat {
-        operated = false
-        first.embeddedEventLoop.run()
-
-        if let data = try readBytesFromChannel(first) {
-            operated = true
-            try second.writeInbound(data)
-        }
-        if let data = try readBytesFromChannel(second) {
-            operated = true
-            try first.writeInbound(data)
-        }
-    } while operated
-}
 
 final class ServerHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
@@ -77,6 +53,28 @@ final class ClientHandler: ChannelInboundHandler {
 }
 
 func run(identifier: String) {
+    testRun(identifier: identifier) { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client, inboundStreamInitializer: nil).wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
+            return channel.pipeline.addHandlers([HTTP2FramePayloadToHTTP1ServerCodec(), ServerHandler()])
+        }.wait()
+    }
+
+    //
+    //MARK: - Inline HTTP2 multiplexer tests
+    testRun(identifier: identifier + "_inline") { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }.wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.pipeline.addHandlers([HTTP2FramePayloadToHTTP1ServerCodec(), ServerHandler()])
+        }.wait()
+    }
+}
+
+private func testRun(identifier: String, clientPipelineConfigurator: (Channel) throws -> MultiplexerChannelCreator, serverPipelineConfigurator: (Channel) throws -> ()) {
     let loop = EmbeddedEventLoop()
 
     measure(identifier: identifier) {
@@ -86,10 +84,8 @@ func run(identifier: String) {
             let clientChannel = EmbeddedChannel(loop: loop)
             let serverChannel = EmbeddedChannel(loop: loop)
 
-            let clientMultiplexer = try! clientChannel.configureHTTP2Pipeline(mode: .client, inboundStreamInitializer: nil).wait()
-            _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
-                return channel.pipeline.addHandlers([HTTP2FramePayloadToHTTP1ServerCodec(), ServerHandler()])
-            }.wait()
+            let clientMultiplexer = try! clientPipelineConfigurator(clientChannel)
+            try! serverPipelineConfigurator(serverChannel)
             try! clientChannel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait()
             try! serverChannel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait()
 

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_request_response.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_request_response.swift
@@ -100,7 +100,7 @@ func run(identifier: String) {
     }
 
     //
-    //MARK: - Inline HTTP2 multiplexer tests
+    // MARK: - Inline HTTP2 multiplexer tests
     testRun(identifier: identifier + "_inline") { clientChannel in
         return try! clientChannel.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
             return channel.eventLoop.makeSucceededVoidFuture()

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_request_response.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_client_server_request_response.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,30 +17,6 @@ import NIOEmbedded
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
-
-/// Have two `EmbeddedChannel` objects send and receive data from each other until
-/// they make no forward progress.
-func interactInMemory(_ first: EmbeddedChannel, _ second: EmbeddedChannel) throws {
-    var operated: Bool
-
-    func readBytesFromChannel(_ channel: EmbeddedChannel) throws -> ByteBuffer? {
-        return try channel.readOutbound(as: ByteBuffer.self)
-    }
-
-    repeat {
-        operated = false
-        first.embeddedEventLoop.run()
-
-        if let data = try readBytesFromChannel(first) {
-            operated = true
-            try second.writeInbound(data)
-        }
-        if let data = try readBytesFromChannel(second) {
-            operated = true
-            try first.writeInbound(data)
-        }
-    } while operated
-}
 
 final class ServerHandler: ChannelInboundHandler {
     typealias InboundIn = HTTP2Frame.FramePayload
@@ -70,18 +46,83 @@ final class ClientHandler: ChannelInboundHandler {
     typealias InboundIn = HTTP2Frame.FramePayload
     typealias OutboundOut = HTTP2Frame.FramePayload
 
+    let dataBlockCount: Int
+    let dataBlockLengthBytes: Int
+
+    init(dataBlockCount: Int, dataBlockLengthBytes: Int) {
+        self.dataBlockCount = dataBlockCount
+        self.dataBlockLengthBytes = dataBlockLengthBytes
+    }
+
     func channelActive(context: ChannelHandlerContext) {
         // Send a request.
         let headers = HPACKHeaders([(":path", "/"),
                                     (":authority", "localhost"),
                                     (":method", "GET"),
                                     (":scheme", "https")])
-        let requestFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: true))
-        context.writeAndFlush(self.wrapOutboundOut(requestFramePayload), promise: nil)
+
+        if self.dataBlockCount > 0 {
+            let requestFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: false))
+            context.write(self.wrapOutboundOut(requestFramePayload), promise: nil)
+
+            let buffer = ByteBuffer(repeating: 0, count: self.dataBlockLengthBytes)
+
+            for _ in 0 ..< self.dataBlockCount-1 {
+                context.write(self.wrapOutboundOut(HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer), endStream: false))), promise: nil)
+            }
+            context.writeAndFlush(self.wrapOutboundOut(HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer), endStream: true))), promise: nil)
+        } else {
+            let requestFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: true))
+            context.writeAndFlush(self.wrapOutboundOut(requestFramePayload), promise: nil)
+        }
     }
 }
 
 func run(identifier: String) {
+    testRun(identifier: identifier) { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }.wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
+            return channel.pipeline.addHandler(ServerHandler())
+        }.wait()
+    }
+
+    testRun(identifier: identifier + "_many", dataBlockCount: 100, dataBlockLengthBytes: 1000) { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }.wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
+            return channel.pipeline.addHandler(ServerHandler())
+        }.wait()
+    }
+
+    //
+    //MARK: - Inline HTTP2 multiplexer tests
+    testRun(identifier: identifier + "_inline") { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }.wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.pipeline.addHandler(ServerHandler())
+        }.wait()
+    }
+
+    testRun(identifier: identifier + "_many_inline", dataBlockCount: 100, dataBlockLengthBytes: 1000) { clientChannel in
+        return try! clientChannel.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }.wait()
+    } serverPipelineConfigurator: { serverChannel in
+        _ = try! serverChannel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+            return channel.pipeline.addHandler(ServerHandler())
+        }.wait()
+    }
+}
+
+private func testRun(identifier: String, dataBlockCount: Int = 0, dataBlockLengthBytes: Int = 0, clientPipelineConfigurator: (Channel) throws -> MultiplexerChannelCreator, serverPipelineConfigurator: (Channel) throws -> ()) {
     let loop = EmbeddedEventLoop()
 
     measure(identifier: identifier) {
@@ -91,16 +132,14 @@ func run(identifier: String) {
             let clientChannel = EmbeddedChannel(loop: loop)
             let serverChannel = EmbeddedChannel(loop: loop)
 
-            let clientMultiplexer = try! clientChannel.configureHTTP2Pipeline(mode: .client, inboundStreamInitializer: nil).wait()
-            _ = try! serverChannel.configureHTTP2Pipeline(mode: .server) { channel in
-                return channel.pipeline.addHandler(ServerHandler())
-            }.wait()
+            let clientMultiplexer = try! clientPipelineConfigurator(clientChannel)
+            try! serverPipelineConfigurator(serverChannel)
             try! clientChannel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait()
             try! serverChannel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait()
 
             let promise = clientChannel.eventLoop.makePromise(of: Channel.self)
             clientMultiplexer.createStreamChannel(promise: promise) { channel in
-                return channel.pipeline.addHandler(ClientHandler())
+                return channel.pipeline.addHandler(ClientHandler(dataBlockCount: dataBlockCount, dataBlockLengthBytes: dataBlockLengthBytes))
             }
             clientChannel.embeddedEventLoop.run()
             let child = try! promise.futureResult.wait()

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_create_client_stream_channel.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_create_client_stream_channel.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -18,10 +18,32 @@ import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
 
+
 func run(identifier: String) {
-    let channel = EmbeddedChannel(handler: NIOHTTP2Handler(mode: .client))
-    let multiplexer = HTTP2StreamMultiplexer(mode: .client, channel: channel, inboundStreamInitializer: nil)
-    try! channel.pipeline.addHandler(multiplexer).wait()
+    testRun(identifier: identifier) { channel in
+        let http2Handler = NIOHTTP2Handler(mode: .client)
+        let multiplexer = HTTP2StreamMultiplexer(mode: .client, channel: channel, inboundStreamInitializer: nil)
+        try! channel.pipeline.addHandlers([
+            http2Handler,
+            multiplexer
+        ]).wait()
+        return multiplexer
+    }
+
+    //
+    //MARK: - Inline HTTP2 multiplexer tests
+    testRun(identifier: identifier + "_inline") { channel in
+        let http2Handler = NIOHTTP2Handler(mode: .client, eventLoop: channel.eventLoop) { channel in
+            return channel.eventLoop.makeSucceededVoidFuture()
+        }
+        try! channel.pipeline.addHandler(http2Handler).wait()
+        return try! http2Handler.multiplexer.wait()
+    }
+}
+
+private func testRun(identifier: String, pipelineConfigurator: (Channel) throws -> MultiplexerChannelCreator) {
+    let channel = EmbeddedChannel(handler: nil)
+    let multiplexer = try! pipelineConfigurator(channel)
     try! channel.connect(to: SocketAddress(ipAddress: "1.2.3.4", port: 5678)).wait()
 
     measure(identifier: identifier) {
@@ -30,11 +52,11 @@ func run(identifier: String) {
         for _ in 0..<1000 {
             let promise = channel.eventLoop.makePromise(of: Channel.self)
             multiplexer.createStreamChannel(promise: promise) { channel in
-                streams += 1
                 return channel.eventLoop.makeSucceededFuture(())
             }
             channel.embeddedEventLoop.run()
             let child = try! promise.futureResult.wait()
+            streams += 1
 
             let closeFuture = child.close()
             channel.embeddedEventLoop.run()

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_create_client_stream_channel.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_create_client_stream_channel.swift
@@ -31,7 +31,7 @@ func run(identifier: String) {
     }
 
     //
-    //MARK: - Inline HTTP2 multiplexer tests
+    // MARK: - Inline HTTP2 multiplexer tests
     testRun(identifier: identifier + "_inline") { channel in
         let http2Handler = NIOHTTP2Handler(mode: .client, eventLoop: channel.eventLoop) { channel in
             return channel.eventLoop.makeSucceededVoidFuture()

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_stream_teardown_100_concurrent.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_stream_teardown_100_concurrent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -16,6 +16,7 @@ import NIOCore
 import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
+import Atomics
 
 struct StreamTeardownBenchmark {
     private let concurrentStreams: Int
@@ -87,12 +88,9 @@ struct StreamTeardownBenchmark {
         self.concurrentStreams = concurrentStreams
     }
 
-    func createChannel() throws -> EmbeddedChannel {
+    private func createChannel(pipelineConfigurator: (Channel, Int) throws -> ()) throws -> EmbeddedChannel {
         let channel = EmbeddedChannel()
-        _ = try channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
-            return streamChannel.pipeline.addHandler(DoNothingServer())
-        }.wait()
-        try channel.pipeline.addHandler(SendGoawayHandler(expectedStreams: self.concurrentStreams)).wait()
+        try! pipelineConfigurator(channel, self.concurrentStreams)
 
         try channel.connect(to: .init(unixDomainSocketPath: "/fake"), promise: nil)
 
@@ -111,11 +109,11 @@ struct StreamTeardownBenchmark {
         _ = try channel.finish()
     }
 
-    mutating func run() throws -> Int {
+    fileprivate mutating func run(pipelineConfigurator: (Channel, Int) throws -> ()) throws -> Int {
         var bodyByteCount = 0
         var completedIterations = 0
         while completedIterations < 10_000 {
-            let channel = try self.createChannel()
+            let channel = try self.createChannel(pipelineConfigurator: pipelineConfigurator)
             bodyByteCount &+= try self.sendInterleavedRequestsAndTerminate(self.concurrentStreams, channel)
             completedIterations += self.concurrentStreams
             try self.destroyChannel(channel)
@@ -158,17 +156,16 @@ fileprivate class SendGoawayHandler: ChannelInboundHandler {
     )
 
     private let expectedStreams: Int
-    private var seenStreams: Int
+    private let seenStreams = ManagedAtomic<Int>(0)
 
     init(expectedStreams: Int) {
         self.expectedStreams = expectedStreams
-        self.seenStreams = 0
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         if event is NIOHTTP2StreamCreatedEvent {
-            self.seenStreams += 1
-            if self.seenStreams == self.expectedStreams {
+            self.seenStreams.wrappingIncrement(ordering: .sequentiallyConsistent)
+            if seenStreams.load(ordering: .sequentiallyConsistent) == self.expectedStreams {
                 // Send a GOAWAY to tear all streams down.
                 context.writeAndFlush(self.wrapOutboundOut(SendGoawayHandler.goawayFrame), promise: nil)
             }
@@ -176,11 +173,51 @@ fileprivate class SendGoawayHandler: ChannelInboundHandler {
     }
 }
 
+fileprivate struct SendGoawayDelegate: @unchecked Sendable {
+    private static let goawayFrame: HTTP2Frame = HTTP2Frame(
+        streamID: .rootStream, payload: .goAway(lastStreamID: .rootStream, errorCode: .enhanceYourCalm, opaqueData: nil)
+    )
+
+    private let expectedStreams: Int
+    private let seenStreams = ManagedAtomic<Int>(0)
+
+    init(expectedStreams: Int) {
+        self.expectedStreams = expectedStreams
+    }
+}
+
+extension SendGoawayDelegate: NIOHTTP2StreamDelegate {
+    func streamCreated(_ id: HTTP2StreamID, channel: Channel) {
+        self.seenStreams.wrappingIncrement(ordering: .sequentiallyConsistent)
+        if seenStreams.load(ordering: .sequentiallyConsistent) == self.expectedStreams {
+            // Send a GOAWAY to tear all streams down.
+            channel.parent!.writeAndFlush(NIOAny(SendGoawayDelegate.goawayFrame), promise: nil)
+        }
+    }
+
+    func streamClosed(_ id: HTTP2StreamID, channel: Channel) {
+        // do nothing
+    }
+}
+
 func run(identifier: String) {
     var benchmark = StreamTeardownBenchmark(concurrentStreams: 100)
 
     measure(identifier: identifier) {
-        return try! benchmark.run()
+        return try! benchmark.run() { channel, concurrentStreams in
+            _ = try channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+                return streamChannel.pipeline.addHandler(DoNothingServer())
+            }.wait()
+            try channel.pipeline.addHandler(SendGoawayHandler(expectedStreams: concurrentStreams)).wait()
+        }
+    }
+
+    measure(identifier: identifier + "_inline") {
+        return try! benchmark.run() { channel, concurrentStreams in
+            _ = try channel.configureHTTP2Pipeline(mode: .server, connectionConfiguration: .init(), streamConfiguration: .init(), streamDelegate: SendGoawayDelegate(expectedStreams: concurrentStreams)) { streamChannel -> EventLoopFuture<Void> in
+                return streamChannel.pipeline.addHandler(DoNothingServer())
+            }.wait()
+        }
     }
 }
 

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -29,15 +29,23 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=46200
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=45100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=304050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=268050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=305050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=270050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1420050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1421050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=40050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=40050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=302350
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -27,15 +27,23 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=264050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -27,15 +27,23 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=264050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
 
   shell:
     image: swift-nio-http2:22.04-5.7

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -26,15 +26,23 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=264050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -26,15 +26,23 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=264050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Allocation tests for direct stream multiplexing

### Motivation:

Increase allocation test coverage to encompass new HTTP2Handler direct stream multiplexing.

### Modifications:

- Duplicate existing relevant allocation tests
- Introduce a new test for inline and legacy modes which creates multiple streams and then performs many requests on each. This is to give an indication of the performance change through many requests and window update frames.

### Result:

More allocation test coverage.