### PR TITLE
H2 stream AsyncIterator non-sendable on 5.7

### DIFF
--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -515,10 +515,11 @@ public struct NIOHTTP2InboundStreamChannels<Output>: AsyncSequence {
     }
 }
 
+#if swift(>=5.7)
+// This doesn't compile on 5.6 but the omission of Sendable is sufficient in any case
 @available(*, unavailable)
 extension NIOHTTP2InboundStreamChannels.AsyncIterator: Sendable {}
 
-#if swift(>=5.7)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension NIOHTTP2InboundStreamChannels: Sendable where Output: Sendable {}
 #else


### PR DESCRIPTION
Motivation:

Marking `NIOHTTP2InboundStreamChannels.AsyncIterator` as non-sendable fails to compile on 5.6 however implicitly non-sendable will do, this is a nice-to-have.

Modifications:

Move the non-sendable annotation to only apply >= 5.7

Result:

`NIOHTTP2InboundStreamChannels.AsyncIterator` is implicitly non-sendable on 5.6