### PR TITLE
update alloc counts ci build script for 5.9

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio-http2-2-"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in swift55 swift56 swift57 swift58 nightly; do
+for f in swift56 swift57 swift58 swift59 nightly; do
     echo "$f"
     url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"
     stripped=${f#"swift"}


### PR DESCRIPTION
Motivation:

update alloc counts ci build script to reflect our current CI pipelines

Modifications:

update alloc counts ci build script to add 5.9 and drop 5.5 to reflect our CI pipelines

Result:

Script should update counts successfully