### PR TITLE
HTTP/2 pipeline NIOAsyncChannel pipeline config

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -245,13 +245,14 @@ extension NIOHTTP2Handler {
 
 
         /// Create a stream channel initialized with the provided closure and return it wrapped within a `NIOAsyncChannel`.
-        /// - parameters:
-        ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
-        ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `initializer`
-        ///     or ``HTTP2Frame/FramePayload`` if there are none.
-        ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the created channel.
-        ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `initializer`
-        ///     or ``HTTP2Frame/FramePayload`` if there are none.
+        ///
+        /// - Parameters:
+        ///     - inboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
+        ///       This type must match the `InboundOut` type of the final handler added to the stream channel by the `initializer`
+        ///       or ``HTTP2Frame/FramePayload`` if there are none.
+        ///     - outboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the created channel.
+        ///       This type must match the `OutboundIn` type of the final handler added to the stream channel by the `initializer`
+        ///       or ``HTTP2Frame/FramePayload`` if there are none.
         ///     - initializer: A callback that will be invoked to allow you to configure the
         ///         `ChannelPipeline` for the newly created channel.
         public func createStreamChannel<Inbound, Outbound>(

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -246,17 +246,17 @@ extension NIOHTTP2Handler {
 
         /// Create a stream channel initialized with the provided closure and return it wrapped within a `NIOAsyncChannel`.
         /// - parameters:
-        ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for outbound stream channels.
+        ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
         ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `initializer`
-        ///     or `HTTP2Frame.Payload` if there are none.
-        ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for outbound stream channels.
+        ///     or ``HTTP2Frame/FramePayload`` if there are none.
+        ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the created channel.
         ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `initializer`
-        ///     or `HTTP2Frame.Payload` if there are none.
+        ///     or ``HTTP2Frame/FramePayload`` if there are none.
         ///     - initializer: A callback that will be invoked to allow you to configure the
         ///         `ChannelPipeline` for the newly created channel.
         public func createStreamChannel<Inbound, Outbound>(
-            inboundType: Inbound.Type = Inbound.self,
-            outboundType: Outbound.Type = Outbound.self,
+            inboundType: Inbound.Type,
+            outboundType: Outbound.Type,
             initializer: @escaping NIOHTTP2Handler.StreamInitializer
         ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
             return try await self.createStreamChannel { channel in

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -990,11 +990,15 @@ extension NIOHTTP2Handler {
 #if swift(>=5.7)
     /// The type of all `inboundStreamInitializer` callbacks.
     public typealias StreamInitializer = @Sendable (Channel) -> EventLoopFuture<Void>
+    /// The type of all `connectionInitializer` callbacks.
+    public typealias ConnectionInitializer = @Sendable (Channel) -> EventLoopFuture<Void>
     /// The type of `inboundStreamInitializer` callbacks which return non-void results.
     public typealias StreamInitializerWithOutput<Output> = @Sendable (Channel) -> EventLoopFuture<Output>
 #else
     /// The type of all `inboundStreamInitializer` callbacks.
     public typealias StreamInitializer = (Channel) -> EventLoopFuture<Void>
+    /// The type of all `connectionInitializer` callbacks.
+    public typealias ConnectionInitializer = (Channel) -> EventLoopFuture<Void>
     /// The type of `inboundStreamInitializer` callbacks which return non-void results.
     public typealias StreamInitializerWithOutput<Output> = (Channel) -> EventLoopFuture<Output>
 #endif

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -278,10 +278,10 @@ extension Channel {
     ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
     ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
     /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
     /// inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
@@ -511,10 +511,10 @@ extension Channel {
     ///     This type must match the `OutboundIn` type of the final handler in the connection channel.
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
     ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - connectionInitializer: A closure that will be called once the `NIOHTTP2Handler` has been added to the pipeline.     
     ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
     /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
@@ -547,12 +547,11 @@ extension Channel {
             inboundStreamInitializer: inboundStreamInitializer
         ).flatMap { multiplexer in
             return connectionInitializer(self).flatMapThrowing { _ in
-                return try NIOAsyncChannel(
+                let connectionAsyncChannel = try NIOAsyncChannel(
                     synchronouslyWrapping: self,
                     inboundType: ConnectionInbound.self,
                     outboundType: ConnectionOutbound.self
                 )
-            }.map { connectionAsyncChannel in
                 return (connectionAsyncChannel, multiplexer)
             }
         }
@@ -663,10 +662,10 @@ extension ChannelPipeline.SynchronousOperations {
     ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
     ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or `HTTP2Frame.Payload` if there are none.
+    ///     or ``HTTP2Frame/FramePayload`` if there are none.
     ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
     /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
     /// inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
@@ -683,7 +682,7 @@ extension ChannelPipeline.SynchronousOperations {
         streamOutboundType: StreamOutbound.Type,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>> {
-        return try configureAsyncHTTP2Pipeline(
+        return try self.configureAsyncHTTP2Pipeline(
             mode: mode,
             connectionConfiguration: connectionConfiguration,
             streamConfiguration: streamConfiguration,

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-import NIOCore
+@_spi(AsyncChannel) import NIOCore
 import NIOEmbedded
 import NIOHPACK
 import NIOHTTP1
@@ -131,6 +131,91 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         }
 
         serverRecorder.receivedFrames.assertFramePayloadsMatch(Array(repeating: ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload, count: requestCount))
+    }
+
+    func testNIOAsyncChannelPipelineCommunicates() async throws {
+        let requestCount = 100
+
+        let (clientAsyncChannel, clientMultiplexer) = try await assertNoThrowWithValue(
+            try await self.clientChannel.configureAsyncHTTP2Pipeline(
+                mode: .client,
+                connectionConfiguration: .init(),
+                streamConfiguration: .init(),
+                connectionInboundType: HTTP2Frame.self,
+                connectionOutboundType: HTTP2Frame.self,
+                streamInboundType: HTTP2Frame.FramePayload.self,
+                streamOutboundType: HTTP2Frame.FramePayload.self
+            ) { channel in
+                channel.eventLoop.makeSucceededVoidFuture()
+            } inboundStreamInitializer: { channel -> EventLoopFuture<Void> in
+                self.serverChannel.eventLoop.makeSucceededVoidFuture()
+            }.get()
+        )
+
+        let (serverAsyncChannel, serverMultiplexer) = try await assertNoThrowWithValue(
+            try await self.serverChannel.configureAsyncHTTP2Pipeline(
+                mode: .server,
+                connectionConfiguration: .init(),
+                streamConfiguration: .init(),
+                connectionInboundType: HTTP2Frame.self,
+                connectionOutboundType: HTTP2Frame.self,
+                streamInboundType: HTTP2Frame.FramePayload.self,
+                streamOutboundType: HTTP2Frame.FramePayload.self
+            ) { channel in
+                channel.eventLoop.makeSucceededVoidFuture()
+            } inboundStreamInitializer: { channel -> EventLoopFuture<Void> in
+                self.serverChannel.eventLoop.makeSucceededVoidFuture()
+            }.get()
+        )
+
+        try await assertNoThrow(try await self.assertDoHandshake(client: self.clientChannel, server: self.serverChannel))
+
+        try await withThrowingTaskGroup(of: Int.self, returning: Void.self) { group in
+            // server
+            group.addTask {
+                var serverInboundChannelCount = 0
+                for try await streamChannel in serverMultiplexer.inbound {
+                    for try await receivedFrame in streamChannel.inboundStream {
+                        receivedFrame.assertFramePayloadMatches(this: ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload)
+
+                        try await streamChannel.outboundWriter.write(ConfiguringPipelineAsyncMultiplexerTests.responseFramePayload)
+                        streamChannel.outboundWriter.finish()
+
+                        try await self.interactInMemory(self.clientChannel, self.serverChannel)
+                    }
+                    serverInboundChannelCount += 1
+                }
+                return serverInboundChannelCount
+            }
+
+            // client
+            for _ in 0 ..< requestCount {
+                let streamChannel = try await clientMultiplexer.createStreamChannel(
+                    inboundType: HTTP2Frame.FramePayload.self,
+                    outboundType: HTTP2Frame.FramePayload.self
+                ) { channel -> EventLoopFuture<Void> in
+                    channel.eventLoop.makeSucceededVoidFuture()
+                }
+                // Let's try sending some requests
+                try await streamChannel.outboundWriter.write(ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload)
+                streamChannel.outboundWriter.finish()
+
+                try await self.interactInMemory(self.clientChannel, self.serverChannel)
+
+                for try await receivedFrame in streamChannel.inboundStream {
+                    receivedFrame.assertFramePayloadMatches(this: ConfiguringPipelineAsyncMultiplexerTests.responseFramePayload)
+                }
+            }
+
+            clientAsyncChannel.outboundWriter.finish()
+            serverAsyncChannel.outboundWriter.finish()
+
+            try await assertNoThrow(try await self.clientChannel.finish())
+            try await assertNoThrow(try await self.serverChannel.finish())
+
+            let serverInboundChannelCount = try await assertNoThrowWithValue(try await group.next()!)
+            XCTAssertEqual(serverInboundChannelCount, requestCount, "We should have created one server-side channel as a result of the one HTTP/2 stream used.")
+        }
     }
 }
 


### PR DESCRIPTION
Motivation:

This continues the work to expose functionality which allows users to interact with HTTP/2 connections via async abstractions and using structured concurrency.

We build atop of previous work to configure pipelines to deal with HTTP/2 (with no protocol negotiation) and to wrap connection/stream channels with `NIOAsyncChannel`s. This will allow users to iterate over streams and HTTP2Frames.

Modifications:

Provide functions which configure channels and pipelines with the HTTP2 handler, expose a multiplexer for dealing with streams and wrap connection and stream channels with `NIOAsyncChannel`s.

Result:

Users will be able to create and interact with HTTP/2 connections via `NIOAsyncChannel`s. Because HTTP/2 is a negotiated protocol and we do not yet handle it, this is of limited utility.