### PR TITLE
use synchronous H2 multiplexer accessor

### DIFF
--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -375,6 +375,6 @@ extension ChannelPipeline.SynchronousOperations {
         try self.addHandler(handler, position: position)
 
         // `multiplexer` will always be non-nil when we are initializing with an `inboundStreamInitializer`
-        return try handler.multiplexer.wait()
+        return try handler.syncMultiplexer()
     }
 }


### PR DESCRIPTION
Motivation:

The `ChannelPipeline.SynchronousOperations.configureHTTP2Pipeline(...)` method added to support synchronously setting up a pipeline to handle HTTP2 with the `StreamMultiplexer` embedded within the `NIOHTTP2Handler` erroneously retrieved the multiplexer via a `.wait()`. This is not permitted and will cause any code which executes it to deadlock.

Modifications:

The synchrounous operation now obtains the multiplexer via `handler.syncMultiplexer()`

Result:

The code should not deadlock.