### PR TITLE
Remove NIOHTTP2StreamDelegate Sendable requirement

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamDelegate.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamDelegate.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// A delegate which can be used with the ``NIOHTTP2Handler`` and its multiplexer.
 ///
 /// Delegates are called when the multiplexer creates or closes HTTP/2 streams.
-public protocol NIOHTTP2StreamDelegate: Sendable {
+public protocol NIOHTTP2StreamDelegate {
     /// A new HTTP/2 stream was created with the given ID.
     func streamCreated(_ id: HTTP2StreamID, channel: Channel)
 

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
@@ -1890,39 +1890,29 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertEqual(consumer.readPending, true)
     }
 
-    fileprivate struct CountingStreamDelegate: NIOHTTP2StreamDelegate, @unchecked Sendable {
-        private let store = NIOLockedValueBox<Store>(Store())
+    fileprivate struct CountingStreamDelegate: NIOHTTP2StreamDelegate {
+        private var store = Store()
 
         func streamCreated(_ id: NIOHTTP2.HTTP2StreamID, channel: NIOCore.Channel) {
-            self.store.withLockedValue { store in
-                store.created+=1
-                store.open+=1
-            }
+            self.store.created+=1
+            self.store.open+=1
         }
 
         func streamClosed(_ id: NIOHTTP2.HTTP2StreamID, channel: NIOCore.Channel) {
-            self.store.withLockedValue { store in
-                store.closed+=1
-                store.open-=1
-            }
+            self.store.closed+=1
+            self.store.open-=1
         }
 
         var created: Int {
-            self.store.withLockedValue { store in
-                store.created
-            }
+            self.store.created
         }
 
         var closed: Int {
-            self.store.withLockedValue { store in
-                store.closed
-            }
+            self.store.closed
         }
 
         var open: Int {
-            self.store.withLockedValue { store in
-                store.open
-            }
+            self.store.open
         }
 
         class Store {


### PR DESCRIPTION
Motivation:

Remove `NIOHTTP2StreamDelegate` `Sendable` conformance requirement. This wasn't needed in the first place because `NIOHTTP2Handler` is not `Sendable`, therefore it never leaves the thread on which it is created.

The delegate may still be `Sendable` depending on the implementation but it is not a strict requirement.

Modifications:

Remove `NIOHTTP2StreamDelegate` `Sendable` requirement

Result:

Sendable is no longer required for `NIOHTTP2StreamDelegate` conformance