### PR TITLE
Update allocation limits

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
 
   shell:
     image: swift-nio-http2:22.04-5.7

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -31,12 +31,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -44,8 +44,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -31,12 +31,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=292050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=261050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1206050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -44,8 +44,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292850
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Allocations regressed due to our use of EmbeddedChannel, which now uses a new atomic since apple/swift-nio#2429. We can update the limits accordingly.