### PR TITLE
Replace estimatedFrameSize with flowControlledSize

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -135,12 +135,12 @@ private enum HTTP2StreamData {
     case frame(HTTP2Frame)
     case framePayload(HTTP2Frame.FramePayload)
 
-    var estimatedFrameSize: Int {
+    var flowControlledSize: Int {
         switch self {
         case .frame(let frame):
-            return frame.payload.estimatedFrameSize
+            return frame.payload.flowControlledSize
         case .framePayload(let payload):
-            return payload.estimatedFrameSize
+            return payload.flowControlledSize
         }
     }
 }
@@ -494,7 +494,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         // Regardless of whether the write succeeded or failed, we don't count
         // the bytes any longer.
         let promise = promise ?? self.eventLoop.makePromise()
-        let writeSize = streamData.estimatedFrameSize
+        let writeSize = streamData.flowControlledSize
 
         // Right now we deal with this math by just attaching a callback to all promises. This is going
         // to be annoyingly expensive, but for now it's the most straightforward approach.

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
@@ -1526,20 +1526,28 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         let childChannel = try assertNoThrowWithValue(childChannelPromise.futureResult.wait())
         XCTAssertTrue(childChannel.isWritable)
 
-        // We're going to write a HEADERS frame (9 bytes) and an 81 byte DATA frame (90 bytes). This will not flip the
+        // We're going to write a HEADERS frame (not counted towards flow control calculations) and a 90 byte DATA frame (90 bytes). This will not flip the
         // writability state.
         let headers = HPACKHeaders([(":path", "/"), (":method", "GET"), (":authority", "localhost"), (":scheme", "https")])
-        let headersFrame = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: false))
+        let headersPayload = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: false))
 
-        var dataBuffer = childChannel.allocator.buffer(capacity: 81)
-        dataBuffer.writeBytes(repeatElement(0, count: 81))
-        let dataFrame = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(dataBuffer), endStream: false))
+        var dataBuffer = childChannel.allocator.buffer(capacity: 90)
+        dataBuffer.writeBytes(repeatElement(0, count: 90))
+        let dataPayload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(dataBuffer), endStream: false))
 
-        childChannel.write(headersFrame, promise: nil)
-        childChannel.write(dataFrame, promise: nil)
+        childChannel.write(headersPayload, promise: nil)
+        childChannel.write(dataPayload, promise: nil)
         XCTAssertTrue(childChannel.isWritable)
 
-        // Now we're going to send another HEADERS frame (for trailers). This should flip the channel writability.
+        // We're going to write another 20 byte DATA frame (20 bytes). This should flip the channel writability.
+        dataBuffer = childChannel.allocator.buffer(capacity: 20)
+        dataBuffer.writeBytes(repeatElement(0, count: 20))
+        let secondDataPayload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(dataBuffer), endStream: false))
+
+        childChannel.write(secondDataPayload, promise: nil)
+        XCTAssertFalse(childChannel.isWritable)
+
+        // Now we're going to send another HEADERS frame (for trailers). This should not affect the channel writability.
         let trailers = HPACKHeaders([])
         let trailersFrame = HTTP2Frame.FramePayload.headers(.init(headers: trailers, endStream: true))
         childChannel.write(trailersFrame, promise: nil)
@@ -1620,20 +1628,28 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
 
         XCTAssertTrue(childChannel.isWritable)
 
-        // We're going to write a HEADERS frame (9 bytes) and an 81 byte DATA frame (90 bytes). This will not flip the
+        // We're going to write a HEADERS frame (not counted towards flow control calculations) and a 90 byte DATA frame (90 bytes). This will not flip the
         // writability state.
         let headers = HPACKHeaders([(":path", "/"), (":method", "GET"), (":authority", "localhost"), (":scheme", "https")])
         let headersPayload = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: false))
 
-        var dataBuffer = childChannel.allocator.buffer(capacity: 81)
-        dataBuffer.writeBytes(repeatElement(0, count: 81))
+        var dataBuffer = childChannel.allocator.buffer(capacity: 90)
+        dataBuffer.writeBytes(repeatElement(0, count: 90))
         let dataPayload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(dataBuffer), endStream: false))
 
         childChannel.write(headersPayload, promise: nil)
         childChannel.write(dataPayload, promise: nil)
         XCTAssertTrue(childChannel.isWritable)
 
-        // Now we're going to send another HEADERS frame (for trailers). This should flip the channel writability.
+        // We're going to write another 20 byte DATA frame (20 bytes). This should flip the channel writability.
+        dataBuffer = childChannel.allocator.buffer(capacity: 20)
+        dataBuffer.writeBytes(repeatElement(0, count: 20))
+        let secondDataPayload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(dataBuffer), endStream: false))
+
+        childChannel.write(secondDataPayload, promise: nil)
+        XCTAssertFalse(childChannel.isWritable)
+
+        // Now we're going to send another HEADERS frame (for trailers). This should not affect the channel writability.
         let trailers = HPACKHeaders([])
         let trailersPayload = HTTP2Frame.FramePayload.headers(.init(headers: trailers, endStream: true))
         childChannel.write(trailersPayload, promise: nil)


### PR DESCRIPTION
Motivation:

`estimatedFrameSize` aims to estimate the number of bytes a frame will use on the wire. It includes the 9-octed frame header and is currently used for flow control estimates but according to spec it shouldn't include those 9 bytes https://www.rfc-editor.org/rfc/rfc9113.html#section-6.9.1

Modifications:

Replace `estimatedFrameSize` with `flowControlledSize` which ignores the 9-octed frame header and update tests.

Result:

Flow control calculations should be more accurate