### PR TITLE
Add `HPACKHeader.removeAll(keepingCapacity:)`

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -426,9 +426,9 @@ extension HPACKHeaders {
         self.headers.reserveCapacity(minimumCapacity)
     }
 
-    /// Removes all headers whist optionally keeping the capacity.
+    /// Removes all headers whilst optionally keeping the capacity.
     ///
-    /// - Parameter keepingCapacity: Wether to keep the underlying memory or not. Use this flag to
+    /// - Parameter keepingCapacity: Whether to keep the underlying memory or not. Use this flag to
     ///                              reduce allocations when reusing the header collection.
     @inlinable
     public mutating func removeAll(keepingCapacity: Bool = false) {

--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -425,6 +425,11 @@ extension HPACKHeaders {
     public mutating func reserveCapacity(_ minimumCapacity: Int) {
         self.headers.reserveCapacity(minimumCapacity)
     }
+
+    @inlinable
+    public mutating func removeAll(keepingCapacity: Bool = false) {
+        self.headers.removeAll(keepingCapacity: keepingCapacity)
+    }
 }
 
 extension HPACKHeaders: RandomAccessCollection {

--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -426,6 +426,10 @@ extension HPACKHeaders {
         self.headers.reserveCapacity(minimumCapacity)
     }
 
+    /// Removes all headers whist optionally keeping the capacity.
+    ///
+    /// - Parameter keepingCapacity: Wether to keep the underlying memory or not. Use this flag to
+    ///                              reduce allocations when reusing the header collection.
     @inlinable
     public mutating func removeAll(keepingCapacity: Bool = false) {
         self.headers.removeAll(keepingCapacity: keepingCapacity)

--- a/Tests/NIOHPACKTests/HPACKHeadersTests.swift
+++ b/Tests/NIOHPACKTests/HPACKHeadersTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2022-2023 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/NIOHPACKTests/HPACKHeadersTests.swift
+++ b/Tests/NIOHPACKTests/HPACKHeadersTests.swift
@@ -180,4 +180,30 @@ final class HPACKHeadersTests: XCTestCase {
             }
         }
     }
+
+    func testRemoveAll() {
+        let original: HPACKHeaders = [
+            "foo": "bar",
+            "bar": "foo",
+            "foo": "baz",
+            "foo": "bar,baz",
+            "foo": " bar ,baz ,,",
+            "bar": "foo"
+        ]
+
+        XCTAssertEqual(original.capacity, 6)
+        var keepCapacity = original
+        XCTAssertEqual(keepCapacity.count, 6)
+        XCTAssertEqual(keepCapacity.capacity, 6)
+        keepCapacity.removeAll(keepingCapacity: true)
+        XCTAssertEqual(keepCapacity.count, 0)
+        XCTAssertEqual(keepCapacity.capacity, 6)
+
+        var lowerCapacity = original
+        XCTAssertEqual(lowerCapacity.count, 6)
+        XCTAssertEqual(lowerCapacity.capacity, 6)
+        lowerCapacity.removeAll(keepingCapacity: false)
+        XCTAssertEqual(lowerCapacity.count, 0)
+        XCTAssertEqual(lowerCapacity.capacity, 0)
+    }
 }

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
+    sed -e 's/20[12][789012]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
In scenarios, in which we want to send lots of small HTTP/2 requests, we want to reuse a single HPACKHeaders object as often as we can. To support this we should have a `removeAll(keepingCapacity:)` method.