### PR TITLE
Add additional NIOAsyncChannel config

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -258,8 +258,8 @@ extension NIOHTTP2Handler {
         @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         @_spi(AsyncChannel)
         public func createStreamChannel<Inbound, Outbound>(
-            inboundType: Inbound.Type,
-            outboundType: Outbound.Type,
+            inboundType: Inbound.Type = Inbound.self,
+            outboundType: Outbound.Type = Inbound.self,
             backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
             isOutboundHalfClosureEnabled: Bool = false,
             initializer: @escaping NIOHTTP2Handler.StreamInitializer

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -247,6 +247,8 @@ extension NIOHTTP2Handler {
         /// Create a stream channel initialized with the provided closure and return it wrapped within a `NIOAsyncChannel`.
         ///
         /// - Parameters:
+        ///     - backpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
+        ///     - isOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
         ///     - inboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
         ///       This type must match the `InboundOut` type of the final handler added to the stream channel by the `initializer`
         ///       or ``HTTP2Frame/FramePayload`` if there are none.
@@ -258,10 +260,10 @@ extension NIOHTTP2Handler {
         @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         @_spi(AsyncChannel)
         public func createStreamChannel<Inbound, Outbound>(
-            inboundType: Inbound.Type = Inbound.self,
-            outboundType: Outbound.Type = Inbound.self,
             backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
             isOutboundHalfClosureEnabled: Bool = false,
+            inboundType: Inbound.Type = Inbound.self,
+            outboundType: Outbound.Type = Outbound.self,
             initializer: @escaping NIOHTTP2Handler.StreamInitializer
         ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
             return try await self.createStreamChannel { channel in

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -255,7 +255,11 @@ extension NIOHTTP2Handler {
         ///       or ``HTTP2Frame/FramePayload`` if there are none.
         ///     - initializer: A callback that will be invoked to allow you to configure the
         ///         `ChannelPipeline` for the newly created channel.
+        @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+        @_spi(AsyncChannel)
         public func createStreamChannel<Inbound, Outbound>(
+            backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+            isOutboundHalfClosureEnabled: Bool = false,
             inboundType: Inbound.Type,
             outboundType: Outbound.Type,
             initializer: @escaping NIOHTTP2Handler.StreamInitializer
@@ -264,6 +268,8 @@ extension NIOHTTP2Handler {
                 initializer(channel).flatMapThrowing { _ in
                     return try NIOAsyncChannel(
                         synchronouslyWrapping: channel,
+                        backpressureStrategy: backpressureStrategy,
+                        isOutboundHalfClosureEnabled: isOutboundHalfClosureEnabled,
                         inboundType: Inbound.self,
                         outboundType: Outbound.self
                     )

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -258,10 +258,10 @@ extension NIOHTTP2Handler {
         @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         @_spi(AsyncChannel)
         public func createStreamChannel<Inbound, Outbound>(
-            backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-            isOutboundHalfClosureEnabled: Bool = false,
             inboundType: Inbound.Type,
             outboundType: Outbound.Type,
+            backpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+            isOutboundHalfClosureEnabled: Bool = false,
             initializer: @escaping NIOHTTP2Handler.StreamInitializer
         ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
             return try await self.createStreamChannel { channel in

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -292,10 +292,10 @@ extension Channel {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        streamDelegate: NIOHTTP2StreamDelegate? = nil,
-        position: ChannelPipeline.Position = .last,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        streamDelegate: NIOHTTP2StreamDelegate? = nil,
+        position: ChannelPipeline.Position = .last,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
@@ -306,10 +306,10 @@ extension Channel {
                     mode: mode,
                     connectionConfiguration: connectionConfiguration,
                     streamConfiguration: streamConfiguration,
-                    streamDelegate: streamDelegate,
-                    position: position,
                     streamInboundType: streamInboundType,
                     streamOutboundType: streamOutboundType,
+                    streamDelegate: streamDelegate,
+                    position: position,
                     inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
                     isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
                     inboundStreamInitializer: inboundStreamInitializer
@@ -321,10 +321,10 @@ extension Channel {
                     mode: mode,
                     connectionConfiguration: connectionConfiguration,
                     streamConfiguration: streamConfiguration,
-                    streamDelegate: streamDelegate,
-                    position: position,
                     streamInboundType: streamInboundType,
                     streamOutboundType: streamOutboundType,
+                    streamDelegate: streamDelegate,
+                    position: position,
                     inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
                     isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
                     inboundStreamInitializer: inboundStreamInitializer
@@ -532,13 +532,13 @@ extension Channel {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        streamDelegate: NIOHTTP2StreamDelegate? = nil,
         connectionInboundType: ConnectionInbound.Type,
         connectionOutboundType: ConnectionOutbound.Type,
-        connectionBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
-        connectionIsOutboundHalfClosureEnabled: Bool = false,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        streamDelegate: NIOHTTP2StreamDelegate? = nil,
+        connectionBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        isConnectionOutboundHalfClosureEnabled: Bool = false,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         connectionInitializer: @escaping NIOHTTP2Handler.ConnectionInitializer,
@@ -551,9 +551,9 @@ extension Channel {
             mode: mode,
             connectionConfiguration: connectionConfiguration,
             streamConfiguration: streamConfiguration,
-            streamDelegate: streamDelegate,
             streamInboundType: streamInboundType,
             streamOutboundType: streamOutboundType,
+            streamDelegate: streamDelegate,
             inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
             isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
             inboundStreamInitializer: inboundStreamInitializer
@@ -562,7 +562,7 @@ extension Channel {
                 let connectionAsyncChannel = try NIOAsyncChannel(
                     synchronouslyWrapping: self,
                     backpressureStrategy: connectionBackpressureStrategy,
-                    isOutboundHalfClosureEnabled: connectionIsOutboundHalfClosureEnabled,
+                    isOutboundHalfClosureEnabled: isConnectionOutboundHalfClosureEnabled,
                     inboundType: ConnectionInbound.self,
                     outboundType: ConnectionOutbound.self
                 )
@@ -690,10 +690,10 @@ extension ChannelPipeline.SynchronousOperations {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        streamDelegate: NIOHTTP2StreamDelegate? = nil,
-        position: ChannelPipeline.Position = .last,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        streamDelegate: NIOHTTP2StreamDelegate? = nil,
+        position: ChannelPipeline.Position = .last,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
@@ -708,6 +708,8 @@ extension ChannelPipeline.SynchronousOperations {
             inboundStreamInitializer(channel).flatMapThrowing { _ in
                 return try NIOAsyncChannel(
                     synchronouslyWrapping: channel,
+                    backpressureStrategy: inboundStreamBackpressureStrategy,
+                    isOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
                     inboundType: StreamInbound.self,
                     outboundType: StreamOutbound.self
                 )

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -296,6 +296,8 @@ extension Channel {
         position: ChannelPipeline.Position = .last,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> EventLoopFuture<NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>>> {
         if self.eventLoop.inEventLoop {
@@ -308,6 +310,8 @@ extension Channel {
                     position: position,
                     streamInboundType: streamInboundType,
                     streamOutboundType: streamOutboundType,
+                    inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
+                    isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
                     inboundStreamInitializer: inboundStreamInitializer
                 )
             }
@@ -321,6 +325,8 @@ extension Channel {
                     position: position,
                     streamInboundType: streamInboundType,
                     streamOutboundType: streamOutboundType,
+                    inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
+                    isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
                     inboundStreamInitializer: inboundStreamInitializer
                 )
             }
@@ -529,8 +535,12 @@ extension Channel {
         streamDelegate: NIOHTTP2StreamDelegate? = nil,
         connectionInboundType: ConnectionInbound.Type,
         connectionOutboundType: ConnectionOutbound.Type,
+        connectionBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        connectionIsOutboundHalfClosureEnabled: Bool = false,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         connectionInitializer: @escaping NIOHTTP2Handler.ConnectionInitializer,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> EventLoopFuture<(
@@ -544,11 +554,15 @@ extension Channel {
             streamDelegate: streamDelegate,
             streamInboundType: streamInboundType,
             streamOutboundType: streamOutboundType,
+            inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
+            isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
             inboundStreamInitializer: inboundStreamInitializer
         ).flatMap { multiplexer in
             return connectionInitializer(self).flatMapThrowing { _ in
                 let connectionAsyncChannel = try NIOAsyncChannel(
                     synchronouslyWrapping: self,
+                    backpressureStrategy: connectionBackpressureStrategy,
+                    isOutboundHalfClosureEnabled: connectionIsOutboundHalfClosureEnabled,
                     inboundType: ConnectionInbound.self,
                     outboundType: ConnectionOutbound.self
                 )
@@ -680,6 +694,8 @@ extension ChannelPipeline.SynchronousOperations {
         position: ChannelPipeline.Position = .last,
         streamInboundType: StreamInbound.Type,
         streamOutboundType: StreamOutbound.Type,
+        inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
+        isInboundStreamOutboundHalfClosureEnabled: Bool = false,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>> {
         return try self.configureAsyncHTTP2Pipeline(

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -276,6 +276,8 @@ extension Channel {
     ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
     ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
     ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.     
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
     ///     or ``HTTP2Frame/FramePayload`` if there are none.
@@ -292,12 +294,12 @@ extension Channel {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        streamInboundType: StreamInbound.Type,
-        streamOutboundType: StreamOutbound.Type,
         streamDelegate: NIOHTTP2StreamDelegate? = nil,
         position: ChannelPipeline.Position = .last,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
+        streamInboundType: StreamInbound.Type = StreamInbound.self,
+        streamOutboundType: StreamOutbound.Type = StreamOutbound.self,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> EventLoopFuture<NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>>> {
         if self.eventLoop.inEventLoop {
@@ -306,12 +308,12 @@ extension Channel {
                     mode: mode,
                     connectionConfiguration: connectionConfiguration,
                     streamConfiguration: streamConfiguration,
-                    streamInboundType: streamInboundType,
-                    streamOutboundType: streamOutboundType,
                     streamDelegate: streamDelegate,
                     position: position,
                     inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
                     isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
+                    streamInboundType: streamInboundType,
+                    streamOutboundType: streamOutboundType,
                     inboundStreamInitializer: inboundStreamInitializer
                 )
             }
@@ -321,12 +323,12 @@ extension Channel {
                     mode: mode,
                     connectionConfiguration: connectionConfiguration,
                     streamConfiguration: streamConfiguration,
-                    streamInboundType: streamInboundType,
-                    streamOutboundType: streamOutboundType,
                     streamDelegate: streamDelegate,
                     position: position,
                     inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
                     isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
+                    streamInboundType: streamInboundType,
+                    streamOutboundType: streamOutboundType,
                     inboundStreamInitializer: inboundStreamInitializer
                 )
             }
@@ -511,10 +513,14 @@ extension Channel {
     ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
     ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
     ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///     - connectionBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
+    ///     - isConnectionOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
     ///     - connectionInboundType: The ``NIOAsyncChannel/inboundStream`` message type for the HTTP/2 connection channel.
     ///     This type must match the `InboundOut` type of the final handler in the connection channel.
     ///     - connectionOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the HTTP/2 connection channel.
     ///     This type must match the `OutboundIn` type of the final handler in the connection channel.
+    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
     ///     or ``HTTP2Frame/FramePayload`` if there are none.
@@ -532,15 +538,15 @@ extension Channel {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        connectionInboundType: ConnectionInbound.Type,
-        connectionOutboundType: ConnectionOutbound.Type,
-        streamInboundType: StreamInbound.Type,
-        streamOutboundType: StreamOutbound.Type,
         streamDelegate: NIOHTTP2StreamDelegate? = nil,
         connectionBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isConnectionOutboundHalfClosureEnabled: Bool = false,
+        connectionInboundType: ConnectionInbound.Type = ConnectionInbound.self,
+        connectionOutboundType: ConnectionOutbound.Type = ConnectionOutbound.self,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
+        streamInboundType: StreamInbound.Type = StreamInbound.self,
+        streamOutboundType: StreamOutbound.Type = StreamOutbound.self,
         connectionInitializer: @escaping NIOHTTP2Handler.ConnectionInitializer,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> EventLoopFuture<(
@@ -551,11 +557,11 @@ extension Channel {
             mode: mode,
             connectionConfiguration: connectionConfiguration,
             streamConfiguration: streamConfiguration,
-            streamInboundType: streamInboundType,
-            streamOutboundType: streamOutboundType,
             streamDelegate: streamDelegate,
             inboundStreamBackpressureStrategy: inboundStreamBackpressureStrategy,
             isInboundStreamOutboundHalfClosureEnabled: isInboundStreamOutboundHalfClosureEnabled,
+            streamInboundType: streamInboundType,
+            streamOutboundType: streamOutboundType,
             inboundStreamInitializer: inboundStreamInitializer
         ).flatMap { multiplexer in
             return connectionInitializer(self).flatMapThrowing { _ in
@@ -674,6 +680,8 @@ extension ChannelPipeline.SynchronousOperations {
     ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
     ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
     ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
     ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
     ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
     ///     or ``HTTP2Frame/FramePayload`` if there are none.
@@ -690,12 +698,12 @@ extension ChannelPipeline.SynchronousOperations {
         mode: NIOHTTP2Handler.ParserMode,
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
-        streamInboundType: StreamInbound.Type,
-        streamOutboundType: StreamOutbound.Type,
         streamDelegate: NIOHTTP2StreamDelegate? = nil,
         position: ChannelPipeline.Position = .last,
         inboundStreamBackpressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark? = nil,
         isInboundStreamOutboundHalfClosureEnabled: Bool = false,
+        streamInboundType: StreamInbound.Type = StreamInbound.self,
+        streamOutboundType: StreamOutbound.Type = StreamOutbound.self,
         inboundStreamInitializer: @escaping NIOHTTP2Handler.StreamInitializer
     ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>> {
         return try self.configureAsyncHTTP2Pipeline(


### PR DESCRIPTION
Motivation:

Recent additions to pipeline configuration did not expose some of the `NIOAsyncChannel` configuration.

Modifications:

Expose `backpressureStrategy`, `isOutboundHalfClosureEnabled`.

I think specific naming and object encapsulation for these parameters should be discussed later before SPI is removed and we review the API as a whole.

Result:

Pipelie helpers for `NIOAsyncChannel` expose `backpressureStrategy`, `isOutboundHalfClosureEnabled`.