### PR TITLE
Inline multiplexer calls writability mgr directly

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InboundStreamMultiplexer.swift
@@ -135,6 +135,15 @@ extension NIOHTTP2Handler.InboundStreamMultiplexer {
             break // do nothing
         }
     }
+
+    func processedFrame(streamID: HTTP2StreamID, size: Int) {
+        switch self {
+        case .inline(let inlineStreamMultiplexer):
+            inlineStreamMultiplexer.processedFrame(streamID: streamID, size: size)
+        case .legacy:
+            break // do nothing
+        }
+    }
 }
 
 /// Provides an inbound stream multiplexer interface for legacy compatibility.

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InboundStreamMultiplexer.swift
@@ -136,10 +136,10 @@ extension NIOHTTP2Handler.InboundStreamMultiplexer {
         }
     }
 
-    func processedFrame(streamID: HTTP2StreamID, size: Int) {
+    func processedFrame(_ frame: HTTP2Frame) {
         switch self {
         case .inline(let inlineStreamMultiplexer):
-            inlineStreamMultiplexer.processedFrame(streamID: streamID, size: size)
+            inlineStreamMultiplexer.processedFrame(frame: frame)
         case .legacy:
             break // do nothing
         }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -134,8 +134,8 @@ extension InlineStreamMultiplexer {
         }
     }
 
-    internal func processedFrame(streamID: HTTP2StreamID, size: Int) {
-        self.commonStreamMultiplexer.processedFrame(streamID: streamID, size: size)
+    internal func processedFrame(frame: HTTP2Frame) {
+        self.commonStreamMultiplexer.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
     }
 }
 

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -133,6 +133,10 @@ extension InlineStreamMultiplexer {
             break
         }
     }
+
+    internal func processedFrame(streamID: HTTP2StreamID, size: Int) {
+        self.commonStreamMultiplexer.processedFrame(streamID: streamID, size: size)
+    }
 }
 
 extension InlineStreamMultiplexer {

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -643,24 +643,24 @@ extension NIOHTTP2Handler {
                 // We need to forward this frame, and then fail these promises.
                 self.processOutboundFrame(context: context, frame: frame, promise: promise)
                 for (droppedFrame, promise) in framesToDrop {
-                    self.inboundStreamMultiplexer?.processedFrame(streamID: droppedFrame.streamID, size: droppedFrame.payload.flowControlledSize)
+                    self.inboundStreamMultiplexer?.processedFrame(droppedFrame)
                     promise?.fail(error)
                 }
             case .succeedAndDrop(let framesToDrop, let error):
                 // We need to succeed this frame promise and fail the others. We fail the others first to keep the
                 // promises in order.
                 for (droppedFrame, promise) in framesToDrop {
-                    self.inboundStreamMultiplexer?.processedFrame(streamID: droppedFrame.streamID, size: droppedFrame.payload.flowControlledSize)
+                    self.inboundStreamMultiplexer?.processedFrame(droppedFrame)
                     promise?.fail(error)
                 }
-                self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
+                self.inboundStreamMultiplexer?.processedFrame(frame)
                 promise?.succeed(())
             }
         } catch let error where error is NIOHTTP2Errors.ExcessiveOutboundFrameBuffering {
-            self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
+            self.inboundStreamMultiplexer?.processedFrame(frame)
             self.inboundConnectionErrorTriggered(context: context, underlyingError: error, reason: .enhanceYourCalm)
         } catch {
-            self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
+            self.inboundStreamMultiplexer?.processedFrame(frame)
             promise?.fail(error)
         }
     }
@@ -710,7 +710,7 @@ extension NIOHTTP2Handler {
 
         // From this point on this will either error or go into `context.write`
         // Once the frame data is out of the HTTP2 handler we consider this 'written'
-        self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
+        self.inboundStreamMultiplexer?.processedFrame(frame)
 
         switch result.result {
         case .ignoreFrame:

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -642,20 +642,25 @@ extension NIOHTTP2Handler {
             case .forwardAndDrop(let framesToDrop, let error):
                 // We need to forward this frame, and then fail these promises.
                 self.processOutboundFrame(context: context, frame: frame, promise: promise)
-                for (_, promise) in framesToDrop {
+                for (droppedFrame, promise) in framesToDrop {
+                    self.inboundStreamMultiplexer?.processedFrame(streamID: droppedFrame.streamID, size: droppedFrame.payload.flowControlledSize)
                     promise?.fail(error)
                 }
             case .succeedAndDrop(let framesToDrop, let error):
                 // We need to succeed this frame promise and fail the others. We fail the others first to keep the
                 // promises in order.
-                for (_, promise) in framesToDrop {
+                for (droppedFrame, promise) in framesToDrop {
+                    self.inboundStreamMultiplexer?.processedFrame(streamID: droppedFrame.streamID, size: droppedFrame.payload.flowControlledSize)
                     promise?.fail(error)
                 }
+                self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
                 promise?.succeed(())
             }
         } catch let error where error is NIOHTTP2Errors.ExcessiveOutboundFrameBuffering {
+            self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
             self.inboundConnectionErrorTriggered(context: context, underlyingError: error, reason: .enhanceYourCalm)
         } catch {
+            self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
             promise?.fail(error)
         }
     }
@@ -702,6 +707,10 @@ extension NIOHTTP2Handler {
         }
 
         self.processStateChange(result.effect)
+
+        // From this point on this will either error or go into `context.write`
+        // Once the frame data is out of the HTTP2 handler we consider this 'written'
+        self.inboundStreamMultiplexer?.processedFrame(streamID: frame.streamID, size: frame.payload.flowControlledSize)
 
         switch result.result {
         case .ignoreFrame:

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -309,6 +309,12 @@ extension HTTP2CommonInboundStreamMultiplexer {
 }
 
 extension HTTP2CommonInboundStreamMultiplexer {
+    /// Mark the bytes as written
+    ///
+    /// > This is only to be called from the inline multiplexer
+    ///
+    /// Mark bytes as written in the `HTTP2StreamChannel` writability manager directly, as used by the inline stream multiplexer.
+    /// This is taken care of separately via a promise in the legacy case.
     internal func processedFrame(streamID: HTTP2StreamID, size: Int) {
         if let channel = self.streams[streamID] {
             channel.wroteBytes(size)

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -307,3 +307,11 @@ extension HTTP2CommonInboundStreamMultiplexer {
         }
     }
 }
+
+extension HTTP2CommonInboundStreamMultiplexer {
+    internal func processedFrame(streamID: HTTP2StreamID, size: Int) {
+        if let channel = self.streams[streamID] {
+            channel.wroteBytes(size)
+        }
+    }
+}

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -141,6 +141,10 @@ extension MultiplexerAbstractChannel {
     func receiveStreamError(_ error: NIOHTTP2Errors.StreamError) {
         self.baseChannel.receiveStreamError(error)
     }
+
+    func wroteBytes(_ size: Int) {
+        self.baseChannel.wroteBytes(size)
+    }
 }
 
 extension MultiplexerAbstractChannel: Equatable {

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -27,16 +27,16 @@ services:
     image: swift-nio-http2:20.04-5.5
     command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh && ./scripts/test_h2spec.sh $${SANITIZER_ARG-}"
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=44150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=43100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=36150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=35100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=44150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=43100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=298050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=299050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=283050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=266050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=258050
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1310050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1311050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=903050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=40050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=40050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -25,16 +25,16 @@ services:
   test:
     image: swift-nio-http2:20.04-5.6
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=35150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=281050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=256050
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=901050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -25,16 +25,16 @@ services:
   test:
     image: swift-nio-http2:22.04-5.7
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=35150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=281050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=256050
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=901050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -24,16 +24,16 @@ services:
   test:
     image: swift-nio-http2:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=35150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=281050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=256050
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=901050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -24,16 +24,16 @@ services:
   test:
     image: swift-nio-http2:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=41150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=40100
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=35150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
       - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=293050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=281050
       - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=262050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=256050
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=1207050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=901050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050


### PR DESCRIPTION
Motivation:

The `HTTP2StreamChannel` keeps track of how many bytes have been written and how many are buffered for use in evaluating the 'writability' of the stream channel. Bytes are considered 'written' or at least no longer buffered when the write is completed (successfully or errored). In order to make the determination of when writes are complete across channel handlers we attach a promise to all writes and deduct adjust the byte counts on completion. Creating and attaching these promises requires costly allocations.

Modifications:

We can remove the need to create these promises for the new inline stream multiplexer because the multiplexer and man HTTP2 channel operations are now all within the `HTTP2ChannelHandler`. This change calls the `writabilityManager` directly when writes are completed.

Result:

* Fewer allocations are required for HTTP2 writes.
* Writes are considered 'complete' when they leave the `HTTP2ChannelHandler`