### PR TITLE
Avoid allocation in outbound frame buffer

### DIFF
--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -27,16 +27,16 @@ services:
     image: swift-nio-http2:20.04-5.5
     command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=46200
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=46200
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=45100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=304050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=305050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=270050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1420050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1421050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=44150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=43100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=44150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=43100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1310050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1311050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=40050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=40050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -44,8 +44,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=303150
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=302350
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=302850
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=302150
 
   shell:
     image: swift-nio-http2:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -25,16 +25,16 @@ services:
   test:
     image: swift-nio-http2:20.04-5.6
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -42,8 +42,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292150
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -25,16 +25,16 @@ services:
   test:
     image: swift-nio-http2:22.04-5.7
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -42,8 +42,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292150
 
   shell:
     image: swift-nio-http2:22.04-5.7

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -24,16 +24,16 @@ services:
   test:
     image: swift-nio-http2:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -41,8 +41,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292150
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -24,16 +24,16 @@ services:
   test:
     image: swift-nio-http2:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=43200
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=42100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1316050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1317050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -41,8 +41,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293150
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292350
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=292150
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:

CiruclarBuffer always allocates on init as it never has a zero capacity. It is implemented in such a way that changing this is not trivial. The compound outbound buffer creates a marked circular buffer unconditionally on each call but only uses it if there are streams to drop.

Modifications:

Add a static empty marked circular buffer to the compound outbound buffer and rely on CoW semantics to avoid the allocation for each call in cases where there are no frames to drop.

Result:

Fewer allocations.