### PR TITLE
Tweak formatting of function DocC comments

### DIFF
--- a/Sources/NIOHPACK/HPACKHeader.swift
+++ b/Sources/NIOHPACK/HPACKHeader.swift
@@ -81,8 +81,8 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
     /// The indexability of all headers is assumed to be the default, i.e. indexable and
     /// rewritable by proxies.
     ///
-    /// - parameters
-    ///     - headers: An initial set of headers to use to populate the header block.
+    /// - Parameters:
+    ///   - headers: An initial set of headers to use to populate the header block.
     @inlinable
     public init(_ headers: [(String, String)] = []) {
         self.headers = headers.map { HPACKHeader(name: $0.0, value: $0.1) }
@@ -104,9 +104,9 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
     /// The indexability of all headers is assumed to be the default, i.e. indexable and
     /// rewritable by proxies.
     ///
-    /// - parameters
-    ///     - headers: An initial set of headers to use to populate the header block.
-    ///     - allocator: The allocator to use to allocate the underlying storage.
+    /// - Parameters:
+    ///   - headers: An initial set of headers to use to populate the header block.
+    ///   - allocator: The allocator to use to allocate the underlying storage.
     @available(*, deprecated, renamed: "init(_:)")
     public init(_ headers: [(String, String)] = [], allocator: ByteBufferAllocator) {
         // We no longer use an allocator so we don't need this method anymore.
@@ -130,10 +130,12 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
     /// This method is strictly additive: if there are other values for the given header name
     /// already in the block, this will add a new entry. `add` performs case-insensitive
     /// comparisons on the header field name.
-    ///
-    /// - Parameter name: The header field name. This must be an ASCII string. For HTTP/2 lowercase
-    ///     header names are strongly encouraged.
-    /// - Parameter value: The header field value to add for the given name.
+    /// - Parameters:
+    ///   - name: The header field name. This must be an ASCII string. For HTTP/2 lowercase
+    ///         header names are strongly encouraged.
+    ///   - value: The header field value to add for the given name.
+    ///   - indexing: The types of indexing and rewriting operations a decoder may take with
+    ///         regard to this header.
     @inlinable
     public mutating func add(name: String, value: String, indexing: HPACKIndexing = .indexable) {
         precondition(!name.utf8.contains(where: { !$0.isASCII }), "name must be ASCII")
@@ -179,10 +181,13 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
     /// Like `add`, this method performs case-insensitive comparisons of the header field
     /// names.
     ///
-    /// - Parameter name: The header field name. For maximum compatibility this should be an
-    ///     ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
-    ///     recommended.
-    /// - Parameter value: The header field value to add for the given name.
+    /// - Parameters:
+    ///   - name: The header field name. For maximum compatibility this should be an
+    ///         ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
+    ///         recommended.
+    ///   - value: The header field value to add for the given name.
+    ///   - indexing: The types of indexing and rewriting operations a decoder may take with
+    ///         regard to this header.
     @inlinable
     public mutating func replaceOrAdd(name: String, value: String, indexing: HPACKIndexing = .indexable) {
         self.remove(name: name)
@@ -239,9 +244,9 @@ public struct HPACKHeaders: ExpressibleByDictionaryLiteral, Sendable {
 
     /// Checks if a header is present.
     ///
-    /// - parameters:
-    ///     - name: The name of the header
-    /// - returns: `true` if a header with the name (and value) exists, `false` otherwise.
+    /// - Parameters:
+    ///   - name: The name of the header
+    /// - Returns: `true` if a header with the name (and value) exists, `false` otherwise.
     @inlinable
     public func contains(name: String) -> Bool {
         guard !self.headers.isEmpty else {

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1612,9 +1612,9 @@ extension HTTP2ConnectionStateMachine {
 
     /// Validates a single HTTP/2 settings block.
     ///
-    /// - parameters:
-    ///     - settings: The HTTP/2 settings block to validate.
-    /// - returns: The result of the validation.
+    /// - Parameters:
+    ///   - settings: The HTTP/2 settings block to validate.
+    /// - Returns: The result of the validation.
     private func validateSettings(_ settings: HTTP2Settings) -> StateMachineResult {
         for setting in settings {
             switch setting.parameter {

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStreamsState.swift
@@ -74,10 +74,10 @@ struct ConnectionStreamState {
     /// Unlike with idle streams, which are served by `modifyStreamStateCreateIfNeeded`, for pushed streams we do not
     /// have to perform a modification operation. For this reason, we can use a simpler control flow.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the pushed stream.
-    ///     - remoteInitialWindowSize: The initial window size of the remote peer.
-    ///     - requestVerb: the HTTP method used on the request
+    /// - Parameters:
+    ///   - streamID: The ID of the pushed stream.
+    ///   - remoteInitialWindowSize: The initial window size of the remote peer.
+    ///   - requestVerb: the HTTP method used on the request
     /// - throws: If the stream ID is invalid.
     mutating func createRemotelyPushedStream(streamID: HTTP2StreamID, remoteInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)
@@ -90,9 +90,9 @@ struct ConnectionStreamState {
     /// Unlike with idle streams, which are served by `modifyStreamStateCreateIfNeeded`, for pushed streams we do not
     /// have to perform a modification operation. For this reason, we can use a simpler control flow.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the pushed stream.
-    ///     - localInitialWindowSize: Our initial window size..
+    /// - Parameters:
+    ///   - streamID: The ID of the pushed stream.
+    ///   - localInitialWindowSize: Our initial window size..
     /// - throws: If the stream ID is invalid.
     mutating func createLocallyPushedStream(streamID: HTTP2StreamID, localInitialWindowSize: UInt32, requestVerb: String?) throws {
         try self.reserveServerStreamID(streamID)
@@ -105,14 +105,14 @@ struct ConnectionStreamState {
     /// The `creator` block will be called if the stream does not exist already. The `modifier` block will be called
     /// if the stream was created, or if it was found in the map.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the stream to modify.
-    ///     - localRole: The connection role of the local peer.
-    ///     - localInitialWindowSize: The initial size of the local flow control window for new streams.
-    ///     - remoteInitialWindowSize: The initial size of the remote flow control window for new streams.
-    ///     - modifier: A block that will be invoked to modify the stream state, if present.
+    /// - Parameters:
+    ///   - streamID: The ID of the stream to modify.
+    ///   - localRole: The connection role of the local peer.
+    ///   - localInitialWindowSize: The initial size of the local flow control window for new streams.
+    ///   - remoteInitialWindowSize: The initial size of the remote flow control window for new streams.
+    ///   - modifier: A block that will be invoked to modify the stream state, if present.
     /// - throws: Any errors thrown from the creator.
-    /// - returns: The result of the state modification, as well as any state change that occurred to the stream.
+    /// - Returns: The result of the state modification, as well as any state change that occurred to the stream.
     mutating func modifyStreamStateCreateIfNeeded(streamID: HTTP2StreamID,
                                                   localRole: HTTP2StreamStateMachine.StreamRole,
                                                   localInitialWindowSize: UInt32,
@@ -152,12 +152,12 @@ struct ConnectionStreamState {
     /// The block will be called so long as the stream exists in the currently active streams. If it does not, we will check
     /// whether the stream has been closed already.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the stream to modify.
-    ///     - ignoreRecentlyReset: Whether a recently reset stream should be ignored. Should be set to `true` when receiving frames.
-    ///     - ignoreClosed: Whether a closed stream should be ignored. Should be set to `true` when receiving window update or reset stream frames.
-    ///     - modifier: A block that will be invoked to modify the stream state, if present.
-    /// - returns: The result of the state modification, as well as any state change that occurred to the stream.
+    /// - Parameters:
+    ///   - streamID: The ID of the stream to modify.
+    ///   - ignoreRecentlyReset: Whether a recently reset stream should be ignored. Should be set to `true` when receiving frames.
+    ///   - ignoreClosed: Whether a closed stream should be ignored. Should be set to `true` when receiving window update or reset stream frames.
+    ///   - modifier: A block that will be invoked to modify the stream state, if present.
+    /// - Returns: The result of the state modification, as well as any state change that occurred to the stream.
     mutating func modifyStreamState(streamID: HTTP2StreamID,
                                     ignoreRecentlyReset: Bool,
                                     ignoreClosed: Bool = false,
@@ -180,10 +180,10 @@ struct ConnectionStreamState {
     ///
     /// This block must close the stream. Failing to do so is a programming error.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the stream to modify.
-    ///     - modifier: A block that will be invoked to modify the stream state, if present.
-    /// - returns: The result of the state modification, as well as any state change that occurred to the stream.
+    /// - Parameters:
+    ///   - streamID: The ID of the stream to modify.
+    ///   - modifier: A block that will be invoked to modify the stream state, if present.
+    /// - Returns: The result of the state modification, as well as any state change that occurred to the stream.
     @inline(__always)
     mutating func locallyResetStreamState(streamID: HTTP2StreamID,
                                           _ modifier: (inout HTTP2StreamStateMachine) -> StateMachineResultWithStreamEffect) -> StateMachineResultWithStreamEffect {
@@ -249,11 +249,11 @@ struct ConnectionStreamState {
 
     /// Drop all streams with stream IDs larger than the given stream ID that were initiated by the given role.
     ///
-    /// - parameters:
-    ///     - streamID: The last stream ID the remote peer is promising to handle.
-    ///     - droppedLocally: Whether this drop was caused by sending a GOAWAY frame or receiving it.
-    ///     - initiator: The peer that sent the GOAWAY frame.
-    /// - returns: the stream IDs closed by this operation.
+    /// - Parameters:
+    ///   - streamID: The last stream ID the remote peer is promising to handle.
+    ///   - droppedLocally: Whether this drop was caused by sending a GOAWAY frame or receiving it.
+    ///   - initiator: The peer that sent the GOAWAY frame.
+    /// - Returns: the stream IDs closed by this operation.
     mutating func dropAllStreamsWithIDHigherThan(_ streamID: HTTP2StreamID,
                                                  droppedLocally: Bool,
                                                  initiatedBy initiator: HTTP2ConnectionStateMachine.ConnectionRole) -> [HTTP2StreamID]? {
@@ -282,11 +282,11 @@ struct ConnectionStreamState {
 
     /// Determines the state machine result to generate when we've been asked to modify a missing stream.
     ///
-    /// - parameters:
-    ///     - streamID: The ID of the missing stream.
-    ///     - ignoreRecentlyReset: Whether a recently reset stream should be ignored.
-    ///     - ignoreClosed: Whether a closed stream should be ignored.
-    /// - returns: A `StateMachineResult` for this frame error.
+    /// - Parameters:
+    ///   - streamID: The ID of the missing stream.
+    ///   - ignoreRecentlyReset: Whether a recently reset stream should be ignored.
+    ///   - ignoreClosed: Whether a closed stream should be ignored.
+    /// - Returns: A `StateMachineResult` for this frame error.
     private func streamMissing(streamID: HTTP2StreamID, ignoreRecentlyReset: Bool, ignoreClosed: Bool) -> StateMachineResult {
         if ignoreRecentlyReset && self.recentlyResetStreams.contains(streamID) {
             return .ignoreFrame

--- a/Sources/NIOHTTP2/ConnectionStateMachine/HTTP2SettingsState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HTTP2SettingsState.swift
@@ -77,8 +77,8 @@ struct HTTP2SettingsState {
     ///
     /// This function assumes that settings have been validated by the state machine.
     ///
-    /// - parameters:
-    ///     - settings: The settings to emit.
+    /// - Parameters:
+    ///   - settings: The settings to emit.
     mutating func emitSettings(_ settings: HTTP2Settings) {
         self.unacknowlegedSettingsFrames.append(settings)
     }
@@ -87,8 +87,8 @@ struct HTTP2SettingsState {
     ///
     /// This applies the pending SETTINGS values. If there are no pending SETTINGS values, this will throw.
     ///
-    /// - parameters:
-    ///     - onValueChange: A callback that will be invoked once for each setting change.
+    /// - Parameters:
+    ///   - onValueChange: A callback that will be invoked once for each setting change.
     mutating func receiveSettingsAck(onValueChange: OnValueChangeCallback) throws {
         guard self.unacknowlegedSettingsFrames.count > 0 else {
             throw NIOHTTP2Errors.receivedBadSettings()
@@ -103,9 +103,9 @@ struct HTTP2SettingsState {
     ///
     /// We auto-ACK all SETTINGS, so this applies the settings immediately.
     ///
-    /// - parameters:
-    ///     - settings: The received settings.
-    ///     - onValueChange: A callback that will be invoked once for each setting change.
+    /// - Parameters:
+    ///   - settings: The received settings.
+    ///   - onValueChange: A callback that will be invoked once for each setting change.
     mutating func receiveSettings(_ settings: HTTP2Settings, onValueChange: OnValueChangeCallback) rethrows {
         return try self.applySettings(settings, onValueChange: onValueChange)
     }
@@ -114,9 +114,9 @@ struct HTTP2SettingsState {
     ///
     /// This function assumes that settings have been validated by the state machine.
     ///
-    /// - parameters:
-    ///     - settings: The settings to apply.
-    ///     - onValueChange: A callback that will be invoked once for each setting change.
+    /// - Parameters:
+    ///   - settings: The settings to apply.
+    ///   - onValueChange: A callback that will be invoked once for each setting change.
     private mutating func applySettings(_ settings: HTTP2Settings, onValueChange: OnValueChangeCallback) rethrows {
         for setting in settings {
             let oldValue = self.currentSettingsValues.updateValue(setting._value, forKey: setting.parameter)

--- a/Sources/NIOHTTP2/Frame Buffers/OutboundFlowControlBuffer.swift
+++ b/Sources/NIOHTTP2/Frame Buffers/OutboundFlowControlBuffer.swift
@@ -455,10 +455,10 @@ extension StreamMap where Element == StreamFlowControlState {
     //
     /// Apply a transform to a wrapped DataBuffer.
     ///
-    /// - parameters:
-    ///     - body: A block that will modify the contained value in the
+    /// - Parameters:
+    ///   - body: A block that will modify the contained value in the
     ///         optional, if there is one present.
-    /// - returns: Whether the value was present or not.
+    /// - Returns: Whether the value was present or not.
     @discardableResult
     fileprivate mutating func apply(streamID: HTTP2StreamID, _ body: (inout Element) -> Void) -> Bool {
         return self.modify(streamID: streamID, body) != nil

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -181,10 +181,10 @@ extension NIOHTTP2Handler {
         ///
         /// > Note: Resources for the stream will be freed after it has been closed.
         ///
-        /// - parameters:
-        ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
+        /// - Parameters:
+        ///   - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
         ///         failed if an error occurs.
-        ///     - streamStateInitializer: A callback that will be invoked to allow you to configure the
+        ///   - streamStateInitializer: A callback that will be invoked to allow you to configure the
         ///         `ChannelPipeline` for the newly created channel.
         public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping StreamInitializer) {
             self.inlineStreamMultiplexer.createStreamChannel(promise: promise, streamStateInitializer)
@@ -247,15 +247,15 @@ extension NIOHTTP2Handler {
         /// Create a stream channel initialized with the provided closure and return it wrapped within a `NIOAsyncChannel`.
         ///
         /// - Parameters:
-        ///     - backpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
-        ///     - isOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
-        ///     - inboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
+        ///   - backpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
+        ///   - isOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
+        ///   - inboundType: The ``NIOAsyncChannel/inboundStream`` message type for the created channel.
         ///       This type must match the `InboundOut` type of the final handler added to the stream channel by the `initializer`
         ///       or ``HTTP2Frame/FramePayload`` if there are none.
-        ///     - outboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the created channel.
+        ///   - outboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the created channel.
         ///       This type must match the `OutboundIn` type of the final handler added to the stream channel by the `initializer`
         ///       or ``HTTP2Frame/FramePayload`` if there are none.
-        ///     - initializer: A callback that will be invoked to allow you to configure the
+        ///   - initializer: A callback that will be invoked to allow you to configure the
         ///         `ChannelPipeline` for the newly created channel.
         @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         @_spi(AsyncChannel)

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -180,11 +180,11 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
 
     /// Constructs a ``NIOHTTP2Handler``.
     ///
-    /// - parameters:
-    ///     - mode: The mode for this handler, client or server.
-    ///     - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
-    ///     - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
-    ///     - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
+    /// - Parameters:
+    ///   - mode: The mode for this handler, client or server.
+    ///   - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
+    ///   - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
+    ///   - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
     public convenience init(mode: ParserMode,
                             initialSettings: HTTP2Settings = nioDefaultSettings,
                             headerBlockValidation: ValidationState = .enabled,
@@ -200,14 +200,14 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
 
     /// Constructs a ``NIOHTTP2Handler``.
     ///
-    /// - parameters:
-    ///     - mode: The mode for this handler, client or server.
-    ///     - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
-    ///     - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
-    ///     - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
-    ///     - maximumSequentialEmptyDataFrames: Controls the number of empty data frames this handler will tolerate receiving in a row before DoS protection
+    /// - Parameters:
+    ///   - mode: The mode for this handler, client or server.
+    ///   - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
+    ///   - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
+    ///   - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
+    ///   - maximumSequentialEmptyDataFrames: Controls the number of empty data frames this handler will tolerate receiving in a row before DoS protection
     ///         is triggered and the connection is terminated. Defaults to 1.
-    ///     - maximumBufferedControlFrames: Controls the maximum buffer size of buffered outbound control frames. If we are unable to send control frames as
+    ///   - maximumBufferedControlFrames: Controls the maximum buffer size of buffered outbound control frames. If we are unable to send control frames as
     ///         fast as we produce them we risk building up an unbounded buffer and exhausting our memory. To protect against this DoS vector, we put an
     ///         upper limit on the depth of this queue. Defaults to 10,000.
     public convenience init(mode: ParserMode,
@@ -245,17 +245,17 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
 
     /// Constructs a ``NIOHTTP2Handler``.
     ///
-    /// - parameters:
-    ///     - mode: The mode for this handler, client or server.
-    ///     - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
-    ///     - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
-    ///     - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
-    ///     - maximumSequentialEmptyDataFrames: Controls the number of empty data frames this handler will tolerate receiving in a row before DoS protection
+    /// - Parameters:
+    ///   - mode: The mode for this handler, client or server.
+    ///   - initialSettings: The settings that will be advertised to the peer in the preamble. Defaults to ``nioDefaultSettings``.
+    ///   - headerBlockValidation: Whether to validate sent and received HTTP/2 header blocks. Defaults to ``ValidationState/enabled``.
+    ///   - contentLengthValidation: Whether to validate the content length of sent and received streams. Defaults to ``ValidationState/enabled``.
+    ///   - maximumSequentialEmptyDataFrames: Controls the number of empty data frames this handler will tolerate receiving in a row before DoS protection
     ///         is triggered and the connection is terminated. Defaults to 1.
-    ///     - maximumBufferedControlFrames: Controls the maximum buffer size of buffered outbound control frames. If we are unable to send control frames as
+    ///   - maximumBufferedControlFrames: Controls the maximum buffer size of buffered outbound control frames. If we are unable to send control frames as
     ///         fast as we produce them we risk building up an unbounded buffer and exhausting our memory. To protect against this DoS vector, we put an
     ///         upper limit on the depth of this queue. Defaults to 10,000.
-    ///     - tolerateImpossibleStateTransitionsInDebugMode: Whether impossible state transitions should be tolerated
+    ///   - tolerateImpossibleStateTransitionsInDebugMode: Whether impossible state transitions should be tolerated
     ///         in debug mode.
     internal init(mode: ParserMode,
                   initialSettings: HTTP2Settings = nioDefaultSettings,

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -35,17 +35,17 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``NoSuchStream`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - streamID: The ``HTTP2StreamID`` for the stream that does not exist.
+    /// - Parameters:
+    ///   - streamID: The ``HTTP2StreamID`` for the stream that does not exist.
     public static func noSuchStream(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> NoSuchStream {
         return NoSuchStream(streamID: streamID, file: file, line: line)
     }
 
     /// Creates a ``StreamClosed`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - streamID: The ``HTTP2StreamID`` for the stream that is or has been closed
-    ///     - errorCode: The ``HTTP2ErrorCode`` representing the reason for closure of the stream.
+    /// - Parameters:
+    ///   - streamID: The ``HTTP2StreamID`` for the stream that is or has been closed
+    ///   - errorCode: The ``HTTP2ErrorCode`` representing the reason for closure of the stream.
     public static func streamClosed(streamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, file: String = #fileID, line: UInt = #line) -> StreamClosed {
         return StreamClosed(streamID: streamID, errorCode: errorCode, file: file, line: line)
     }
@@ -57,17 +57,17 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``BadStreamStateTransition`` error with appropriate source context
     ///
-    /// - parameters
-    ///     - state: The ``NIOHTTP2StreamState`` representing the state of the stream from which we were trying to transition
+    /// - Parameters:
+    ///   - state: The ``NIOHTTP2StreamState`` representing the state of the stream from which we were trying to transition
     public static func badStreamStateTransition(from state: NIOHTTP2StreamState? = nil, file: String = #fileID, line: UInt = #line) -> BadStreamStateTransition {
         return BadStreamStateTransition(from: state, file: file, line: line)
     }
 
     /// Creates an ``InvalidFlowControlWindowSize`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - delta: The change in the window size that was proposed in error
-    ///     - currentWindowSize: The current size of the stream flow control window
+    /// - Parameters:
+    ///   - delta: The change in the window size that was proposed in error
+    ///   - currentWindowSize: The current size of the stream flow control window
     public static func invalidFlowControlWindowSize(delta: Int, currentWindowSize: Int, file: String = #fileID, line: UInt = #line) -> InvalidFlowControlWindowSize {
         return InvalidFlowControlWindowSize(delta: delta, currentWindowSize: currentWindowSize, file: file, line: line)
     }
@@ -79,8 +79,8 @@ public enum NIOHTTP2Errors {
 
     /// Creates an ``InvalidSetting`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - setting: The invalid setting in question
+    /// - Parameters:
+    ///   - setting: The invalid setting in question
     public static func invalidSetting(setting: HTTP2Setting, file: String = #fileID, line: UInt = #line) -> InvalidSetting {
         return InvalidSetting(setting: setting, file: file, line: line)
     }
@@ -137,8 +137,8 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``Unsupported`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///      - info: Human-readable information describing _what_ is unsupported.
+    /// - Parameters:
+    ///   - info: Human-readable information describing _what_ is unsupported.
     public static func unsupported(info: String, file: String = #fileID, line: UInt = #line) -> Unsupported {
         return Unsupported(info: info, file: file, line: line)
     }
@@ -155,40 +155,40 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``MissingPseudoHeader`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///      - name: The name of the pseudo-header that was missing from the header block.
+    /// - Parameters:
+    ///   - name: The name of the pseudo-header that was missing from the header block.
     public static func missingPseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> MissingPseudoHeader {
         return MissingPseudoHeader(name, file: file, line: line)
     }
 
     /// Creates a ``DuplicatePseudoHeader`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - name: The name of the pseudo-header that was duplicated within the header block.
+    /// - Parameters:
+    ///   - name: The name of the pseudo-header that was duplicated within the header block.
     public static func duplicatePseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> DuplicatePseudoHeader {
         return DuplicatePseudoHeader(name, file: file, line: line)
     }
 
     /// Creates a ``PseudoHeaderAfterRegularHeader`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - name: The name of the pseudo-header that appeared after a regular header in the header block.
+    /// - Parameters:
+    ///   - name: The name of the pseudo-header that appeared after a regular header in the header block.
     public static func pseudoHeaderAfterRegularHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> PseudoHeaderAfterRegularHeader {
         return PseudoHeaderAfterRegularHeader(name, file: file, line: line)
     }
 
     /// Creates a ``UnknownPseudoHeader`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - name: The name of the pseudo-header that was not recognised by ``NIOHTTP2``.
+    /// - Parameters:
+    ///   - name: The name of the pseudo-header that was not recognised by ``NIOHTTP2``.
     public static func unknownPseudoHeader(_ name: String, file: String = #fileID, line: UInt = #line) -> UnknownPseudoHeader {
         return UnknownPseudoHeader(name, file: file, line: line)
     }
 
     /// Creates a ``InvalidPseudoHeaders`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - block: The block of `HPACKHeaders` that contain the invalid pseudo headers.
+    /// - Parameters:
+    ///   - block: The block of `HPACKHeaders` that contain the invalid pseudo headers.
     public static func invalidPseudoHeaders(_ block: HPACKHeaders, file: String = #fileID, line: UInt = #line) -> InvalidPseudoHeaders {
         return InvalidPseudoHeaders(block, file: file, line: line)
     }
@@ -210,41 +210,41 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``InvalidStatusValue`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - value: The value of the `:status` header that is invalid.
+    /// - Parameters:
+    ///   - value: The value of the `:status` header that is invalid.
     public static func invalidStatusValue(_ value: String, file: String = #fileID, line: UInt = #line) -> InvalidStatusValue {
         return InvalidStatusValue(value, file: file, line: line)
     }
 
     /// Creates a ``PriorityCycle`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - streamID: The ``HTTP2StreamID`` representing the stream that created the priority cycle.
+    /// - Parameters:
+    ///   - streamID: The ``HTTP2StreamID`` representing the stream that created the priority cycle.
     public static func priorityCycle(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> PriorityCycle {
         return PriorityCycle(streamID: streamID, file: file, line: line)
     }
 
     /// Creates a ``TrailersWithoutEndStream`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - streamID: The ``HTTP2StreamID`` on which the `HEADERS` frame without `END_STREAM` was received.
+    /// - Parameters:
+    ///   - streamID: The ``HTTP2StreamID`` on which the `HEADERS` frame without `END_STREAM` was received.
     public static func trailersWithoutEndStream(streamID: HTTP2StreamID, file: String = #fileID, line: UInt = #line) -> TrailersWithoutEndStream {
         return TrailersWithoutEndStream(streamID: streamID, file: file, line: line)
     }
 
     /// Creates a ``InvalidHTTP2HeaderFieldName`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - fieldName: The invalid HTTP/2 header field name
+    /// - Parameters:
+    ///   - fieldName: The invalid HTTP/2 header field name
     public static func invalidHTTP2HeaderFieldName(_ fieldName: String, file: String = #fileID, line: UInt = #line) -> InvalidHTTP2HeaderFieldName {
         return InvalidHTTP2HeaderFieldName(fieldName, file: file, line: line)
     }
 
     /// Creates a ``ForbiddenHeaderField`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - name: The field name for the forbidden header field
-    ///     - value: The field value for the forbidden header field
+    /// - Parameters:
+    ///   - name: The field name for the forbidden header field
+    ///   - value: The field value for the forbidden header field
     public static func forbiddenHeaderField(name: String, value: String, file: String = #fileID, line: UInt = #line) -> ForbiddenHeaderField {
         return ForbiddenHeaderField(name: name, value: value, file: file, line: line)
     }
@@ -291,9 +291,9 @@ public enum NIOHTTP2Errors {
 
     /// Creates a ``StreamError`` error with appropriate source context.
     ///
-    /// - parameters:
-    ///     - streamID: The ``HTTP2StreamID`` on which this error was triggered
-    ///     - baseError: The underlying `Error` that was thrown.
+    /// - Parameters:
+    ///   - streamID: The ``HTTP2StreamID`` on which this error was triggered
+    ///   - baseError: The underlying `Error` that was thrown.
     public static func streamError(streamID: HTTP2StreamID, baseError: Error) -> StreamError {
         return StreamError(streamID: streamID, baseError: baseError)
     }

--- a/Sources/NIOHTTP2/HTTP2ErrorCode.swift
+++ b/Sources/NIOHTTP2/HTTP2ErrorCode.swift
@@ -158,9 +158,9 @@ public extension ByteBuffer {
     /// Serializes a ``HTTP2ErrorCode`` into a `ByteBuffer` in the appropriate endianness
     /// for use in HTTP/2.
     ///
-    /// - parameters:
-    ///     - code: The ``HTTP2ErrorCode`` to serialize.
-    /// - returns: The number of bytes written.
+    /// - Parameters:
+    ///   - code: The ``HTTP2ErrorCode`` to serialize.
+    /// - Returns: The number of bytes written.
     mutating func write(http2ErrorCode code: HTTP2ErrorCode) -> Int {
         return self.writeInteger(UInt32(http2ErrorCode: code))
     }

--- a/Sources/NIOHTTP2/HTTP2FlowControlWindow.swift
+++ b/Sources/NIOHTTP2/HTTP2FlowControlWindow.swift
@@ -48,7 +48,7 @@ struct HTTP2FlowControlWindow {
     /// - A stream was created with initial window size of 2 ** 31 - 1 (a.k.a. Int32.max)
     /// - Int32.max bytes were sent, leaving the window size at zero.
     /// - The value of SETTINGS_INITIAL_WINDOW_SIZE was set to 0, leading to a window size delta of
-    ///     -(Int32.max), and setting the window size to -(Int32.max).
+    ///   -(Int32.max), and setting the window size to -(Int32.max).
     ///
     /// As -(Int32.max) definitionally still fits into Int32, Int32 is the appropriate type to use here.
     fileprivate private(set) var windowSize: Int32
@@ -79,8 +79,8 @@ struct HTTP2FlowControlWindow {
     /// the valid values of a WINDOW_UPDATE frame. It is assumed that the frame parser validates the values in
     /// WINDOW_UPDATE frames.
     ///
-    /// - parameters:
-    ///     - amount: The size of the increment.
+    /// - Parameters:
+    ///   - amount: The size of the increment.
     /// - throws: When `amount` is outside of RFC 7540's allowed range, or when it would move this value outside
     ///     of the allowed range.
     mutating func windowUpdate(by amount: UInt32) throws {
@@ -109,8 +109,8 @@ struct HTTP2FlowControlWindow {
     /// This method will throw if this change forces the flow control window size to become larger than the maximum flow
     /// control window size.
     ///
-    /// - parameters:
-    ///     - amount: The size of the increment/decrement.
+    /// - Parameters:
+    ///   - amount: The size of the increment/decrement.
     /// - throws: When `amount` would move the flow control window outside the allowed range.
     mutating func initialSizeChanged(by amount: Int32) throws {
         assert(amount >= -(Int32.max))
@@ -124,8 +124,8 @@ struct HTTP2FlowControlWindow {
 
     /// Consume a portion of the flow control window.
     ///
-    /// - parameters:
-    ///     - flowControlledBytes: The number of flow controlled bytes to consume
+    /// - Parameters:
+    ///   - flowControlledBytes: The number of flow controlled bytes to consume
     mutating func consume(flowControlledBytes size: Int) throws {
         assert(size >= 0)
         // TODO(cory): This is the max value of SETTINGS_MAX_FRAME_SIZE, we should name this thing.

--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -763,7 +763,7 @@ struct HTTP2FrameDecoder {
     /// Attempts to decode a frame from the accumulated bytes passed to
     /// `append(bytes:)`.
     ///
-    /// - returns: A decoded frame, or `nil` if no frame could be decoded.
+    /// - Returns: A decoded frame, or `nil` if no frame could be decoded.
     /// - throws: An error if a decoded frame violated the HTTP/2 protocol
     ///           rules.
     mutating func nextFrame() throws -> (HTTP2Frame, flowControlledLength: Int)? {

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -50,14 +50,14 @@ extension ChannelPipeline {
     ///
     /// This configuration is acceptable for use on both client and server channel pipelines.
     ///
-    /// - parameters:
-    ///     - h2PipelineConfigurator: A callback that will be invoked if HTTP/2 has been negogiated, and that
+    /// - Parameters:
+    ///   - h2PipelineConfigurator: A callback that will be invoked if HTTP/2 has been negogiated, and that
     ///         should configure the pipeline for HTTP/2 use. Must return a future that completes when the
     ///         pipeline has been fully mutated.
-    ///     - http1PipelineConfigurator: A callback that will be invoked if HTTP/1.1 has been explicitly
+    ///   - http1PipelineConfigurator: A callback that will be invoked if HTTP/1.1 has been explicitly
     ///         negotiated, or if no protocol was negotiated. Must return a future that completes when the
     ///         pipeline has been fully mutated.
-    /// - returns: An `EventLoopFuture<Void>` that completes when the pipeline is ready to negotiate.
+    /// - Returns: An `EventLoopFuture<Void>` that completes when the pipeline is ready to negotiate.
     @available(*, deprecated, renamed: "Channel.configureHTTP2SecureUpgrade(h2ChannelConfigurator:http1ChannelConfigurator:)")
     public func configureHTTP2SecureUpgrade(h2PipelineConfigurator: @escaping (ChannelPipeline) -> EventLoopFuture<Void>,
                                             http1PipelineConfigurator: @escaping (ChannelPipeline) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
@@ -87,14 +87,14 @@ extension Channel {
     /// Instead, this simply adds the handlers required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
     /// Whenever possible use this function to setup a HTTP/2 server pipeline, as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - position: The position in the pipeline into which to insert these handlers.
-    ///     - inboundStreamStateInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
+    ///   - position: The position in the pipeline into which to insert these handlers.
+    ///   - inboundStreamStateInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
     ///         be provided, especially on servers.
-    /// - returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
+    /// - Returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
     @available(*, deprecated, renamed: "configureHTTP2Pipeline(mode:initialLocalSettings:position:targetWindowSize:inboundStreamInitializer:)")
     public func configureHTTP2Pipeline(mode: NIOHTTP2Handler.ParserMode,
                                        initialLocalSettings: [HTTP2Setting] = nioDefaultSettings,
@@ -109,15 +109,15 @@ extension Channel {
     /// Instead, this simply adds the handlers required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
     /// Whenever possible use this function to setup a HTTP/2 server pipeline, as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - position: The position in the pipeline into which to insert these handlers.
-    ///     - targetWindowSize: The target size of the HTTP/2 flow control window.
-    ///     - inboundStreamStateInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
+    ///   - position: The position in the pipeline into which to insert these handlers.
+    ///   - targetWindowSize: The target size of the HTTP/2 flow control window.
+    ///   - inboundStreamStateInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
     ///         be provided, especially on servers.
-    /// - returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
+    /// - Returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
     @available(*, deprecated, renamed: "configureHTTP2Pipeline(mode:initialLocalSettings:position:targetWindowSize:inboundStreamInitializer:)")
     public func configureHTTP2Pipeline(mode: NIOHTTP2Handler.ParserMode,
                                        initialLocalSettings: [HTTP2Setting] = nioDefaultSettings,
@@ -139,15 +139,15 @@ extension Channel {
     /// Instead, this simply adds the handlers required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
     /// Whenever possible use this function to setup a HTTP/2 server pipeline, as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - initialLocalSettings: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - position: The position in the pipeline into which to insert these handlers.
-    ///     - targetWindowSize: The target size of the HTTP/2 flow control window.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
+    ///   - position: The position in the pipeline into which to insert these handlers.
+    ///   - targetWindowSize: The target size of the HTTP/2 flow control window.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream. This should almost always
     ///         be provided, especially on servers.
-    /// - returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
+    /// - Returns: An `EventLoopFuture` containing the `HTTP2StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
     public func configureHTTP2Pipeline(mode: NIOHTTP2Handler.ParserMode,
                                        initialLocalSettings: [HTTP2Setting] = nioDefaultSettings,
                                        position: ChannelPipeline.Position = .last,
@@ -168,15 +168,15 @@ extension Channel {
     /// Instead, this simply adds the handler required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
     /// Whenever possible use this function to setup a HTTP/2 server pipeline, as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert this handler.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert this handler.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
     public func configureHTTP2Pipeline(mode: NIOHTTP2Handler.ParserMode,
                                        connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
                                        streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
@@ -215,16 +215,16 @@ extension Channel {
     /// Use this function to setup a HTTP/2 pipeline if you wish to use async sequence abstractions over inbound and outbound streams.
     /// Using this rather than implementing a similar function yourself allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert this handler.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
-    /// be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert this handler.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
+    ///     be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public func configureAsyncHTTP2Pipeline<Output>(
@@ -269,25 +269,25 @@ extension Channel {
     ///
     /// Using this rather than implementing a similar function yourself allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
-    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
-    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.     
-    ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
-    ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
-    ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
-    /// inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
-    /// and iterate over inbound HTTP/2 stream channels.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///   - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
+    ///         This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
+    ///         This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
+    ///     inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
+    ///     and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public func configureAsyncHTTP2Pipeline<StreamInbound, StreamOutbound>(
@@ -352,14 +352,14 @@ extension Channel {
     ///
     /// This configuration is acceptable for use on both client and server channel pipelines.
     ///
-    /// - parameters:
-    ///     - h2ChannelConfigurator: A callback that will be invoked if HTTP/2 has been negogiated, and that
+    /// - Parameters:
+    ///   - h2ChannelConfigurator: A callback that will be invoked if HTTP/2 has been negogiated, and that
     ///         should configure the channel for HTTP/2 use. Must return a future that completes when the
     ///         channel has been fully mutated.
-    ///     - http1ChannelConfigurator: A callback that will be invoked if HTTP/1.1 has been explicitly
+    ///   - http1ChannelConfigurator: A callback that will be invoked if HTTP/1.1 has been explicitly
     ///         negotiated, or if no protocol was negotiated. Must return a future that completes when the
     ///         channel has been fully mutated.
-    /// - returns: An `EventLoopFuture<Void>` that completes when the channel is ready to negotiate.
+    /// - Returns: An `EventLoopFuture<Void>` that completes when the channel is ready to negotiate.
     public func configureHTTP2SecureUpgrade(h2ChannelConfigurator: @escaping (Channel) -> EventLoopFuture<Void>,
                                             http1ChannelConfigurator: @escaping (Channel) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         let alpnHandler = ApplicationProtocolNegotiationHandler { result in
@@ -389,13 +389,13 @@ extension Channel {
     /// This function doesn't configure the TLS handler. Callers of this function need to add a TLS
     /// handler appropriately configured to perform protocol negotiation.
     ///
-    /// - parameters:
-    ///     - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
+    /// - Parameters:
+    ///   - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
     ///         when the negotiated protocol is H2 to configure the connection channel.
-    ///     - configurator: A callback that will be invoked after a protocol has been negotiated.
+    ///   - configurator: A callback that will be invoked after a protocol has been negotiated.
     ///         The callback only needs to add application-specific handlers and must return a future
     ///         that completes when the channel has been fully mutated.
-    /// - returns: `EventLoopFuture<Void>` that completes when the channel is ready.
+    /// - Returns: `EventLoopFuture<Void>` that completes when the channel is ready.
     public func configureCommonHTTPServerPipeline(
         h2ConnectionChannelConfigurator: ((Channel) -> EventLoopFuture<Void>)? = nil,
         _ configurator: @escaping (Channel) -> EventLoopFuture<Void>
@@ -412,14 +412,14 @@ extension Channel {
     /// This function doesn't configure the TLS handler. Callers of this function need to add a TLS
     /// handler appropriately configured to perform protocol negotiation.
     ///
-    /// - parameters:
-    ///     - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
+    /// - Parameters:
+    ///   - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
     ///         when the negotiated protocol is H2 to configure the connection channel.
-    ///     - targetWindowSize: The target size of the HTTP/2 flow control window.
-    ///     - configurator: A callback that will be invoked after a protocol has been negotiated.
+    ///   - targetWindowSize: The target size of the HTTP/2 flow control window.
+    ///   - configurator: A callback that will be invoked after a protocol has been negotiated.
     ///         The callback only needs to add application-specific handlers and must return a future
     ///         that completes when the channel has been fully mutated.
-    /// - returns: `EventLoopFuture<Void>` that completes when the channel is ready.
+    /// - Returns: `EventLoopFuture<Void>` that completes when the channel is ready.
     public func configureCommonHTTPServerPipeline(
         h2ConnectionChannelConfigurator: ((Channel) -> EventLoopFuture<Void>)? = nil,
         targetWindowSize: Int,
@@ -466,15 +466,15 @@ extension Channel {
     /// This function doesn't configure the TLS handler. Callers of this function need to add a TLS
     /// handler appropriately configured to perform protocol negotiation.
     ///
-    /// - parameters:
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - h2ConnectionChannelConfigurator: An optional callback that will be invoked only
     ///         when the negotiated protocol is H2 to configure the connection channel.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: `EventLoopFuture<Void>` that completes when the channel is ready.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: `EventLoopFuture<Void>` that completes when the channel is ready.
     public func configureCommonHTTPServerPipeline(
         connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
         streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
@@ -506,32 +506,32 @@ extension Channel {
     /// 
     /// Using this rather than implementing a similar function yourself allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
-    ///     - connectionBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
-    ///     - isConnectionOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
-    ///     - connectionInboundType: The ``NIOAsyncChannel/inboundStream`` message type for the HTTP/2 connection channel.
-    ///     This type must match the `InboundOut` type of the final handler in the connection channel.
-    ///     - connectionOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the HTTP/2 connection channel.
-    ///     This type must match the `OutboundIn` type of the final handler in the connection channel.
-    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
-    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
-    ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
-    ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
-    ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - connectionInitializer: A closure that will be called once the `NIOHTTP2Handler` has been added to the pipeline.     
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
-    /// inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
-    /// and iterate over inbound HTTP/2 stream channels.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///   - connectionBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
+    ///   - isConnectionOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel`` wrapping the HTTP/2 connection channel.
+    ///   - connectionInboundType: The ``NIOAsyncChannel/inboundStream`` message type for the HTTP/2 connection channel.
+    ///         This type must match the `InboundOut` type of the final handler in the connection channel.
+    ///   - connectionOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for the HTTP/2 connection channel.
+    ///         This type must match the `OutboundIn` type of the final handler in the connection channel.
+    ///   - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
+    ///         This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
+    ///         This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - connectionInitializer: A closure that will be called once the `NIOHTTP2Handler` has been added to the pipeline.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
+    ///     inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
+    ///     and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public func configureAsyncHTTP2Pipeline<ConnectionInbound, ConnectionOutbound, StreamInbound, StreamOutbound>(
@@ -587,15 +587,15 @@ extension ChannelPipeline.SynchronousOperations {
     /// Instead, this simply adds the handler required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
     /// Whenever possible use this function to setup a HTTP/2 server pipeline, as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert this handler.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: The `StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert this handler.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: The `StreamMultiplexer` inserted into this pipeline, which can be used to initiate new streams.
     public func configureHTTP2Pipeline(mode: NIOHTTP2Handler.ParserMode,
                                        connectionConfiguration: NIOHTTP2Handler.ConnectionConfiguration,
                                        streamConfiguration: NIOHTTP2Handler.StreamConfiguration,
@@ -626,15 +626,15 @@ extension ChannelPipeline.SynchronousOperations {
     /// Use this function to setup a HTTP/2 pipeline if you wish to use async sequence abstractions over inbound and outbound streams,
     /// as it allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert this handler.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert this handler.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
     /// be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
@@ -673,25 +673,25 @@ extension ChannelPipeline.SynchronousOperations {
     /// 
     /// Using this rather than implementing a similar function yourself allows that pipeline to evolve without breaking your code.
     ///
-    /// - parameters:
-    ///     - mode: The mode this pipeline will operate in, server or client.
-    ///     - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
-    ///     - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///     - streamDelegate: The delegate to be notified in the event of stream creation and close.
-    ///     - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
-    ///     - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
-    ///     - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
-    ///     - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
-    ///     This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
-    ///     This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
-    ///     or ``HTTP2Frame/FramePayload`` if there are none.
-    ///     - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    /// - returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
-    /// inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
-    /// and iterate over inbound HTTP/2 stream channels.
+    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
+    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - position: The position in the pipeline into which to insert the `NIOHTTP2Handler`.
+    ///   - inboundStreamBackpressureStrategy: The backpressure strategy of the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - isInboundStreamOutboundHalfClosureEnabled: If outbound half closure should be enabled for the ``NIOAsyncChannel``s wrapping inbound HTTP/2 streams.
+    ///   - streamInboundType: The ``NIOAsyncChannel/inboundStream`` message type for inbound stream channels.
+    ///         This type must match the `InboundOut` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - streamOutboundType: The ``NIOAsyncChannel/outboundWriter`` message type for inbound stream channels.
+    ///         This type must match the `OutboundIn` type of the final handler added to the stream channel by the `inboundStreamInitializer`
+    ///         or ``HTTP2Frame/FramePayload`` if there are none.
+    ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline which wraps
+    ///     inbound streams as `NIOAsyncChannels` after initialization. The multiplexer can be used to initiate new streams
+    ///     and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public func configureAsyncHTTP2Pipeline<StreamInbound, StreamOutbound>(

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -800,8 +800,8 @@ private extension HTTP2StreamChannel {
 internal extension HTTP2StreamChannel {
     /// Called when a frame is received from the network.
     ///
-    /// - parameters:
-    ///     - frame: The `HTTP2Frame` received from the network.
+    /// - Parameters:
+    ///   - frame: The `HTTP2Frame` received from the network.
     func receiveInboundFrame(_ frame: HTTP2Frame) {
         guard self.state != .closed else {
             // Do nothing
@@ -828,9 +828,9 @@ internal extension HTTP2StreamChannel {
 
     /// Called when a frame is sent to the network.
     ///
-    /// - parameters:
-    ///     - frame: The `HTTP2Frame` to send to the network.
-    ///     - promise: The promise associated with the frame write.
+    /// - Parameters:
+    ///   - frame: The `HTTP2Frame` to send to the network.
+    ///   - promise: The promise associated with the frame write.
     private func receiveOutboundFrame(_ frame: HTTP2Frame, promise: EventLoopPromise<Void>?) {
         guard self.state != .closed else {
             let error = ChannelError.alreadyClosed
@@ -843,8 +843,8 @@ internal extension HTTP2StreamChannel {
 
     /// Called when a stream closure is received from the network.
     ///
-    /// - parameters:
-    ///     - reason: The reason received from the network, if any.
+    /// - Parameters:
+    ///   - reason: The reason received from the network, if any.
     func receiveStreamClosed(_ reason: HTTP2ErrorCode?) {
         // Avoid emitting any WINDOW_UPDATE frames now that we're closed.
         self.windowManager.closed = true

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -133,11 +133,11 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
 
     /// Create a new ``HTTP2StreamMultiplexer``.
     ///
-    /// - parameters:
-    ///     - mode: The mode of the HTTP/2 connection being used: server or client.
-    ///     - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
-    ///     - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
-    ///     - inboundStreamStateInitializer: A block that will be invoked to configure each new child stream
+    /// - Parameters:
+    ///   - mode: The mode of the HTTP/2 connection being used: server or client.
+    ///   - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
+    ///   - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
+    ///   - inboundStreamStateInitializer: A block that will be invoked to configure each new child stream
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
@@ -156,17 +156,17 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
 
     /// Create a new ``HTTP2StreamMultiplexer``.
     ///
-    /// - parameters:
-    ///     - mode: The mode of the HTTP/2 connection being used: server or client.
-    ///     - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
-    ///     - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
-    ///     - outboundBufferSizeHighWatermark: The high watermark for the number of bytes of writes that are
+    /// - Parameters:
+    ///   - mode: The mode of the HTTP/2 connection being used: server or client.
+    ///   - channel: The Channel to which this ``HTTP2StreamMultiplexer`` belongs.
+    ///   - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
+    ///   - outboundBufferSizeHighWatermark: The high watermark for the number of bytes of writes that are
     ///         allowed to be un-sent on any child stream. This is broadly analogous to a regular socket send buffer.
     ///         Defaults to 8196 bytes.
-    ///     - outboundBufferSizeLowWatermark: The low watermark for the number of bytes of writes that are
+    ///   - outboundBufferSizeLowWatermark: The low watermark for the number of bytes of writes that are
     ///         allowed to be un-sent on any child stream. This is broadly analogous to a regular socket send buffer.
     ///         Defaults to 4092 bytes.
-    ///     - inboundStreamInitializer: A block that will be invoked to configure each new child stream
+    ///   - inboundStreamInitializer: A block that will be invoked to configure each new child stream
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
@@ -187,15 +187,15 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
 
     /// Create a new ``HTTP2StreamMultiplexer``.
     ///
-    /// - parameters:
-    ///     - mode: The mode of the HTTP/2 connection being used: server or client.
-    ///     - channel: The Channel to which this `HTTP2StreamMultiplexer` belongs.
-    ///     - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
-    ///     - outboundBufferSizeHighWatermark: The high watermark for the number of bytes of writes that are
+    /// - Parameters:
+    ///   - mode: The mode of the HTTP/2 connection being used: server or client.
+    ///   - channel: The Channel to which this `HTTP2StreamMultiplexer` belongs.
+    ///   - targetWindowSize: The target inbound connection and stream window size. Defaults to 65535 bytes.
+    ///   - outboundBufferSizeHighWatermark: The high watermark for the number of bytes of writes that are
     ///         allowed to be un-sent on any child stream. This is broadly analogous to a regular socket send buffer.
-    ///     - outboundBufferSizeLowWatermark: The low watermark for the number of bytes of writes that are
+    ///   - outboundBufferSizeLowWatermark: The low watermark for the number of bytes of writes that are
     ///         allowed to be un-sent on any child stream. This is broadly analogous to a regular socket send buffer.
-    ///     - inboundStreamStateInitializer: A block that will be invoked to configure each new child stream
+    ///   - inboundStreamStateInitializer: A block that will be invoked to configure each new child stream
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
@@ -244,10 +244,10 @@ extension HTTP2StreamMultiplexer {
     ///
     /// > Note: Resources for the stream will be freed after it has been closed.
     ///
-    /// - parameters:
-    ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
+    /// - Parameters:
+    ///   - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
     ///         failed if an error occurs.
-    ///     - streamStateInitializer: A callback that will be invoked to allow you to configure the
+    ///   - streamStateInitializer: A callback that will be invoked to allow you to configure the
     ///         `ChannelPipeline` for the newly created channel.
     public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>) {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .legacy(LegacyOutboundStreamMultiplexer(multiplexer: self)), promise: promise, streamStateInitializer)
@@ -260,10 +260,10 @@ extension HTTP2StreamMultiplexer {
     ///
     /// > Note: Resources for the stream will be freed after it has been closed.
     ///
-    /// - parameters:
-    ///     - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
+    /// - Parameters:
+    ///   - promise: An `EventLoopPromise` that will be succeeded with the new activated channel, or
     ///         failed if an error occurs.
-    ///     - streamStateInitializer: A callback that will be invoked to allow you to configure the
+    ///   - streamStateInitializer: A callback that will be invoked to allow you to configure the
     ///         `ChannelPipeline` for the newly created channel.
     @available(*, deprecated, message: "The signature of 'streamStateInitializer' has changed to '(Channel) -> EventLoopFuture<Void>'")
     public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping (Channel, HTTP2StreamID) -> EventLoopFuture<Void>) {

--- a/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
+++ b/Sources/NIOHTTP2/HTTP2ToHTTP1Codec.swift
@@ -28,9 +28,9 @@ fileprivate struct BaseClientCodec {
 
     /// Initializes a `BaseClientCodec`.
     ///
-    /// - parameters:
-    ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
-    ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
+    /// - Parameters:
+    ///   - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
+    ///   - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
     ///                            headers related to HTTP/1's keep-alive behaviour. Unless you are sure that all your
@@ -142,10 +142,10 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
 
     /// Initializes a ``HTTP2ToHTTP1ClientCodec`` for the given ``HTTP2StreamID``.
     ///
-    /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
-    ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
-    ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
+    /// - Parameters:
+    ///   - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
+    ///   - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
+    ///   - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
     ///                            headers related to HTTP/1's keep-alive behaviour. Unless you are sure that all your
@@ -157,9 +157,9 @@ public final class HTTP2ToHTTP1ClientCodec: ChannelInboundHandler, ChannelOutbou
 
     /// Initializes a ``HTTP2ToHTTP1ClientCodec`` for the given ``HTTP2StreamID``.
     ///
-    /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
-    ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
+    /// - Parameters:
+    ///   - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ClientCodec`` will be used for
+    ///   - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
     public convenience init(streamID: HTTP2StreamID, httpProtocol: HTTPProtocol) {
         self.init(streamID: streamID, httpProtocol: httpProtocol, normalizeHTTPHeaders: true)
     }
@@ -218,9 +218,9 @@ public final class HTTP2FramePayloadToHTTP1ClientCodec: ChannelInboundHandler, C
 
     /// Initializes a ``HTTP2FramePayloadToHTTP1ClientCodec``.
     ///
-    /// - parameters:
-    ///    - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
-    ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
+    /// - Parameters:
+    ///   - httpProtocol: The protocol (usually `"http"` or `"https"` that is used).
+    ///   - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
     ///                            headers related to HTTP/1's keep-alive behaviour. Unless you are sure that all your
@@ -344,9 +344,9 @@ public final class HTTP2ToHTTP1ServerCodec: ChannelInboundHandler, ChannelOutbou
 
     /// Initializes a ``HTTP2ToHTTP1ServerCodec`` for the given ``HTTP2StreamID``.
     ///
-    /// - parameters:
-    ///    - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ServerCodec`` will be used for
-    ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
+    /// - Parameters:
+    ///   - streamID: The HTTP/2 stream ID this ``HTTP2ToHTTP1ServerCodec`` will be used for
+    ///   - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
     ///                            headers related to HTTP/1's keep-alive behaviour. Unless you are sure that all your
@@ -403,8 +403,8 @@ public final class HTTP2FramePayloadToHTTP1ServerCodec: ChannelInboundHandler, C
 
     /// Initializes a ``HTTP2FramePayloadToHTTP1ServerCodec``.
     ///
-    /// - parameters:
-    ///    - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
+    /// - Parameters:
+    ///   - normalizeHTTPHeaders: Whether to automatically normalize the HTTP headers to be suitable for HTTP/2.
     ///                            The normalization will for example lower-case all header names (as required by the
     ///                            HTTP/2 spec) and remove headers that are unsuitable for HTTP/2 such as
     ///                            headers related to HTTP/1's keep-alive behaviour. Unless you are sure that all your
@@ -614,8 +614,8 @@ extension HPACKHeaders {
     /// Grabs a pseudo-header from a header block. Does not remove it.
     ///
     /// - parameter:
-    ///     - name: The header name to find.
-    /// - returns: The value for this pseudo-header.
+    ///   - name: The header name to find.
+    /// - Returns: The value for this pseudo-header.
     /// - throws: If there is no such header, or multiple.
     internal func peekPseudoHeader(name: String) throws -> String {
         // This could be done with .lazy.filter.map but that generates way more ARC traffic.

--- a/Sources/NIOHTTP2/StreamMap.swift
+++ b/Sources/NIOHTTP2/StreamMap.swift
@@ -161,10 +161,10 @@ internal extension StreamMap where Element == HTTP2StreamStateMachine {
     //
     /// Transform the value of an HTTP2StreamStateMachine, closing it if it ends up closed.
     ///
-    /// - parameters:
-    ///     - modifier: A block that will modify the contained value in the
+    /// - Parameters:
+    ///   - modifier: A block that will modify the contained value in the
     ///          map, if there is one present.
-    /// - returns: The return value of the block or `nil` if the element was not present.
+    /// - Returns: The return value of the block or `nil` if the element was not present.
     mutating func autoClosingTransform<T>(streamID: HTTP2StreamID, _ modifier: (inout Element) -> T) -> T? {
         if streamID.mayBeInitiatedBy(.client) {
             return self.clientInitiated.autoClosingTransform(streamID: streamID, modifier)
@@ -295,10 +295,10 @@ extension CircularBuffer where Element == HTTP2StreamStateMachine {
     //
     /// Transform the value of an HTTP2StreamStateMachine, closing it if it ends up closed.
     ///
-    /// - parameters:
-    ///     - modifier: A block that will modify the contained value in the
+    /// - Parameters:
+    ///   - modifier: A block that will modify the contained value in the
     ///         map, if there is one present.
-    /// - returns: The return value of the block or `nil` if the element was not in the map.
+    /// - Returns: The return value of the block or `nil` if the element was not in the map.
     mutating func autoClosingTransform<ResultType>(streamID: HTTP2StreamID, _ modifier: (inout Element) -> ResultType) -> ResultType? {
         guard let index = self.findIndexForStreamID(streamID) else {
             return nil


### PR DESCRIPTION
Motivation:

Tweaking the formatting of the DocC comments enables syntax highlighting for parameter names in Xcode

Modifications:

Whitespace changes, capitalisation changes and added a parameter description for `indexing` in HOACKHeaders `replaceOrAdd`, `add`.

Result:

More readable DocC comments