### PR TITLE
Fix test for `HPACKHeader.removeAll(keepingCapacity:)` on Android

### DIFF
--- a/Tests/NIOHPACKTests/HPACKHeadersTests.swift
+++ b/Tests/NIOHPACKTests/HPACKHeadersTests.swift
@@ -191,17 +191,17 @@ final class HPACKHeadersTests: XCTestCase {
             "bar": "foo"
         ]
 
-        XCTAssertEqual(original.capacity, 6)
+        let originalCapacity = original.capacity
         var keepCapacity = original
         XCTAssertEqual(keepCapacity.count, 6)
-        XCTAssertEqual(keepCapacity.capacity, 6)
+        XCTAssertEqual(keepCapacity.capacity, originalCapacity)
         keepCapacity.removeAll(keepingCapacity: true)
         XCTAssertEqual(keepCapacity.count, 0)
-        XCTAssertEqual(keepCapacity.capacity, 6)
+        XCTAssertEqual(keepCapacity.capacity, originalCapacity)
 
         var lowerCapacity = original
         XCTAssertEqual(lowerCapacity.count, 6)
-        XCTAssertEqual(lowerCapacity.capacity, 6)
+        XCTAssertEqual(lowerCapacity.capacity, originalCapacity)
         lowerCapacity.removeAll(keepingCapacity: false)
         XCTAssertEqual(lowerCapacity.count, 0)
         XCTAssertEqual(lowerCapacity.capacity, 0)


### PR DESCRIPTION
Motivation:

Get this test passing on Android

Modifications:

Change the capacity to whatever it originally was, rather than a hard-coded value.

Result:

Resolves #394 and the test now passes

I could not reproduce on Android when assigning to a String array like this, implying this overcapacity is specific to this HPACK header array:
```
var headerArray : [String] = []

func assign(_ headers: [(String, String)] = []) {
   print(headers.count)
   print(headers.capacity)
   headerArray = headers.map { "headerKey : \($0.0), headerValue: \($0.1)" }
   print(headerArray.count)
   print(headerArray.capacity)
}
        let original = [
            ("foo", "bar"),
            ("bar", "foo"),
            ("foo", "baz"),
            ("foo", "bar,baz"),
            ("foo", " bar ,baz ,,"),
            ("bar", "foo")
        ]
assign(original)
```