### PR TITLE
HTTP/2 negotiated connection pipeline config

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -253,8 +253,8 @@ extension NIOHTTP2Handler {
         @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
         @_spi(AsyncChannel)
         public func createStreamChannel<Inbound, Outbound>(
-            configuration: NIOAsyncChannel<Inbound, Outbound>.Configuration,
-            initializer: @escaping NIOHTTP2Handler.StreamInitializer
+            configuration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init(),
+            initializer: @escaping NIOChannelInitializer
         ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
             return try await self.createStreamChannel { channel in
                 initializer(channel).flatMapThrowing { _ in

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -148,7 +148,7 @@ extension InlineStreamMultiplexer {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .inline(self), streamStateInitializer)
     }
 
-    internal func createStreamChannel<Output>(_ initializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>) -> EventLoopFuture<Output> {
+    internal func createStreamChannel<Output>(_ initializer: @escaping NIOChannelInitializerWithOutput<Output>) -> EventLoopFuture<Output> {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .inline(self), initializer)
     }
 }
@@ -239,7 +239,7 @@ extension NIOHTTP2Handler {
         }
 
         /// Create a stream channel initialized with the provided closure
-        public func createStreamChannel<OutboundStreamOutput>(_ initializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
+        public func createStreamChannel<OutboundStreamOutput>(_ initializer: @escaping NIOChannelInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
             return try await self.inlineStreamMultiplexer.createStreamChannel(initializer).get()
         }
 

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -23,7 +23,6 @@ public let nioDefaultSettings = [
     HTTP2Setting(parameter: .maxHeaderListSize, value: HPACKDecoder.defaultMaxHeaderListSize),
 ]
 
-
 /// ``NIOHTTP2Handler`` implements the HTTP/2 protocol for a single connection.
 ///
 /// This `ChannelHandler` takes a series of bytes and turns them into a sequence of ``HTTP2Frame`` objects.
@@ -988,23 +987,11 @@ extension NIOHTTP2Handler {
 
 extension NIOHTTP2Handler {
 #if swift(>=5.7)
-    /// The type of all `inboundStreamInitializer` callbacks.
-    public typealias StreamInitializer = @Sendable (Channel) -> EventLoopFuture<Void>
-    /// The type of all `connectionInitializer` callbacks.
-    public typealias ConnectionInitializer = @Sendable (Channel) -> EventLoopFuture<Void>
-    /// The type of `inboundStreamInitializer` callbacks which return non-void results.
-    public typealias StreamInitializerWithOutput<Output> = @Sendable (Channel) -> EventLoopFuture<Output>
-    /// The type of all `connectionInitializer` callbacks which return non-void results.
-    public typealias ConnectionInitializerWithOutput<Output> = @Sendable (Channel) -> EventLoopFuture<Output>
+    /// The type of all `inboundStreamInitializer` callbacks which do not need to return data.
+    public typealias StreamInitializer = NIOChannelInitializer
 #else
-    /// The type of all `inboundStreamInitializer` callbacks.
-    public typealias StreamInitializer = (Channel) -> EventLoopFuture<Void>
-    /// The type of all `connectionInitializer` callbacks.
-    public typealias ConnectionInitializer = (Channel) -> EventLoopFuture<Void>
-    /// The type of `inboundStreamInitializer` callbacks which return non-void results.
-    public typealias StreamInitializerWithOutput<Output> = (Channel) -> EventLoopFuture<Output>
-    /// The type of all `connectionInitializer` callbacks which return non-void results.
-    public typealias ConnectionInitializerWithOutput<Output> = (Channel) -> EventLoopFuture<Output>
+    /// The type of all `inboundStreamInitializer` callbacks which need to return data.
+    public typealias StreamInitializer = NIOChannelInitializer
 #endif
 
     /// Creates a new ``NIOHTTP2Handler`` with a local multiplexer. (i.e. using

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1052,10 +1052,19 @@ extension NIOHTTP2Handler {
     public struct Configuration: Hashable, Sendable {
         /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the
         /// handshake.
-        public var connection: ConnectionConfiguration = .init()
+        public var connection: ConnectionConfiguration
         /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
-        public var stream: StreamConfiguration = .init()
-        public init() {}
+        public var stream: StreamConfiguration
+
+        public init() {
+            self.connection = .init()
+            self.stream = .init()
+        }
+
+        public init(connection: ConnectionConfiguration, stream: StreamConfiguration) {
+            self.connection = connection
+            self.stream = stream
+        }
     }
 
     /// An `EventLoopFuture` which returns a ``StreamMultiplexer`` which can be used to create new outbound HTTP/2 streams.

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -994,6 +994,8 @@ extension NIOHTTP2Handler {
     public typealias ConnectionInitializer = @Sendable (Channel) -> EventLoopFuture<Void>
     /// The type of `inboundStreamInitializer` callbacks which return non-void results.
     public typealias StreamInitializerWithOutput<Output> = @Sendable (Channel) -> EventLoopFuture<Output>
+    /// The type of all `connectionInitializer` callbacks which return non-void results.
+    public typealias ConnectionInitializerWithOutput<Output> = @Sendable (Channel) -> EventLoopFuture<Output>
 #else
     /// The type of all `inboundStreamInitializer` callbacks.
     public typealias StreamInitializer = (Channel) -> EventLoopFuture<Void>
@@ -1001,6 +1003,8 @@ extension NIOHTTP2Handler {
     public typealias ConnectionInitializer = (Channel) -> EventLoopFuture<Void>
     /// The type of `inboundStreamInitializer` callbacks which return non-void results.
     public typealias StreamInitializerWithOutput<Output> = (Channel) -> EventLoopFuture<Output>
+    /// The type of all `connectionInitializer` callbacks which return non-void results.
+    public typealias ConnectionInitializerWithOutput<Output> = (Channel) -> EventLoopFuture<Output>
 #endif
 
     /// Creates a new ``NIOHTTP2Handler`` with a local multiplexer. (i.e. using

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1026,6 +1026,9 @@ extension NIOHTTP2Handler {
     }
 
     /// Connection-level configuration.
+    ///
+    /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+    /// handshake.
     public struct ConnectionConfiguration: Hashable, Sendable {
         public var initialSettings: HTTP2Settings = nioDefaultSettings
         public var headerBlockValidation: ValidationState = .enabled
@@ -1036,10 +1039,22 @@ extension NIOHTTP2Handler {
     }
 
     /// Stream-level configuration.
+    ///
+    /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
     public struct StreamConfiguration: Hashable, Sendable {
         public var targetWindowSize: Int = 65535
         public var outboundBufferSizeHighWatermark: Int = 8196
         public var outboundBufferSizeLowWatermark: Int = 4092
+        public init() {}
+    }
+
+    /// Overall connection and stream-level configuration.
+    public struct Configuration: Hashable, Sendable {
+        /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the
+        /// handshake.
+        public var connection: ConnectionConfiguration = .init()
+        /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
+        public var stream: StreamConfiguration = .init()
         public init() {}
     }
 

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -286,7 +286,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
     internal func _createStreamChannel<Output>(
         _ multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         _ promise: EventLoopPromise<Output>?,
-        _ streamStateInitializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+        _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) {
         self.channel.eventLoop.assertInEventLoop()
 
@@ -307,7 +307,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
     internal func createStreamChannel<Output>(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         promise: EventLoopPromise<Output>?,
-        _ streamStateInitializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+        _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) {
         if self.channel.eventLoop.inEventLoop {
             self._createStreamChannel(multiplexer, promise, streamStateInitializer)
@@ -320,7 +320,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
 
     internal func createStreamChannel<Output>(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
-        _ streamStateInitializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+        _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) -> EventLoopFuture<Output> {
         let promise = self.channel.eventLoop.makePromise(of: Output.self)
         self.createStreamChannel(multiplexer: multiplexer, promise: promise, streamStateInitializer)
@@ -426,11 +426,11 @@ internal protocol ChannelContinuation {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct StreamChannelContinuation<Output>: ChannelContinuation {
     private var continuation: AsyncThrowingStream<Output, Error>.Continuation
-    private let inboundStreamInititializer: NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+    private let inboundStreamInititializer: NIOChannelInitializerWithOutput<Output>
 
     private init(
         continuation: AsyncThrowingStream<Output, Error>.Continuation,
-        inboundStreamInititializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+        inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) {
         self.continuation = continuation
         self.inboundStreamInititializer = inboundStreamInititializer
@@ -446,7 +446,7 @@ struct StreamChannelContinuation<Output>: ChannelContinuation {
     ///   have a `Output` corresponding to that `NIOAsyncChannel` type. Another example is in cases where there is
     ///   per-stream protocol negotiation where `Output` would be some form of `NIOProtocolNegotiationResult`.
     static func initialize(
-        with inboundStreamInititializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>
+        with inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) -> (StreamChannelContinuation<Output>, NIOHTTP2InboundStreamChannels<Output>) {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: Output.self)
         return (StreamChannelContinuation(continuation: continuation, inboundStreamInititializer: inboundStreamInititializer), NIOHTTP2InboundStreamChannels(stream))

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -660,10 +660,9 @@ extension ChannelPipeline.SynchronousOperations {
             eventLoop: self.eventLoop,
             connectionConfiguration: connectionConfiguration,
             streamConfiguration: streamConfiguration,
-            streamDelegate: streamDelegate
-        ) { channel in
-            inboundStreamInitializer(channel)
-        }
+            streamDelegate: streamDelegate,
+            inboundStreamInitializer: inboundStreamInitializer
+        )
 
         try self.addHandler(handler, position: position)
 
@@ -772,7 +771,7 @@ public enum NIONegotiatedHTTPVersion<HTTP1Output: Sendable, HTTP2Output: Sendabl
 /// `NIOHTTP2AsyncConfiguration` contains all configuration required for setting up an HTTP/2 async connection.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
-public struct NIOHTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2ConnectionOutbound: Sendable, HTTP2StreamInbound: Sendable, HTTP2StreamOutbound: Sendable>: Sendable {
+public struct NIOHTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2ConnectionOutbound: Sendable, HTTP2StreamInbound: Sendable, HTTP2StreamOutbound: Sendable> {
     /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
     public var connection: NIOHTTP2Handler.ConnectionConfiguration
     /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -274,7 +274,7 @@ extension Channel {
     ///
     /// - Parameters:
     ///   - mode: The mode this pipeline will operate in, server or client.
-    ///   - inboundStreamAsyncChannelConfiguration: Settings relating to `NIOAsyncChannel`s wrapping internal stream channels
+    ///   - inboundStreamAsyncChannelConfiguration: Settings relating to `NIOAsyncChannel`s wrapping internal stream channels.
     ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
     ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
@@ -389,7 +389,7 @@ extension Channel {
     ///         channel has been fully mutated.
     /// - Returns: An `EventLoopFuture` containing a ``NIOTypedApplicationProtocolNegotiationHandler`` that completes when the channel
     ///     is ready to negotiate. This can then be used to access the ``NIOProtocolNegotiationResult`` which may itself
-    ///     be waited on to retrieve the result of the negotiation
+    ///     be waited on to retrieve the result of the negotiation.
     internal func configureHTTP2AsyncSecureUpgrade<HTTP1Output, HTTP2Output>(
         http1ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP1Output>,
         http2ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP2Output>
@@ -549,7 +549,7 @@ extension Channel {
     ///   - http2InboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
     /// - Returns: An `EventLoopFuture` containing a ``NIOTypedApplicationProtocolNegotiationHandler`` that completes when the channel
     ///     is ready to negotiate. This can then be used to access the ``NIOProtocolNegotiationResult`` which may itself
-    ///     be waited on to retrieve the result of the negotiation
+    ///     be waited on to retrieve the result of the negotiation.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public func configureAsyncHTTPServerPipeline<HTTP1ConnectionOutput, HTTP2ConnectionOutput, HTTP2StreamOutput>(
@@ -681,10 +681,7 @@ extension ChannelPipeline.SynchronousOperations {
     ///
     /// - Parameters:
     ///   - mode: The mode this pipeline will operate in, server or client.
-    ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
-    ///         handshake.
-    ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
-    ///   - streamDelegate: The delegate to be notified in the event of stream creation and close.
+    ///   - configuration: The settings that will be used when establishing the connection and new streams.
     ///   - position: The position in the pipeline into which to insert this handler.
     ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
     /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
@@ -725,7 +722,7 @@ extension ChannelPipeline.SynchronousOperations {
     ///
     /// - Parameters:
     ///   - mode: The mode this pipeline will operate in, server or client.
-    ///   - inboundStreamAsyncChannelConfiguration: Settings relating to `NIOAsyncChannel`s wrapping internal stream channels
+    ///   - inboundStreamAsyncChannelConfiguration: Settings relating to `NIOAsyncChannel`s wrapping internal stream channels.
     ///   - connectionConfiguration: The settings that will be used when establishing the connection. These will be sent to the peer as part of the
     ///         handshake.
     ///   - streamConfiguration: The settings that will be used when establishing new streams. These mainly pertain to flow control.
@@ -806,6 +803,7 @@ public struct NIOHTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2
 }
 
 #if swift(>=5.7)
+// Unchecked sendable because `NIOAsyncChannel.Configuration` is actually sendable but not yet marked as such
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
 extension NIOHTTP2AsyncConfiguration: @unchecked Sendable {}

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -804,3 +804,9 @@ public struct NIOHTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2
         self.inboundStreamInitializer = inboundStreamInitializer
     }
 }
+
+#if swift(>=5.7)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@_spi(AsyncChannel)
+extension NIOHTTP2AsyncConfiguration: @unchecked Sendable {}
+#endif

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -604,7 +604,7 @@ extension Channel {
     @_spi(AsyncChannel)
     public func configureAsyncHTTP2Pipeline<ConnectionInbound, ConnectionOutbound, StreamInbound, StreamOutbound>(
         mode: NIOHTTP2Handler.ParserMode,
-        configuration: HTTP2AsyncConfiguration<ConnectionInbound, ConnectionOutbound, StreamInbound, StreamOutbound>
+        configuration: NIOHTTP2AsyncConfiguration<ConnectionInbound, ConnectionOutbound, StreamInbound, StreamOutbound>
     ) -> EventLoopFuture<(
         NIOAsyncChannel<ConnectionInbound, ConnectionOutbound>,
         NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>>
@@ -769,10 +769,10 @@ public enum NIONegotiatedHTTPVersion<HTTP1Output: Sendable, HTTP2Output: Sendabl
     case http2(HTTP2Output)
 }
 
-/// `HTTP2AsyncConfiguration` contains all configuration required for setting up an HTTP/2 async connection.
+/// `NIOHTTP2AsyncConfiguration` contains all configuration required for setting up an HTTP/2 async connection.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
-public struct HTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2ConnectionOutbound: Sendable, HTTP2StreamInbound: Sendable, HTTP2StreamOutbound: Sendable>: Sendable {
+public struct NIOHTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2ConnectionOutbound: Sendable, HTTP2StreamInbound: Sendable, HTTP2StreamOutbound: Sendable>: Sendable {
     /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
     public var connection: NIOHTTP2Handler.ConnectionConfiguration
     /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -724,7 +724,6 @@ extension ChannelPipeline.SynchronousOperations {
     /// 
     /// Using this rather than implementing a similar function yourself allows that pipeline to evolve without breaking your code.
     ///
-
     /// - Parameters:
     ///   - mode: The mode this pipeline will operate in, server or client.
     ///   - inboundStreamAsyncChannelConfiguration: Settings relating to `NIOAsyncChannel`s wrapping internal stream channels
@@ -745,12 +744,12 @@ extension ChannelPipeline.SynchronousOperations {
         position: ChannelPipeline.Position = .last,
         inboundStreamInitializer: @escaping NIOChannelInitializer
     ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<NIOAsyncChannel<StreamInbound, StreamOutbound>> {
-        var configuration = NIOHTTP2Handler.Configuration()
-        configuration.connection = connectionConfiguration
-        configuration.stream = streamConfiguration
         return try self.configureAsyncHTTP2Pipeline(
             mode: mode,
-            configuration: configuration,
+            configuration: .init(
+                connection: connectionConfiguration,
+                stream: streamConfiguration
+            ),
             position: position
         ) { channel in
             inboundStreamInitializer(channel).flatMapThrowing { _ in
@@ -765,7 +764,7 @@ extension ChannelPipeline.SynchronousOperations {
 
 /// `NIONegotiatedHTTPVersion` is a generic negotiation result holder for HTTP/1.1 and HTTP/2
 @_spi(AsyncChannel)
-public enum NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output> {
+public enum NIONegotiatedHTTPVersion<HTTP1Output: Sendable, HTTP2Output: Sendable> {
     case http1_1(HTTP1Output)
     case http2(HTTP2Output)
 }
@@ -773,7 +772,7 @@ public enum NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output> {
 /// `HTTP2AsyncConfiguration` contains all configuration required for setting up an HTTP/2 async connection.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
-public struct HTTP2AsyncConfiguration<HTTP2ConnectionInbound, HTTP2ConnectionOutbound, HTTP2StreamInbound, HTTP2StreamOutbound> {
+public struct HTTP2AsyncConfiguration<HTTP2ConnectionInbound: Sendable, HTTP2ConnectionOutbound: Sendable, HTTP2StreamInbound: Sendable, HTTP2StreamOutbound: Sendable>: Sendable {
     /// The settings that will be used when establishing new streams. These mainly pertain to flow control.
     public var connection: NIOHTTP2Handler.ConnectionConfiguration
     /// The settings that will be used when establishing the connection. These will be sent to the peer as part of the

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -230,7 +230,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         }
     }
 
-    internal func configure<Output>(initializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>, userPromise promise: EventLoopPromise<Output>?) {
+    internal func configure<Output>(initializer: @escaping NIOChannelInitializerWithOutput<Output>, userPromise promise: EventLoopPromise<Output>?) {
         assert(self.streamDataType == .framePayload)
         // We need to configure this channel. This involves doing four things:
         // 1. Setting our autoRead state from the parent

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -106,7 +106,7 @@ extension MultiplexerAbstractChannel {
         self.baseChannel.configure(initializer: initializer, userPromise: promise)
     }
 
-    func configure<Output>(initializer: @escaping NIOHTTP2Handler.StreamInitializerWithOutput<Output>, userPromise promise: EventLoopPromise<Output>?) {
+    func configure<Output>(initializer: @escaping NIOChannelInitializerWithOutput<Output>, userPromise promise: EventLoopPromise<Output>?) {
         self.baseChannel.configure(initializer: initializer, userPromise: promise)
     }
 

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -35,9 +35,11 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         self.serverChannel = nil
     }
 
-
     static let requestFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: HPACKHeaders([(":method", "GET"), (":authority", "localhost"), (":scheme", "https"), (":path", "/")]), endStream: true))
     static let responseFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: HPACKHeaders([(":status", "200")]), endStream: true))
+
+    static let requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: .GET, uri: "/testHTTP1")
+    static let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok, headers: HTTPHeaders([("transfer-encoding", "chunked")]))
 
     final class OKResponder: ChannelInboundHandler {
         typealias InboundIn = HTTP2Frame.FramePayload
@@ -57,6 +59,23 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         }
     }
 
+    final class HTTP1OKResponder: ChannelInboundHandler {
+        typealias InboundIn = HTTPServerRequestPart
+        typealias OutboundOut = HTTPServerResponsePart
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            guard case .end = self.unwrapInboundIn(data) else {
+                context.fireChannelRead(data)
+                return
+            }
+
+            context.write(self.wrapOutboundOut(.head(responseHead)), promise: nil)
+            context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+
+            context.fireChannelRead(data)
+        }
+    }
+
     final class SimpleRequest: ChannelInboundHandler {
         typealias InboundIn = HTTP2Frame.FramePayload
         typealias OutboundOut = HTTP2Frame.FramePayload
@@ -71,6 +90,8 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         }
     }
 
+    // `testBasicPipelineCommunicates` ensures that a client-server system set up to use async stream abstractions
+    // can communicate successfully.
     func testBasicPipelineCommunicates() async throws {
         let requestCount = 100
 
@@ -133,6 +154,8 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         serverRecorder.receivedFrames.assertFramePayloadsMatch(Array(repeating: ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload, count: requestCount))
     }
 
+    // `testNIOAsyncConnectionStreamChannelPipelineCommunicates` ensures that a client-server system set up to use `NIOAsyncChannel`
+    // wrappers around connection and stream channels can communicate successfully.
     func testNIOAsyncConnectionStreamChannelPipelineCommunicates() async throws {
         let requestCount = 100
 
@@ -220,6 +243,8 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
         }
     }
 
+    // `testNIOAsyncStreamChannelPipelineCommunicates` ensures that a client-server system set up to use `NIOAsyncChannel`
+    // wrappers around stream channels can communicate successfully.
     func testNIOAsyncStreamChannelPipelineCommunicates() async throws {
         let requestCount = 100
 
@@ -293,6 +318,201 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
 
             let serverInboundChannelCount = try await assertNoThrowWithValue(try await group.next()!)
             XCTAssertEqual(serverInboundChannelCount, requestCount, "We should have created one server-side channel as a result of the one HTTP/2 stream used.")
+        }
+    }
+
+    // `testNegotiatedHTTP2BasicPipelineCommunicates` ensures that a client-server system set up to use async stream abstractions
+    // can communicate successfully when HTTP/2 is negotiated.
+    func testNegotiatedHTTP2BasicPipelineCommunicates() async throws {
+        let requestCount = 100
+
+        let serverRecorder = InboundFramePayloadRecorder()
+
+        let clientMultiplexer = try await assertNoThrowWithValue(
+            try await self.clientChannel.configureAsyncHTTP2Pipeline(
+                mode: .client,
+                connectionConfiguration: .init(),
+                streamConfiguration: .init()
+            ) { channel -> EventLoopFuture<Channel> in
+                channel.eventLoop.makeSucceededFuture(channel)
+            }.get()
+        )
+
+        let nioProtocolNegotiationResultFuture = try self.serverChannel.configureAsyncHTTPServerPipeline(
+            connectionConfiguration: .init(),
+            streamConfiguration: .init()
+        ) { channel in
+            channel.eventLoop.makeSucceededVoidFuture()
+        } h2ConnectionChannelConfigurator: { channel in
+            channel.eventLoop.makeSucceededVoidFuture()
+        } streamInitializer: { channel -> EventLoopFuture<Channel> in
+            channel.pipeline.addHandlers([OKResponder(), serverRecorder]).map { _ in channel }
+        }
+
+        // Let's pretend the TLS handler did protocol negotiation for us
+        self.serverChannel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "h2"))
+
+        let nioProtocolNegotiationResult = try await nioProtocolNegotiationResultFuture.get()
+
+        try await assertNoThrow(try await self.assertDoHandshake(client: self.clientChannel, server: self.serverChannel))
+
+        let serverMultiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Channel>
+        switch nioProtocolNegotiationResult {
+        case .deferredResult:
+            preconditionFailure("Negotiation result must be ready")
+        case .finished(let negotiationResult):
+            switch negotiationResult {
+            case .http1_1:
+                preconditionFailure("Negotiation result must be ready")
+            case .http2(let (_, multiplexer)):
+                serverMultiplexer = multiplexer
+            }
+        }
+
+        try await withThrowingTaskGroup(of: Int.self, returning: Void.self) { group in
+            // server
+            group.addTask {
+                var serverInboundChannelCount = 0
+                for try await _ in serverMultiplexer.inbound {
+                    serverInboundChannelCount += 1
+                }
+                return serverInboundChannelCount
+            }
+
+            // client
+            for _ in 0 ..< requestCount {
+                // Let's try sending some requests
+                let streamChannel = try await clientMultiplexer.createStreamChannel { channel -> EventLoopFuture<Channel> in
+                    return channel.pipeline.addHandlers([SimpleRequest(), InboundFramePayloadRecorder()]).map {
+                        return channel
+                    }
+                }
+
+                let clientRecorder = try await streamChannel.pipeline.handler(type: InboundFramePayloadRecorder.self).get()
+                try await self.interactInMemory(self.clientChannel, self.serverChannel)
+                clientRecorder.receivedFrames.assertFramePayloadsMatch([ConfiguringPipelineAsyncMultiplexerTests.responseFramePayload])
+                try await streamChannel.closeFuture.get()
+            }
+
+            try await assertNoThrow(try await self.clientChannel.finish())
+            try await assertNoThrow(try await self.serverChannel.finish())
+
+            let serverInboundChannelCount = try await assertNoThrowWithValue(try await group.next()!)
+            XCTAssertEqual(serverInboundChannelCount, requestCount, "We should have created one server-side channel as a result of the each HTTP/2 stream used.")
+        }
+
+        serverRecorder.receivedFrames.assertFramePayloadsMatch(Array(repeating: ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload, count: requestCount))
+    }
+
+    // `testNegotiatedHTTP1BasicPipelineCommunicates` ensures that a client-server system set up to use async stream abstractions
+    // can communicate successfully when HTTP/1.1 is negotiated.
+    func testNegotiatedHTTP1BasicPipelineCommunicates() async throws {
+        let requestCount = 100
+
+        let _ = try await self.clientChannel.pipeline.addHTTPClientHandlers().map { _ in
+            self.clientChannel.pipeline.addHandlers([HTTP1ClientResponseRecorderHandler(), HTTP1ClientSendability()])
+        }.get()
+
+        let nioProtocolNegotiationResultFuture = try self.serverChannel.configureAsyncHTTPServerPipeline(
+            connectionConfiguration: .init(),
+            streamConfiguration: .init()
+        ) { channel in
+            channel.pipeline.addHandlers([HTTP1OKResponder(), HTTP1ServerRequestRecorderHandler()])
+        } h2ConnectionChannelConfigurator: { channel in
+            channel.eventLoop.makeSucceededVoidFuture()
+        } streamInitializer: { channel -> EventLoopFuture<Channel> in
+            channel.eventLoop.makeSucceededFuture(channel)
+        }
+
+        // Let's pretend the TLS handler did protocol negotiation for us
+        self.serverChannel.pipeline.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: "http/1.1"))
+
+        let nioProtocolNegotiationResult = try await nioProtocolNegotiationResultFuture.get()
+
+        try await self.interactInMemory(self.clientChannel, self.serverChannel)
+
+        switch nioProtocolNegotiationResult {
+        case .deferredResult:
+            preconditionFailure("Negotiation result must be ready")
+        case .finished(let negotiationResult):
+            switch negotiationResult {
+            case .http1_1:
+                break
+            case .http2:
+                preconditionFailure("Negotiation result must be http/1.1")
+            }
+        }
+
+        // client
+        for _ in 0 ..< requestCount {
+            // Let's try sending some http/1.1 requests.
+            // we need to put these through a mapping to remove references to `IOData` which isn't Sendable
+            try await self.clientChannel.writeOutbound(HTTP1ClientSendability.RequestPart.head(ConfiguringPipelineAsyncMultiplexerTests.requestHead))
+            try await self.clientChannel.writeAndFlush(HTTP1ClientSendability.RequestPart.end(nil)).get()
+            try await self.interactInMemory(self.clientChannel, self.serverChannel)
+        }
+
+        // check expectations
+        let clientRecorder = try await self.clientChannel.pipeline.handler(type: HTTP1ClientResponseRecorderHandler.self).get()
+        let serverRecorder = try await self.serverChannel.pipeline.handler(type: HTTP1ServerRequestRecorderHandler.self).get()
+
+        for i in 0 ..< requestCount {
+            XCTAssertEqual(serverRecorder.receivedParts[i*2], HTTPServerRequestPart.head(ConfiguringPipelineAsyncMultiplexerTests.requestHead), "Unexpected request part in iteration \(i)")
+            XCTAssertEqual(serverRecorder.receivedParts[i*2+1], HTTPServerRequestPart.end(nil), "Unexpected request part in iteration \(i)")
+
+            XCTAssertEqual(clientRecorder.receivedParts[i*2], HTTPClientResponsePart.head(ConfiguringPipelineAsyncMultiplexerTests.responseHead), "Unexpected response part in iteration \(i)")
+            XCTAssertEqual(clientRecorder.receivedParts[i*2+1], HTTPClientResponsePart.end(nil), "Unexpected response part in iteration \(i)")
+        }
+
+        try await assertNoThrow(try await self.clientChannel.finish())
+        try await assertNoThrow(try await self.serverChannel.finish())
+    }
+
+    // Simple handler which maps client request parts to remove references to `IOData` which isn't Sendable
+    internal final class HTTP1ClientSendability: ChannelOutboundHandler {
+        public typealias RequestPart = HTTPPart<HTTPRequestHead, ByteBuffer>
+
+        typealias OutboundIn = RequestPart
+        typealias OutboundOut = HTTPClientRequestPart
+
+        func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+            let requestPart = self.unwrapOutboundIn(data)
+
+            let httpClientRequestPart: HTTPClientRequestPart
+            switch requestPart {
+            case .head(let head):
+                httpClientRequestPart = .head(head)
+            case .body(let byteBuffer):
+                httpClientRequestPart = .body(.byteBuffer(byteBuffer))
+            case .end(let headers):
+                httpClientRequestPart = .end(headers)
+            }
+
+            context.write(self.wrapOutboundOut(httpClientRequestPart), promise: promise)
+        }
+    }
+
+    /// A simple channel handler that records inbound frames.
+    class HTTP1ServerRequestRecorderHandler: ChannelInboundHandler {
+        typealias InboundIn = HTTPServerRequestPart
+
+        var receivedParts: [HTTPServerRequestPart] = []
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            self.receivedParts.append(self.unwrapInboundIn(data))
+            context.fireChannelRead(data)
+        }
+    }
+
+    /// A simple channel handler that records inbound frames.
+    class HTTP1ClientResponseRecorderHandler: ChannelInboundHandler {
+        typealias InboundIn = HTTPClientResponsePart
+
+        var receivedParts: [HTTPClientResponsePart] = []
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            self.receivedParts.append(self.unwrapInboundIn(data))
+            context.fireChannelRead(data)
         }
     }
 }

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -64,6 +64,8 @@ extension XCTestCase {
 
     /// Have two `NIOAsyncTestingChannel` objects send and receive data from each other until
     /// they make no forward progress.
+    ///
+    /// ** This function is not thread safe and can lead to deadlocks, prefer the one-way variant which is less error-prone**
     func interactInMemory(_ first: NIOAsyncTestingChannel, _ second: NIOAsyncTestingChannel, file: StaticString = #filePath, line: UInt = #line) async throws {
         var operated: Bool
 
@@ -81,6 +83,23 @@ extension XCTestCase {
             if let data = await readBytesFromChannel(second) {
                 operated = true
                 try await assertNoThrow(try await first.writeInbound(data), file: file, line: line)
+            }
+        } while operated
+    }
+
+    /// Have a `NIOAsyncTestingChannel` send data to another until it makes no forward progress.
+    func deliverAllBytes(from source: NIOAsyncTestingChannel, to destination: NIOAsyncTestingChannel, file: StaticString = #filePath, line: UInt = #line) async throws {
+        var operated: Bool
+
+        func readBytesFromChannel(_ channel: NIOAsyncTestingChannel) async -> ByteBuffer? {
+            return try? await assertNoThrowWithValue(await channel.readOutbound(as: ByteBuffer.self))
+        }
+
+        repeat {
+            operated = false
+            if let data = await readBytesFromChannel(source) {
+                operated = true
+                try await assertNoThrow(try await destination.writeInbound(data), file: file, line: line)
             }
         } while operated
     }
@@ -919,6 +938,18 @@ internal func assertNil(
 ) async rethrows {
     let result = try await expression()
     XCTAssertNil(result, file: file, line: line)
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+internal func assertEqual<T: Equatable>(
+    _ expression1: @autoclosure () async throws -> T?,
+    _ expression2: @autoclosure () async throws -> T?,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async rethrows {
+    let result1 = try await expression1()
+    let result2 = try await expression2()
+    XCTAssertEqual(result1, result2, file: file, line: line)
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -65,7 +65,7 @@ extension XCTestCase {
     /// Have two `NIOAsyncTestingChannel` objects send and receive data from each other until
     /// they make no forward progress.
     ///
-    /// ** This function is not thread safe and can lead to deadlocks, prefer the one-way variant which is less error-prone**
+    /// ** This function is racy and can lead to deadlocks, prefer the one-way variant which is less error-prone**
     func interactInMemory(_ first: NIOAsyncTestingChannel, _ second: NIOAsyncTestingChannel, file: StaticString = #filePath, line: UInt = #line) async throws {
         var operated: Bool
 


### PR DESCRIPTION
Motivation:

This continues the work to expose functionality which allows users to interact with HTTP/2 connections via async abstractions and using structured concurrency.

This work enables protocol negotiation between HTTP/1.1 and HTTP/2 in its most generic form.

Modifications:

Enable protocol negotiation between HTTP/1.1 and HTTP/2 using typed negotiation results (`NIOProtocolNegotiationResult`) from the `NIOTypedApplicationProtocolNegotiationHandler`.
In the HTTP/2 case the negotiation result will return the HTTP/2 connection channel and the `NIOHTTP2Handler.AsyncStreamMultiplexer` which exposes inbound streams as an iterable async stream.

Result:

Users will be able to set up negotiated HTTP/1.1 / HTTP/2 connections and iterate over inbound streams.