### PR TITLE
Async stream initializers order matches existing

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -242,27 +242,5 @@ extension NIOHTTP2Handler {
         public func createStreamChannel<OutboundStreamOutput>(_ initializer: @escaping NIOChannelInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
             return try await self.inlineStreamMultiplexer.createStreamChannel(initializer).get()
         }
-
-        /// Create a stream channel initialized with the provided closure and return it wrapped within a `NIOAsyncChannel`.
-        ///
-        /// - Parameters:
-        ///   - configuration: Configuration for the ``NIOAsyncChannel`` wrapping the HTTP/2 stream channel.
-        ///   - initializer: A callback that will be invoked to allow you to configure the
-        ///         `ChannelPipeline` for the newly created channel.
-        @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-        @_spi(AsyncChannel)
-        public func createStreamChannel<Inbound, Outbound>(
-            asyncChannelConfiguration: NIOAsyncChannel<Inbound, Outbound>.Configuration = .init(),
-            initializer: @escaping NIOChannelInitializer
-        ) async throws -> NIOAsyncChannel<Inbound, Outbound> {
-            return try await self.createStreamChannel { channel in
-                initializer(channel).flatMapThrowing { _ in
-                    return try NIOAsyncChannel(
-                        synchronouslyWrapping: channel,
-                        configuration: asyncChannelConfiguration
-                    )
-                }
-            }
-        }
     }
 }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -148,7 +148,7 @@ extension InlineStreamMultiplexer {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .inline(self), streamStateInitializer)
     }
 
-    internal func createStreamChannel<Output>(_ initializer: @escaping NIOChannelInitializerWithOutput<Output>) -> EventLoopFuture<Output> {
+    internal func createStreamChannel<Output: Sendable>(_ initializer: @escaping NIOChannelInitializerWithOutput<Output>) -> EventLoopFuture<Output> {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .inline(self), initializer)
     }
 }
@@ -239,7 +239,7 @@ extension NIOHTTP2Handler {
         }
 
         /// Create a stream channel initialized with the provided closure
-        public func createStreamChannel<OutboundStreamOutput>(_ initializer: @escaping NIOChannelInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
+        public func createStreamChannel<OutboundStreamOutput: Sendable>(_ initializer: @escaping NIOChannelInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
             return try await self.inlineStreamMultiplexer.createStreamChannel(initializer).get()
         }
     }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler+InlineStreamMultiplexer.swift
@@ -224,7 +224,7 @@ extension NIOHTTP2Handler {
     /// and `IOData`.
     ///
     /// Outbound stream channel objects are initialized upon creation using the supplied `streamStateInitializer` which returns a type
-    /// `OutboundStreamOutput`. This type may be `HTTP2Frame` or changed to any other type.
+    /// `Output`. This type may be `HTTP2Frame` or changed to any other type.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
     public struct AsyncStreamMultiplexer<InboundStreamOutput> {
@@ -239,7 +239,7 @@ extension NIOHTTP2Handler {
         }
 
         /// Create a stream channel initialized with the provided closure
-        public func createStreamChannel<OutboundStreamOutput: Sendable>(_ initializer: @escaping NIOChannelInitializerWithOutput<OutboundStreamOutput>) async throws -> OutboundStreamOutput {
+        public func createStreamChannel<Output: Sendable>(_ initializer: @escaping NIOChannelInitializerWithOutput<Output>) async throws -> Output {
             return try await self.inlineStreamMultiplexer.createStreamChannel(initializer).get()
         }
     }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1142,7 +1142,7 @@ extension NIOHTTP2Handler {
     }
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    internal func syncAsyncStreamMultiplexer<Output>(continuation: any AnyContinuation, inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
+    internal func syncAsyncStreamMultiplexer<Output: Sendable>(continuation: any AnyContinuation, inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
         self.eventLoop!.preconditionInEventLoop()
 
         switch self.inboundStreamMultiplexer {

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -120,6 +120,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     private enum InboundStreamMultiplexerState {
         case uninitializedLegacy
         case uninitializedInline(StreamConfiguration, StreamInitializer, NIOHTTP2StreamDelegate?)
+        case uninitializedAsync(StreamConfiguration, StreamInitializerWithAnyOutput, NIOHTTP2StreamDelegate?)
         case initialized(InboundStreamMultiplexer)
         case deinitialized
 
@@ -127,7 +128,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
             switch self {
             case .initialized(let inboundStreamMultiplexer):
                 return inboundStreamMultiplexer
-            case .uninitializedLegacy, .uninitializedInline, .deinitialized:
+            case .uninitializedLegacy, .uninitializedInline, .uninitializedAsync, .deinitialized:
                 return nil
             }
         }
@@ -146,6 +147,20 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                         outboundView: .init(http2Handler: http2Handler),
                         mode: mode,
                         inboundStreamStateInitializer: .excludesStreamID(inboundStreamInitializer),
+                        targetWindowSize: max(0, min(streamConfiguration.targetWindowSize, Int(Int32.max))),
+                        streamChannelOutboundBytesHighWatermark: streamConfiguration.outboundBufferSizeHighWatermark,
+                        streamChannelOutboundBytesLowWatermark: streamConfiguration.outboundBufferSizeLowWatermark,
+                        streamDelegate: streamDelegate
+                    )
+                ))
+
+            case .uninitializedAsync(let streamConfiguration, let inboundStreamInitializer, let streamDelegate):
+                self = .initialized(.inline(
+                    InlineStreamMultiplexer(
+                        context: context,
+                        outboundView: .init(http2Handler: http2Handler),
+                        mode: mode,
+                        inboundStreamStateInitializer: .returnsAny(inboundStreamInitializer),
                         targetWindowSize: max(0, min(streamConfiguration.targetWindowSize, Int(Int32.max))),
                         streamChannelOutboundBytesHighWatermark: streamConfiguration.outboundBufferSizeHighWatermark,
                         streamChannelOutboundBytesLowWatermark: streamConfiguration.outboundBufferSizeLowWatermark,
@@ -989,9 +1004,13 @@ extension NIOHTTP2Handler {
 #if swift(>=5.7)
     /// The type of all `inboundStreamInitializer` callbacks which do not need to return data.
     public typealias StreamInitializer = NIOChannelInitializer
+    /// The type of NIO Channel initializer callbacks which need to return untyped data.
+    internal typealias StreamInitializerWithAnyOutput = @Sendable (Channel) -> EventLoopFuture<Any>
 #else
     /// The type of all `inboundStreamInitializer` callbacks which need to return data.
     public typealias StreamInitializer = NIOChannelInitializer
+    /// The type of NIO Channel initializer callbacks which need to return untyped data.
+    internal typealias StreamInitializerWithAnyOutput = (Channel) -> EventLoopFuture<Any>
 #endif
 
     /// Creates a new ``NIOHTTP2Handler`` with a local multiplexer. (i.e. using
@@ -1014,15 +1033,37 @@ extension NIOHTTP2Handler {
         streamDelegate: NIOHTTP2StreamDelegate? = nil,
         inboundStreamInitializer: @escaping StreamInitializer
     ) {
-        self.init(mode: mode,
-                  eventLoop: eventLoop,
-                  initialSettings: connectionConfiguration.initialSettings,
-                  headerBlockValidation: connectionConfiguration.headerBlockValidation,
-                  contentLengthValidation: connectionConfiguration.contentLengthValidation,
-                  maximumSequentialEmptyDataFrames: connectionConfiguration.maximumSequentialEmptyDataFrames,
-                  maximumBufferedControlFrames: connectionConfiguration.maximumBufferedControlFrames
+        self.init(
+            mode: mode,
+            eventLoop: eventLoop,
+            initialSettings: connectionConfiguration.initialSettings,
+            headerBlockValidation: connectionConfiguration.headerBlockValidation,
+            contentLengthValidation: connectionConfiguration.contentLengthValidation,
+            maximumSequentialEmptyDataFrames: connectionConfiguration.maximumSequentialEmptyDataFrames,
+            maximumBufferedControlFrames: connectionConfiguration.maximumBufferedControlFrames
         )
+
         self.inboundStreamMultiplexerState = .uninitializedInline(streamConfiguration, inboundStreamInitializer, streamDelegate)
+    }
+
+    internal convenience init(
+        mode: ParserMode,
+        eventLoop: EventLoop,
+        connectionConfiguration: ConnectionConfiguration = .init(),
+        streamConfiguration: StreamConfiguration = .init(),
+        streamDelegate: NIOHTTP2StreamDelegate? = nil,
+        inboundStreamInitializerWithAnyOutput: @escaping StreamInitializerWithAnyOutput
+    ) {
+        self.init(
+            mode: mode,
+            eventLoop: eventLoop,
+            initialSettings: connectionConfiguration.initialSettings,
+            headerBlockValidation: connectionConfiguration.headerBlockValidation,
+            contentLengthValidation: connectionConfiguration.contentLengthValidation,
+            maximumSequentialEmptyDataFrames: connectionConfiguration.maximumSequentialEmptyDataFrames,
+            maximumBufferedControlFrames: connectionConfiguration.maximumBufferedControlFrames
+        )
+        self.inboundStreamMultiplexerState = .uninitializedAsync(streamConfiguration, inboundStreamInitializerWithAnyOutput, streamDelegate)
     }
 
     /// Connection-level configuration.
@@ -1101,7 +1142,7 @@ extension NIOHTTP2Handler {
     }
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    internal func syncAsyncStreamMultiplexer<Output>(continuation: any ChannelContinuation, inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
+    internal func syncAsyncStreamMultiplexer<Output>(continuation: any AnyContinuation, inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
         self.eventLoop!.preconditionInEventLoop()
 
         switch self.inboundStreamMultiplexer {

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -119,7 +119,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     /// - `InboundStreamMultiplexer`: The component responsible for (de)multiplexing inbound streams.
     private enum InboundStreamMultiplexerState {
         case uninitializedLegacy
-        case uninitializedInline(StreamConfiguration, StreamInitializer, NIOHTTP2StreamDelegate?)
+        case uninitializedInline(StreamConfiguration, StreamInitializer, NIOHTTP2StreamDelegate?, (any AnyContinuation)?)
         case initialized(InboundStreamMultiplexer)
         case deinitialized
 
@@ -139,7 +139,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
             case .uninitializedLegacy:
                 self = .initialized(.legacy(LegacyInboundStreamMultiplexer(context: context)))
 
-            case .uninitializedInline(let streamConfiguration, let inboundStreamInitializer, let streamDelegate):
+            case .uninitializedInline(let streamConfiguration, let inboundStreamInitializer, let streamDelegate, let streamInitializerProductContinuation):
                 self = .initialized(.inline(
                     InlineStreamMultiplexer(
                         context: context,
@@ -149,7 +149,8 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                         targetWindowSize: max(0, min(streamConfiguration.targetWindowSize, Int(Int32.max))),
                         streamChannelOutboundBytesHighWatermark: streamConfiguration.outboundBufferSizeHighWatermark,
                         streamChannelOutboundBytesLowWatermark: streamConfiguration.outboundBufferSizeLowWatermark,
-                        streamDelegate: streamDelegate
+                        streamDelegate: streamDelegate,
+                        streamInitializerProductContinuation: streamInitializerProductContinuation
                     )
                 ))
 
@@ -1022,7 +1023,40 @@ extension NIOHTTP2Handler {
                   maximumSequentialEmptyDataFrames: connectionConfiguration.maximumSequentialEmptyDataFrames,
                   maximumBufferedControlFrames: connectionConfiguration.maximumBufferedControlFrames
         )
-        self.inboundStreamMultiplexerState = .uninitializedInline(streamConfiguration, inboundStreamInitializer, streamDelegate)
+        self.inboundStreamMultiplexerState = .uninitializedInline(streamConfiguration, inboundStreamInitializer, streamDelegate, nil)
+    }
+
+    /// Creates a new ``NIOHTTP2Handler`` with a local multiplexer which yields inbound stream initializer products to
+    /// an async stream.
+    ///
+    /// Frames on the root stream will continue to be passed down the main channel, whereas those intended for
+    /// other streams will be forwarded to the appropriate child channel.
+    ///
+    /// To create streams using the local multiplexer, first obtain it via the computed property (`multiplexer`)
+    /// and then invoke one of the `multiplexer.createStreamChannel` methods. If possible the multiplexer should be
+    /// stored and used across multiple invocations because obtaining it requires synchronizing on the event loop.
+    ///
+    /// the `streamInitializerProductContinuation` will be used to asynchronously stream inbound stream initializer products.
+    ///
+    /// The optional `streamDelegate` will be notified of stream creation and close events.
+    internal convenience init(
+        mode: ParserMode,
+        eventLoop: EventLoop,
+        connectionConfiguration: ConnectionConfiguration = .init(),
+        streamConfiguration: StreamConfiguration = .init(),
+        streamDelegate: NIOHTTP2StreamDelegate? = nil,
+        streamInitializerProductContinuation: any AnyContinuation,
+        inboundStreamInitializer: @escaping StreamInitializer
+    ) {
+        self.init(mode: mode,
+                  eventLoop: eventLoop,
+                  initialSettings: connectionConfiguration.initialSettings,
+                  headerBlockValidation: connectionConfiguration.headerBlockValidation,
+                  contentLengthValidation: connectionConfiguration.contentLengthValidation,
+                  maximumSequentialEmptyDataFrames: connectionConfiguration.maximumSequentialEmptyDataFrames,
+                  maximumBufferedControlFrames: connectionConfiguration.maximumBufferedControlFrames
+        )
+        self.inboundStreamMultiplexerState = .uninitializedInline(streamConfiguration, inboundStreamInitializer, streamDelegate, streamInitializerProductContinuation)
     }
 
     /// Connection-level configuration.
@@ -1101,12 +1135,12 @@ extension NIOHTTP2Handler {
     }
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    internal func syncAsyncStreamMultiplexer<Output>(continuation: any ChannelContinuation, inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
+    internal func syncAsyncStreamMultiplexer<Output>(inboundStreamChannels: NIOHTTP2InboundStreamChannels<Output>) throws -> AsyncStreamMultiplexer<Output> {
         self.eventLoop!.preconditionInEventLoop()
 
         switch self.inboundStreamMultiplexer {
         case let .some(.inline(multiplexer)):
-            return AsyncStreamMultiplexer(multiplexer, continuation: continuation, inboundStreamChannels: inboundStreamChannels)
+            return AsyncStreamMultiplexer(multiplexer, inboundStreamChannels: inboundStreamChannels)
         case .some(.legacy), .none:
             throw NIOHTTP2Errors.missingMultiplexer()
         }

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1010,7 +1010,7 @@ extension NIOHTTP2Handler {
     /// The type of all `inboundStreamInitializer` callbacks which need to return data.
     public typealias StreamInitializer = NIOChannelInitializer
     /// The type of NIO Channel initializer callbacks which need to return untyped data.
-    internal typealias StreamInitializerWithAnyOutput = (Channel) -> EventLoopFuture<Any>
+    internal typealias StreamInitializerWithAnyOutput = (Channel) -> EventLoopFuture<any Sendable>
 #endif
 
     /// Creates a new ``NIOHTTP2Handler`` with a local multiplexer. (i.e. using

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1005,7 +1005,7 @@ extension NIOHTTP2Handler {
     /// The type of all `inboundStreamInitializer` callbacks which do not need to return data.
     public typealias StreamInitializer = NIOChannelInitializer
     /// The type of NIO Channel initializer callbacks which need to return untyped data.
-    internal typealias StreamInitializerWithAnyOutput = @Sendable (Channel) -> EventLoopFuture<Any>
+    internal typealias StreamInitializerWithAnyOutput = @Sendable (Channel) -> EventLoopFuture<any Sendable>
 #else
     /// The type of all `inboundStreamInitializer` callbacks which need to return data.
     public typealias StreamInitializer = NIOChannelInitializer

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -322,6 +322,8 @@ extension HTTP2CommonInboundStreamMultiplexer {
             anyPromise?.futureResult.whenComplete { result in
                 switch result {
                 case .success(let any):
+                    // The cast through any here is unfortunate but the only way to make this work right now
+                    // since the HTTP2ChildChannel and the multiplexer is not generic over the output of the initializer.
                     promise.succeed(any as! Output)
                 case .failure(let error):
                     promise.fail(error)

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -293,7 +293,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
 }
 
 extension HTTP2CommonInboundStreamMultiplexer {
-    internal func _createStreamChannel<Output>(
+    internal func _createStreamChannel<Output: Sendable>(
         _ multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         _ promise: EventLoopPromise<Output>?,
         _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
@@ -313,11 +313,10 @@ extension HTTP2CommonInboundStreamMultiplexer {
         self.pendingStreams[channel.channelID] = channel
 
         let anyInitializer: NIOChannelInitializerWithOutput<any Sendable> = { channel in
-            streamStateInitializer(channel).map { $0 }
+            streamStateInitializer(channel).map { return $0 }
         }
 
         let anyPromise: EventLoopPromise<Any>?
-
         if let promise = promise {
             anyPromise = channel.baseChannel.eventLoop.makePromise(of: Any.self)
             anyPromise?.futureResult.whenComplete { result in
@@ -335,7 +334,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
         channel.configure(initializer: anyInitializer, userPromise: anyPromise)
     }
 
-    internal func createStreamChannel<Output>(
+    internal func createStreamChannel<Output: Sendable>(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         promise: EventLoopPromise<Output>?,
         _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
@@ -348,7 +347,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
         }
     }
 
-    internal func createStreamChannel<Output>(
+    internal func createStreamChannel<Output: Sendable>(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         _ streamStateInitializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) -> EventLoopFuture<Output> {

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -38,7 +38,7 @@ internal class HTTP2CommonInboundStreamMultiplexer {
     private var isReading = false
     private var flushPending = false
 
-    var streamChannelContinuation: (any ChannelContinuation)?
+    var streamChannelContinuation: (any AnyContinuation)?
 
     init(
         mode: NIOHTTP2Handler.ParserMode,
@@ -103,17 +103,21 @@ extension HTTP2CommonInboundStreamMultiplexer {
 
             self.streams[streamID] = channel
 
-            // If we have an async sequence of inbound stream channels yield the channel to it
-            // This also implicitly performs the stream initialization step.
-            // Note that in this case the API is constructed such that `self.inboundStreamStateInitializer`
-            // does no actual work.
-            self.streamChannelContinuation?.yield(channel: channel.baseChannel)
-
             // Note: Firing the initial (header) frame before calling `HTTP2StreamChannel.configureInboundStream(initializer:)`
             // is crucial to preserve frame order, since the initialization process might trigger another read on the parent
             // channel which in turn might cause further frames to be processed synchronously.
             channel.receiveInboundFrame(frame)
-            channel.configureInboundStream(initializer: self.inboundStreamStateInitializer)
+
+            let initializerProductPromise = self.streamChannelContinuation == nil ? nil : self.channel.eventLoop.makePromise(of: Any.self)
+            channel.configureInboundStream(initializer: self.inboundStreamStateInitializer, promise: initializerProductPromise)
+
+            // If we have an async sequence of inbound stream channels yield the channel to it
+            // but only once we are sure initialization and activation succeed
+            if let streamChannelContinuation = self.streamChannelContinuation {
+                initializerProductPromise!.futureResult.whenSuccess { value in
+                    streamChannelContinuation.yield(any: value)
+                }
+            }
 
             if !channel.inList {
                 self.didReadChannels.append(channel)
@@ -304,7 +308,20 @@ extension HTTP2CommonInboundStreamMultiplexer {
             inboundStreamStateInitializer: .excludesStreamID(nil)
         )
         self.pendingStreams[channel.channelID] = channel
-        channel.configure(initializer: streamStateInitializer, userPromise: promise)
+
+        let anyInitializer: NIOChannelInitializerWithOutput<Any> = { channel in
+            streamStateInitializer(channel).map { $0 }
+        }
+
+        let anyPromise: EventLoopPromise<Any>?
+        if let promise = promise {
+            anyPromise = channel.baseChannel.eventLoop.makePromise(of: Any.self)
+            promise.completeWith(anyPromise!.futureResult.map { value in value as! Output })
+        } else {
+            anyPromise = nil
+        }
+
+        channel.configure(initializer: anyInitializer, userPromise: anyPromise)
     }
 
     internal func createStreamChannel<Output>(
@@ -332,7 +349,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
     internal func _createStreamChannel(
         _ multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         _ promise: EventLoopPromise<Channel>?,
-        _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+        _ streamStateInitializer: @escaping NIOChannelInitializer
     ) {
         let channel = MultiplexerAbstractChannel(
             allocator: self.channel.allocator,
@@ -345,13 +362,14 @@ extension HTTP2CommonInboundStreamMultiplexer {
             inboundStreamStateInitializer: .excludesStreamID(nil)
         )
         self.pendingStreams[channel.channelID] = channel
+
         channel.configure(initializer: streamStateInitializer, userPromise: promise)
     }
 
     internal func createStreamChannel(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
         promise: EventLoopPromise<Channel>?,
-        _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+        _ streamStateInitializer: @escaping NIOChannelInitializer
     ) {
         // Always create streams channels on the next event loop tick. This avoids re-entrancy
         // issues where handlers interposed between the two HTTP/2 handlers could create streams
@@ -363,7 +381,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
 
     internal func createStreamChannel(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
-        _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>) -> EventLoopFuture<Channel> {
+        _ streamStateInitializer: @escaping NIOChannelInitializer) -> EventLoopFuture<Channel> {
         let promise = self.channel.eventLoop.makePromise(of: Channel.self)
         self.createStreamChannel(multiplexer: multiplexer, promise: promise, streamStateInitializer)
         return promise.futureResult
@@ -408,7 +426,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
 }
 
 extension HTTP2CommonInboundStreamMultiplexer {
-    func setChannelContinuation(_ streamChannels: any ChannelContinuation) {
+    func setChannelContinuation(_ streamChannels: any AnyContinuation) {
         self.channel.eventLoop.assertInEventLoop()
         self.streamChannelContinuation = streamChannels
     }
@@ -416,76 +434,15 @@ extension HTTP2CommonInboundStreamMultiplexer {
 
 /// `ChannelContinuation` is used to generic async-sequence-like objects to deal with `Channel`s. This is so that they may be held
 /// by the `HTTP2ChannelHandler` without causing it to become generic itself.
-internal protocol ChannelContinuation {
-    func yield(channel: Channel)
+internal protocol AnyContinuation {
+    func yield(any: Any)
     func finish()
     func finish(throwing error: Error)
 }
 
 
-/// `StreamChannelContinuation` is a wrapper for a generic `AsyncThrowingStream` which holds the inbound HTTP2 stream channels.
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-struct StreamChannelContinuation<Output>: ChannelContinuation {
-    private var continuation: AsyncThrowingStream<Output, Error>.Continuation
-    private let inboundStreamInititializer: NIOChannelInitializerWithOutput<Output>
-
-    private init(
-        continuation: AsyncThrowingStream<Output, Error>.Continuation,
-        inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
-    ) {
-        self.continuation = continuation
-        self.inboundStreamInititializer = inboundStreamInititializer
-    }
-
-    /// `initialize` creates a new `StreamChannelContinuation` object and returns it along with its backing `AsyncThrowingStream`.
-    /// The `StreamChannelContinuation` provides access to the inbound HTTP2 stream channels.
-    ///
-    /// - Parameters:
-    ///   - inboundStreamInititializer: A closure which initializes the newly-created inbound stream channel and returns a generic.
-    ///   The returned type corresponds to the output of the channel once the operations in the initializer have been performed.
-    ///   For example an `inboundStreamInititializer` which inserts handlers before wrapping the channel in a `NIOAsyncChannel` would
-    ///   have a `Output` corresponding to that `NIOAsyncChannel` type. Another example is in cases where there is
-    ///   per-stream protocol negotiation where `Output` would be some form of `NIOProtocolNegotiationResult`.
-    static func initialize(
-        with inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
-    ) -> (StreamChannelContinuation<Output>, NIOHTTP2InboundStreamChannels<Output>) {
-        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Output.self)
-        return (StreamChannelContinuation(continuation: continuation, inboundStreamInititializer: inboundStreamInititializer), NIOHTTP2InboundStreamChannels(stream))
-    }
-
-    /// `yield` takes a channel, executes the stored `streamInitializer` upon it and then yields the *derived* type to
-    /// the wrapped `AsyncThrowingStream`.
-    func yield(channel: Channel) {
-        channel.eventLoop.assertInEventLoop()
-        self.inboundStreamInititializer(channel).whenSuccess { output in
-            let yieldResult = self.continuation.yield(output)
-            switch yieldResult {
-            case .enqueued:
-                break // success, nothing to do
-            case .dropped:
-                preconditionFailure("Attempted to yield channel when AsyncThrowingStream is over capacity. This shouldn't be possible for an unbounded stream.")
-            case .terminated:
-                channel.close(mode: .all, promise: nil)
-                preconditionFailure("Attempted to yield channel to AsyncThrowingStream in terminated state.")
-            default:
-                channel.close(mode: .all, promise: nil)
-                preconditionFailure("Attempt to yield channel to AsyncThrowingStream failed for unhandled reason.")
-            }
-        }
-    }
-
-    /// `finish` marks the continuation as finished.
-    func finish() {
-        self.continuation.finish()
-    }
-
-    /// `finish` marks the continuation as finished with the supplied error.
-    func finish(throwing error: Error) {
-        self.continuation.finish(throwing: error)
-    }
-}
-
-/// `NIOHTTP2InboundStreamChannels` provides access to inbound stream channels as an `AsyncSequence`.
+/// `NIOHTTP2InboundStreamChannels` provides access to inbound stream channels as a generic `AsyncSequence`.
+/// They make use of generics to allow for wrapping the stream `Channel`s, for example as `NIOAsyncChannel`s or protocol negotiation objects.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
 public struct NIOHTTP2InboundStreamChannels<Output>: AsyncSequence {
@@ -507,12 +464,69 @@ public struct NIOHTTP2InboundStreamChannels<Output>: AsyncSequence {
 
     private let asyncThrowingStream: AsyncThrowingStream<Output, Error>
 
-    init(_ asyncThrowingStream: AsyncThrowingStream<Output, Error>) {
+    private init(_ asyncThrowingStream: AsyncThrowingStream<Output, Error>) {
         self.asyncThrowingStream = asyncThrowingStream
     }
 
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(self.asyncThrowingStream.makeAsyncIterator())
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension NIOHTTP2InboundStreamChannels {
+    /// `Continuation` is a wrapper for a generic `AsyncThrowingStream` to which inbound HTTP2 stream channels are yielded..
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    struct Continuation: AnyContinuation {
+        private var continuation: AsyncThrowingStream<Output, Error>.Continuation
+
+        internal init(
+            continuation: AsyncThrowingStream<Output, Error>.Continuation
+        ) {
+            self.continuation = continuation
+        }
+
+        /// `yield` takes a channel as outputted by the stream initializer and yields the wrapped `AsyncThrowingStream`.
+        ///
+        /// It takes channels as as `Any` type to allow wrapping by the stream initializer.
+        func yield(any: Any) {
+            let yieldResult = self.continuation.yield(any as! Output)
+                switch yieldResult {
+                case .enqueued:
+                    break // success, nothing to do
+                case .dropped:
+                    preconditionFailure("Attempted to yield when AsyncThrowingStream is over capacity. This shouldn't be possible for an unbounded stream.")
+                case .terminated:
+                    preconditionFailure("Attempted to yield to AsyncThrowingStream in terminated state.")
+                default:
+                    preconditionFailure("Attempt to yield to AsyncThrowingStream failed for unhandled reason.")
+                }
+        }
+
+        /// `finish` marks the continuation as finished.
+        func finish() {
+            self.continuation.finish()
+        }
+
+        /// `finish` marks the continuation as finished with the supplied error.
+        func finish(throwing error: Error) {
+            self.continuation.finish(throwing: error)
+        }
+    }
+
+
+    /// `initialize` creates a new `Continuation` object and returns it along with its backing `AsyncThrowingStream`.
+    /// The `StreamChannelContinuation` provides access to the inbound HTTP2 stream channels.
+    ///
+    /// - Parameters:
+    ///   - inboundStreamInititializer: A closure which initializes the newly-created inbound stream channel and returns a generic.
+    ///   The returned type corresponds to the output of the channel once the operations in the initializer have been performed.
+    ///   For example an `inboundStreamInititializer` which inserts handlers before wrapping the channel in a `NIOAsyncChannel` would
+    ///   have a `Output` corresponding to that `NIOAsyncChannel` type. Another example is in cases where there is
+    ///   per-stream protocol negotiation where `Output` would be some form of `NIOProtocolNegotiationResult`.
+    static func initialize(inboundStreamInitializerOutput: Output.Type = Output.self) -> (NIOHTTP2InboundStreamChannels<Output>, Continuation) {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Output.self)
+        return (.init(stream), Continuation(continuation: continuation))
     }
 }
 

--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -38,7 +38,7 @@ internal class HTTP2CommonInboundStreamMultiplexer {
     private var isReading = false
     private var flushPending = false
 
-    var streamInitializerProductContinuation: (any AnyContinuation)?
+    var streamChannelContinuation: (any ChannelContinuation)?
 
     init(
         mode: NIOHTTP2Handler.ParserMode,
@@ -46,8 +46,7 @@ internal class HTTP2CommonInboundStreamMultiplexer {
         inboundStreamStateInitializer: MultiplexerAbstractChannel.InboundStreamStateInitializer,
         targetWindowSize: Int,
         streamChannelOutboundBytesHighWatermark: Int,
-        streamChannelOutboundBytesLowWatermark: Int,
-        streamInitializerProductContinuation: (any AnyContinuation)?
+        streamChannelOutboundBytesLowWatermark: Int
     ) {
         self.channel = channel
         self.inboundStreamStateInitializer = inboundStreamStateInitializer
@@ -55,8 +54,6 @@ internal class HTTP2CommonInboundStreamMultiplexer {
         self.connectionFlowControlManager = InboundWindowManager(targetSize: Int32(targetWindowSize))
         self.streamChannelOutboundBytesHighWatermark = streamChannelOutboundBytesHighWatermark
         self.streamChannelOutboundBytesLowWatermark = streamChannelOutboundBytesLowWatermark
-        self.streamInitializerProductContinuation = streamInitializerProductContinuation
-
         self.mode = mode
         switch mode {
         case .client:
@@ -105,6 +102,12 @@ extension HTTP2CommonInboundStreamMultiplexer {
             )
 
             self.streams[streamID] = channel
+
+            // If we have an async sequence of inbound stream channels yield the channel to it
+            // This also implicitly performs the stream initialization step.
+            // Note that in this case the API is constructed such that `self.inboundStreamStateInitializer`
+            // does no actual work.
+            self.streamChannelContinuation?.yield(channel: channel.baseChannel)
 
             // Note: Firing the initial (header) frame before calling `HTTP2StreamChannel.configureInboundStream(initializer:)`
             // is crucial to preserve frame order, since the initialization process might trigger another read on the parent
@@ -195,7 +198,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
             channel.receiveStreamClosed(nil)
         }
         // there cannot be any more inbound streams now that the connection channel is inactive
-        self.streamInitializerProductContinuation?.finish()
+        self.streamChannelContinuation?.finish()
     }
 
     internal func propagateChannelWritabilityChanged(context: ChannelHandlerContext) {
@@ -360,8 +363,7 @@ extension HTTP2CommonInboundStreamMultiplexer {
 
     internal func createStreamChannel(
         multiplexer: HTTP2StreamChannel.OutboundStreamMultiplexer,
-        _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>
-    ) -> EventLoopFuture<Channel> {
+        _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>) -> EventLoopFuture<Channel> {
         let promise = self.channel.eventLoop.makePromise(of: Channel.self)
         self.createStreamChannel(multiplexer: multiplexer, promise: promise, streamStateInitializer)
         return promise.futureResult
@@ -405,17 +407,85 @@ extension HTTP2CommonInboundStreamMultiplexer {
     }
 }
 
-/// `AnyContinuation` is used to describe generic async-sequence-like objects which deal with the products of inbound stream initializers.
-/// This is so that they may be held by the `HTTP2ChannelHandler` without causing it to become generic itself.
-internal protocol AnyContinuation {
-    func yield(_ any: Any)
+extension HTTP2CommonInboundStreamMultiplexer {
+    func setChannelContinuation(_ streamChannels: any ChannelContinuation) {
+        self.channel.eventLoop.assertInEventLoop()
+        self.streamChannelContinuation = streamChannels
+    }
+}
+
+/// `ChannelContinuation` is used to generic async-sequence-like objects to deal with `Channel`s. This is so that they may be held
+/// by the `HTTP2ChannelHandler` without causing it to become generic itself.
+internal protocol ChannelContinuation {
+    func yield(channel: Channel)
     func finish()
     func finish(throwing error: Error)
 }
 
 
+/// `StreamChannelContinuation` is a wrapper for a generic `AsyncThrowingStream` which holds the inbound HTTP2 stream channels.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct StreamChannelContinuation<Output>: ChannelContinuation {
+    private var continuation: AsyncThrowingStream<Output, Error>.Continuation
+    private let inboundStreamInititializer: NIOChannelInitializerWithOutput<Output>
 
-/// `NIOHTTP2InboundStreamChannels` provides access to the products of inbound stream channel initializers as an `AsyncSequence`.
+    private init(
+        continuation: AsyncThrowingStream<Output, Error>.Continuation,
+        inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
+    ) {
+        self.continuation = continuation
+        self.inboundStreamInititializer = inboundStreamInititializer
+    }
+
+    /// `initialize` creates a new `StreamChannelContinuation` object and returns it along with its backing `AsyncThrowingStream`.
+    /// The `StreamChannelContinuation` provides access to the inbound HTTP2 stream channels.
+    ///
+    /// - Parameters:
+    ///   - inboundStreamInititializer: A closure which initializes the newly-created inbound stream channel and returns a generic.
+    ///   The returned type corresponds to the output of the channel once the operations in the initializer have been performed.
+    ///   For example an `inboundStreamInititializer` which inserts handlers before wrapping the channel in a `NIOAsyncChannel` would
+    ///   have a `Output` corresponding to that `NIOAsyncChannel` type. Another example is in cases where there is
+    ///   per-stream protocol negotiation where `Output` would be some form of `NIOProtocolNegotiationResult`.
+    static func initialize(
+        with inboundStreamInititializer: @escaping NIOChannelInitializerWithOutput<Output>
+    ) -> (StreamChannelContinuation<Output>, NIOHTTP2InboundStreamChannels<Output>) {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Output.self)
+        return (StreamChannelContinuation(continuation: continuation, inboundStreamInititializer: inboundStreamInititializer), NIOHTTP2InboundStreamChannels(stream))
+    }
+
+    /// `yield` takes a channel, executes the stored `streamInitializer` upon it and then yields the *derived* type to
+    /// the wrapped `AsyncThrowingStream`.
+    func yield(channel: Channel) {
+        channel.eventLoop.assertInEventLoop()
+        self.inboundStreamInititializer(channel).whenSuccess { output in
+            let yieldResult = self.continuation.yield(output)
+            switch yieldResult {
+            case .enqueued:
+                break // success, nothing to do
+            case .dropped:
+                preconditionFailure("Attempted to yield channel when AsyncThrowingStream is over capacity. This shouldn't be possible for an unbounded stream.")
+            case .terminated:
+                channel.close(mode: .all, promise: nil)
+                preconditionFailure("Attempted to yield channel to AsyncThrowingStream in terminated state.")
+            default:
+                channel.close(mode: .all, promise: nil)
+                preconditionFailure("Attempt to yield channel to AsyncThrowingStream failed for unhandled reason.")
+            }
+        }
+    }
+
+    /// `finish` marks the continuation as finished.
+    func finish() {
+        self.continuation.finish()
+    }
+
+    /// `finish` marks the continuation as finished with the supplied error.
+    func finish(throwing error: Error) {
+        self.continuation.finish(throwing: error)
+    }
+}
+
+/// `NIOHTTP2InboundStreamChannels` provides access to inbound stream channels as an `AsyncSequence`.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @_spi(AsyncChannel)
 public struct NIOHTTP2InboundStreamChannels<Output>: AsyncSequence {
@@ -437,65 +507,12 @@ public struct NIOHTTP2InboundStreamChannels<Output>: AsyncSequence {
 
     private let asyncThrowingStream: AsyncThrowingStream<Output, Error>
 
-    private init(_ asyncThrowingStream: AsyncThrowingStream<Output, Error>) {
+    init(_ asyncThrowingStream: AsyncThrowingStream<Output, Error>) {
         self.asyncThrowingStream = asyncThrowingStream
     }
 
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(self.asyncThrowingStream.makeAsyncIterator())
-    }
-}
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension NIOHTTP2InboundStreamChannels {
-    /// `Continuation` provides an async stream interface for accessing initialized inbound HTTP/2 stream channels.
-    ///
-    /// This is defined to operate on a generic `Output` type rather than `Channel` to allow the stream channel initializer
-    /// to wrap the underlying channel, for example as `NIOAsyncChannel`s or protocol negotiation objects.
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    struct Continuation: AnyContinuation {
-        private var continuation: AsyncThrowingStream<Output, Error>.Continuation
-
-        internal init(
-            continuation: AsyncThrowingStream<Output, Error>.Continuation
-        ) {
-            self.continuation = continuation
-        }
-
-        /// `yield` supplies the provided object to the .
-        func yield(_ any: Any) {
-            let output = any as! Output
-            let yieldResult = self.continuation.yield(output)
-            switch yieldResult {
-            case .enqueued:
-                break // success, nothing to do
-            case .dropped:
-                preconditionFailure("Attempted to yield when AsyncThrowingStream is over capacity. This shouldn't be possible for an unbounded stream.")
-            case .terminated:
-                preconditionFailure("Attempted to yield to AsyncThrowingStream in terminated state.")
-            default:
-                preconditionFailure("Attempt to yield to AsyncThrowingStream failed for unhandled reason.")
-            }
-        }
-
-        /// `finish` marks the continuation as finished.
-        func finish() {
-            self.continuation.finish()
-        }
-
-        /// `finish` marks the continuation as finished with the supplied error.
-        func finish(throwing error: Error) {
-            self.continuation.finish(throwing: error)
-        }
-    }
-
-    /// `initialize` creates a new `NIOHTTP2InboundStreamChannels` object and returns it along with its `StreamChannelContinuation`.
-    ///
-    /// This is defined to operate on a generic `Output` type rather than `Channel` to allow the stream channel initializer
-    /// to wrap the underlying channel, for example as `NIOAsyncChannel`s or protocol negotiation objects.
-    static func initialize(inboundStreamInitializerOutput: Output.Type = Output.self) -> (NIOHTTP2InboundStreamChannels<Output>, Continuation) {
-        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Output.self)
-        return (.init(stream), Continuation(continuation: continuation))
     }
 }
 

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -439,12 +439,12 @@ extension Channel {
     ///   - configuration: The settings that will be used when establishing the connection and new streams.
     ///   - position: The position in the pipeline into which to insert this handler.
     ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    ///     It must output the stream `Channel` (either directly or wrapped in some form) to allow users to iterate over inbound streams.
+    ///     The output of this closure is the element type of the returned multiplexer
     /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
     ///     be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
-    public func configureAsyncHTTP2Pipeline<Output>(
+    public func configureAsyncHTTP2Pipeline<Output: Sendable>(
         mode: NIOHTTP2Handler.ParserMode,
         configuration: NIOHTTP2Handler.Configuration = .init(),
         position: ChannelPipeline.Position = .last,
@@ -497,7 +497,7 @@ extension Channel {
     ///         channel has been fully mutated.
     /// - Returns: An `EventLoopFuture` of an `EventLoopFuture` containing the `NIOProtocolNegotiationResult` that completes when the channel
     ///     is ready to negotiate.
-    internal func configureHTTP2AsyncSecureUpgrade<HTTP1Output, HTTP2Output>(
+    internal func configureHTTP2AsyncSecureUpgrade<HTTP1Output: Sendable, HTTP2Output: Sendable>(
         http1ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP1Output>,
         http2ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP2Output>
     ) -> EventLoopFuture<EventLoopFuture<NIOProtocolNegotiationResult<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>>> {
@@ -538,13 +538,13 @@ extension Channel {
     ///   - http2ConnectionInitializer: An optional callback that will be invoked only when the negotiated protocol
     ///     is HTTP/2 to configure the connection channel.
     ///   - http2InboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    ///     It must output the stream `Channel` (either directly or wrapped in some form) to allow users to iterate over inbound streams.   
+    ///     The output of this closure is the element type of the returned multiplexer
     /// - Returns: An `EventLoopFuture` containing a ``NIOTypedApplicationProtocolNegotiationHandler`` that completes when the channel
     ///     is ready to negotiate. This can then be used to access the ``NIOProtocolNegotiationResult`` which may itself
     ///     be waited on to retrieve the result of the negotiation.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
-    public func configureAsyncHTTPServerPipeline<HTTP1ConnectionOutput, HTTP2ConnectionOutput, HTTP2StreamOutput>(
+    public func configureAsyncHTTPServerPipeline<HTTP1ConnectionOutput: Sendable, HTTP2ConnectionOutput: Sendable, HTTP2StreamOutput: Sendable>(
         http2Configuration: NIOHTTP2Handler.Configuration = .init(),
         http1ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP1ConnectionOutput>,
         http2ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP2ConnectionOutput>,
@@ -591,7 +591,7 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The settings that will be used when establishing the connection and new streams.
     ///   - position: The position in the pipeline into which to insert this handler.
     ///   - inboundStreamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
-    ///     It must output the stream `Channel` (either directly or wrapped in some form) to allow users to iterate over inbound streams.
+    ///     The output of this closure is the element type of the returned multiplexer
     /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
     /// be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -596,7 +596,7 @@ extension ChannelPipeline.SynchronousOperations {
     /// be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     @_spi(AsyncChannel)
-    public func configureAsyncHTTP2Pipeline<Output>(
+    public func configureAsyncHTTP2Pipeline<Output: Sendable>(
         mode: NIOHTTP2Handler.ParserMode,
         configuration: NIOHTTP2Handler.Configuration = .init(),
         position: ChannelPipeline.Position = .last,
@@ -608,7 +608,7 @@ extension ChannelPipeline.SynchronousOperations {
             connectionConfiguration: configuration.connection,
             streamConfiguration: configuration.stream,
             inboundStreamInitializerWithAnyOutput: { channel in
-                inboundStreamInitializer(channel).map { $0 }
+                inboundStreamInitializer(channel).map { return $0 }
             }
         )
 

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -253,7 +253,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         }
     }
 
-    func onInitializationResult<Output>(_ initializerResult: Result<Output, Error>, promise: EventLoopPromise<Output>?) {
+    func onInitializationResult<Output: Sendable>(_ initializerResult: Result<Output, Error>, promise: EventLoopPromise<Output>?) {
         switch initializerResult {
         case .success(let output):
             self.postInitializerActivate(output: output, promise: promise)
@@ -279,7 +279,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     }
 
     /// Activates the channel if the parent channel is active and succeeds the given `promise`.
-    private func postInitializerActivate<Output>(output: Output, promise: EventLoopPromise<Output>?) {
+    private func postInitializerActivate<Output: Sendable>(output: Output, promise: EventLoopPromise<Output>?) {
         // This force unwrap is safe as parent is assigned in the initializer, and never unassigned.
         // If parent is not active, we expect to receive a channelActive later.
         if self.parent!.isActive {
@@ -291,7 +291,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     }
 
     /// Handle any error that occurred during configuration.
-    private func configurationFailed<Output>(withError error: Error, promise: EventLoopPromise<Output>?) {
+    private func configurationFailed<Output: Sendable>(withError error: Error, promise: EventLoopPromise<Output>?) {
         switch self.state {
         case .idle, .localActive, .closed:
             // The stream isn't open on the network, nothing to close.

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -233,7 +233,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     // This variant is used in the async stream case.
     // It uses `Any`s because when called from `configureInboundStream` it is passed the initializer stored on the handler
     // which can't be a typed generic without changing the handler API.
-    internal func configure(initializer: (@escaping (Channel) -> EventLoopFuture<Any>), userPromise promise: EventLoopPromise<Any>?) {
+    internal func configure(initializer: (@escaping (Channel) -> EventLoopFuture<any Sendable>), userPromise promise: EventLoopPromise<Any>?) {
         assert(self.streamDataType == .framePayload)
         // We need to configure this channel. This involves doing four things:
         // 1. Setting our autoRead state from the parent

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -198,7 +198,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
                         self.onInitializationResult(result.map { self }, promise: promise)
                     }
                 } else {
-                    self.postInitializerActivate(promise: promise, output: self)
+                    self.postInitializerActivate(output: self, promise: promise)
                 }
             case .failure(let error):
                 self.configurationFailed(withError: error, promise: promise)
@@ -222,7 +222,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
                         self.onInitializationResult(result.map { self }, promise: promise)
                     }
                 } else {
-                    self.postInitializerActivate(promise: promise, output: self)
+                    self.postInitializerActivate(output: self, promise: promise)
                 }
             case .failure(let error):
                 self.configurationFailed(withError: error, promise: promise)
@@ -230,7 +230,10 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
         }
     }
 
-    internal func configure<Output>(initializer: @escaping NIOChannelInitializerWithOutput<Output>, userPromise promise: EventLoopPromise<Output>?) {
+    // This variant is used in the async stream case.
+    // It uses `Any`s because when called from `configureInboundStream` it is passed the initializer stored on the handler
+    // which can't be a typed generic without changing the handler API.
+    internal func configure(initializer: (@escaping (Channel) -> EventLoopFuture<Any>), userPromise promise: EventLoopPromise<Any>?) {
         assert(self.streamDataType == .framePayload)
         // We need to configure this channel. This involves doing four things:
         // 1. Setting our autoRead state from the parent
@@ -242,7 +245,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
             case .success(let autoRead):
                 self.autoRead = autoRead
                 initializer(self).whenComplete { result in
-                    self.onInitializationResult(result, promise: promise)
+                    self.onInitializationResult(result.map { $0 }, promise: promise)
                 }
             case .failure(let error):
                 self.configurationFailed(withError: error, promise: promise)
@@ -253,7 +256,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     func onInitializationResult<Output>(_ initializerResult: Result<Output, Error>, promise: EventLoopPromise<Output>?) {
         switch initializerResult {
         case .success(let output):
-            self.postInitializerActivate(promise: promise, output: output)
+            self.postInitializerActivate(output: output, promise: promise)
         case .failure(let error):
             self.configurationFailed(withError: error, promise: promise)
         }
@@ -276,7 +279,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore {
     }
 
     /// Activates the channel if the parent channel is active and succeeds the given `promise`.
-    private func postInitializerActivate<Output>(promise: EventLoopPromise<Output>?, output: Output) {
+    private func postInitializerActivate<Output>(output: Output, promise: EventLoopPromise<Output>?) {
         // This force unwrap is safe as parent is assigned in the initializer, and never unassigned.
         // If parent is not active, we expect to receive a channelActive later.
         if self.parent!.isActive {

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -249,7 +249,7 @@ extension HTTP2StreamMultiplexer {
     ///         failed if an error occurs.
     ///   - streamStateInitializer: A callback that will be invoked to allow you to configure the
     ///         `ChannelPipeline` for the newly created channel.
-    public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping (Channel) -> EventLoopFuture<Void>) {
+    public func createStreamChannel(promise: EventLoopPromise<Channel>?, _ streamStateInitializer: @escaping NIOChannelInitializer) {
         self.commonStreamMultiplexer.createStreamChannel(multiplexer: .legacy(LegacyOutboundStreamMultiplexer(multiplexer: self)), promise: promise, streamStateInitializer)
     }
 

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -215,12 +215,14 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                   inboundStreamStateInitializer: .includesStreamID(inboundStreamStateInitializer))
     }
 
-    private init(mode: NIOHTTP2Handler.ParserMode,
-                 channel: Channel,
-                 targetWindowSize: Int = 65535,
-                 outboundBufferSizeHighWatermark: Int,
-                 outboundBufferSizeLowWatermark: Int,
-                 inboundStreamStateInitializer: MultiplexerAbstractChannel.InboundStreamStateInitializer) {
+    private init(
+        mode: NIOHTTP2Handler.ParserMode,
+        channel: Channel,
+        targetWindowSize: Int = 65535,
+        outboundBufferSizeHighWatermark: Int,
+        outboundBufferSizeLowWatermark: Int,
+        inboundStreamStateInitializer: MultiplexerAbstractChannel.InboundStreamStateInitializer
+    ) {
         self.channel = channel
 
         self.commonStreamMultiplexer = HTTP2CommonInboundStreamMultiplexer(
@@ -229,7 +231,8 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             inboundStreamStateInitializer: inboundStreamStateInitializer,
             targetWindowSize: targetWindowSize,
             streamChannelOutboundBytesHighWatermark: outboundBufferSizeHighWatermark,
-            streamChannelOutboundBytesLowWatermark: outboundBufferSizeLowWatermark
+            streamChannelOutboundBytesLowWatermark: outboundBufferSizeLowWatermark,
+            streamInitializerProductContinuation: nil // async is only supported for the HTTP2Handler inline multiplexer
         )
     }
 }

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -215,14 +215,12 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
                   inboundStreamStateInitializer: .includesStreamID(inboundStreamStateInitializer))
     }
 
-    private init(
-        mode: NIOHTTP2Handler.ParserMode,
-        channel: Channel,
-        targetWindowSize: Int = 65535,
-        outboundBufferSizeHighWatermark: Int,
-        outboundBufferSizeLowWatermark: Int,
-        inboundStreamStateInitializer: MultiplexerAbstractChannel.InboundStreamStateInitializer
-    ) {
+    private init(mode: NIOHTTP2Handler.ParserMode,
+                 channel: Channel,
+                 targetWindowSize: Int = 65535,
+                 outboundBufferSizeHighWatermark: Int,
+                 outboundBufferSizeLowWatermark: Int,
+                 inboundStreamStateInitializer: MultiplexerAbstractChannel.InboundStreamStateInitializer) {
         self.channel = channel
 
         self.commonStreamMultiplexer = HTTP2CommonInboundStreamMultiplexer(
@@ -231,8 +229,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
             inboundStreamStateInitializer: inboundStreamStateInitializer,
             targetWindowSize: targetWindowSize,
             streamChannelOutboundBytesHighWatermark: outboundBufferSizeHighWatermark,
-            streamChannelOutboundBytesLowWatermark: outboundBufferSizeLowWatermark,
-            streamInitializerProductContinuation: nil // async is only supported for the HTTP2Handler inline multiplexer
+            streamChannelOutboundBytesLowWatermark: outboundBufferSizeLowWatermark
         )
     }
 }

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -141,7 +141,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         ``createStreamChannel(promise:_:)-18bxc``.
+    ///         ``createStreamChannel(promise:_:)-1jk0q``.
     @available(*, deprecated, renamed: "init(mode:channel:targetWindowSize:outboundBufferSizeHighWatermark:outboundBufferSizeLowWatermark:inboundStreamInitializer:)")
     public convenience init(mode: NIOHTTP2Handler.ParserMode, channel: Channel, targetWindowSize: Int = 65535, inboundStreamStateInitializer: ((Channel, HTTP2StreamID) -> EventLoopFuture<Void>)? = nil) {
         // We default to an 8kB outbound buffer size: this is a good trade off for avoiding excessive buffering while ensuring that decent
@@ -170,7 +170,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         ``createStreamChannel(promise:_:)-18bxc``.
+    ///         ``createStreamChannel(promise:_:)-1jk0q``.
     public convenience init(mode: NIOHTTP2Handler.ParserMode,
                             channel: Channel,
                             targetWindowSize: Int = 65535,
@@ -199,7 +199,7 @@ public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboun
     ///         channel that is created by the remote peer. For servers, these are channels created by
     ///         receiving a `HEADERS` frame from a client. For clients, these are channels created by
     ///         receiving a `PUSH_PROMISE` frame from a server. To initiate a new outbound channel, use
-    ///         ``createStreamChannel(promise:_:)-18bxc``.
+    ///         ``createStreamChannel(promise:_:)-1jk0q``.
     @available(*, deprecated, renamed: "init(mode:channel:targetWindowSize:outboundBufferSizeHighWatermark:outboundBufferSizeLowWatermark:inboundStreamInitializer:)")
     public convenience init(mode: NIOHTTP2Handler.ParserMode,
                             channel: Channel,

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -63,7 +63,7 @@ extension MultiplexerAbstractChannel {
     enum InboundStreamStateInitializer {
         case includesStreamID(((Channel, HTTP2StreamID) -> EventLoopFuture<Void>)?)
         case excludesStreamID(((Channel) -> EventLoopFuture<Void>)?)
-        case returnsAny(((Channel) -> EventLoopFuture<Any>))
+        case returnsAny(((Channel) -> EventLoopFuture<any Sendable>))
     }
 }
 
@@ -90,12 +90,21 @@ extension MultiplexerAbstractChannel {
         }
     }
 
-    func configureInboundStream(initializer: InboundStreamStateInitializer, promise: EventLoopPromise<Any>?) {
+    func configureInboundStream(initializer: InboundStreamStateInitializer) {
         switch initializer {
         case .includesStreamID(let initializer):
             self.baseChannel.configure(initializer: initializer, userPromise: nil)
         case .excludesStreamID(let initializer):
             self.baseChannel.configure(initializer: initializer, userPromise: nil)
+        case .returnsAny(let initializer):
+            self.baseChannel.configure(initializer: initializer, userPromise: nil)
+        }
+    }
+
+    func configureInboundStream(initializer: InboundStreamStateInitializer, promise: EventLoopPromise<Any>?) {
+        switch initializer {
+        case .includesStreamID, .excludesStreamID:
+            preconditionFailure("Configuration with a supplied `Any` promise is not supported with this initializer type.")
         case .returnsAny(let initializer):
             self.baseChannel.configure(initializer: initializer, userPromise: promise)
         }
@@ -112,7 +121,7 @@ extension MultiplexerAbstractChannel {
     }
 
     // used for async multiplexer
-    func configure(initializer: @escaping NIOChannelInitializerWithOutput<Any>, userPromise promise: EventLoopPromise<Any>?) {
+    func configure(initializer: @escaping NIOChannelInitializerWithOutput<any Sendable>, userPromise promise: EventLoopPromise<Any>?) {
         self.baseChannel.configure(initializer: initializer, userPromise: promise)
     }
 

--- a/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
+++ b/Sources/NIOHTTP2/MultiplexerAbstractChannel.swift
@@ -95,14 +95,7 @@ extension MultiplexerAbstractChannel {
         case .includesStreamID(let initializer):
             self.baseChannel.configure(initializer: initializer, userPromise: nil)
         case .excludesStreamID(let initializer):
-            let channelPromise: EventLoopPromise<Channel>?
-            if let promise = promise {
-                channelPromise = self.baseChannel.eventLoop.makePromise(of: Channel.self)
-                channelPromise!.completeWith(promise.futureResult.map { value in value as! Channel })
-            } else {
-                channelPromise = nil
-            }
-            self.baseChannel.configure(initializer: initializer, userPromise: channelPromise)
+            self.baseChannel.configure(initializer: initializer, userPromise: nil)
         case .returnsAny(let initializer):
             self.baseChannel.configure(initializer: initializer, userPromise: promise)
         }

--- a/Sources/NIOHTTP2PerformanceTester/Bench1Conn10kRequests.swift
+++ b/Sources/NIOHTTP2PerformanceTester/Bench1Conn10kRequests.swift
@@ -76,7 +76,7 @@ func setupServer(group: EventLoopGroup) throws -> Channel {
 
 func sendOneRequest(channel: Channel, multiplexer: HTTP2StreamMultiplexer) throws -> Int {
     let responseReceivedPromise = channel.eventLoop.makePromise(of: Int.self)
-    func requestStreamInitializer(channel: Channel) -> EventLoopFuture<Void> {
+    let requestStreamInitializer: NIOChannelInitializer = { channel in
         return channel.pipeline.addHandlers([HTTP2FramePayloadToHTTP1ClientCodec(httpProtocol: .https),
                                              SendRequestHandler(host: "127.0.0.1",
                                                                 request: .init(version: .init(major: 2, minor: 0),

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -203,13 +203,16 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
 
             // client
             for _ in 0 ..< requestCount {
-                let streamChannel = try await clientMultiplexer.createStreamChannel(
-                    asyncChannelConfiguration: .init(
-                        inboundType: HTTP2Frame.FramePayload.self,
-                        outboundType: HTTP2Frame.FramePayload.self
-                    )
-                ) { channel -> EventLoopFuture<Void> in
-                    channel.eventLoop.makeSucceededVoidFuture()
+                let streamChannel = try await clientMultiplexer.createStreamChannel() { channel in
+                    channel.eventLoop.makeCompletedFuture {
+                        try NIOAsyncChannel(
+                            synchronouslyWrapping: channel,
+                            configuration: .init(
+                                inboundType: HTTP2Frame.FramePayload.self,
+                                outboundType: HTTP2Frame.FramePayload.self
+                            )
+                        )
+                    }
                 }
                 // Let's try sending some requests
                 try await streamChannel.outboundWriter.write(ConfiguringPipelineAsyncMultiplexerTests.requestFramePayload)

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -204,7 +204,7 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
             // client
             for _ in 0 ..< requestCount {
                 let streamChannel = try await clientMultiplexer.createStreamChannel(
-                    configuration: .init(
+                    asyncChannelConfiguration: .init(
                         inboundType: HTTP2Frame.FramePayload.self,
                         outboundType: HTTP2Frame.FramePayload.self
                     )

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
@@ -24,9 +24,9 @@ import NIOHTTP1
 private extension Channel {
     /// Adds a simple no-op ``HTTP2StreamMultiplexer`` to the pipeline.
     func addNoOpInlineMultiplexer(mode: NIOHTTP2Handler.ParserMode, eventLoop: EventLoop) {
-        XCTAssertNoThrow(try self.pipeline.addHandler(NIOHTTP2Handler(mode: mode, eventLoop: eventLoop) { channel in
+        XCTAssertNoThrow(try self.pipeline.addHandler(NIOHTTP2Handler(mode: mode, eventLoop: eventLoop, inboundStreamInitializer: { channel in
             self.eventLoop.makeSucceededFuture(())
-        }).wait())
+        })).wait())
     }
 }
 

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -638,8 +638,9 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         // Now we're going to send a request, including a very large body: 65536 bytes in size. To avoid spending too much
         // time initializing buffers, we're going to send the same 1kB data frame 64 times.
         let headers = HPACKHeaders([(":path", "/"), (":method", "POST"), (":scheme", "https"), (":authority", "localhost")])
-        var requestBody = self.clientChannel.allocator.buffer(capacity: 1024)
-        requestBody.writeBytes(Array(repeating: UInt8(0x04), count: 1024))
+        var _requestBody = self.clientChannel.allocator.buffer(capacity: 1024)
+        _requestBody.writeBytes(Array(repeating: UInt8(0x04), count: 1024))
+        let requestBody = _requestBody
 
         // We're going to open a stream and queue up the frames for that stream.
         let handler = try self.clientChannel.pipeline.context(handlerType: HTTP2StreamMultiplexer.self).wait().handler as! HTTP2StreamMultiplexer
@@ -1796,7 +1797,7 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
             // Here we send a large response: 65535 bytes in size.
             let responseHeaders = HPACKHeaders([(":status", "200"), ("content-length", "65535")])
 
-            var responseBody = self.clientChannel.allocator.buffer(capacity: 65535)
+            var responseBody = channel.allocator.buffer(capacity: 65535)
             responseBody.writeBytes(Array(repeating: UInt8(0x04), count: 65535))
 
             let respFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: responseHeaders))
@@ -1814,11 +1815,10 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
 
         // We're going to open a stream and queue up the frames for that stream.
         let handler = try self.clientChannel.pipeline.handler(type: HTTP2StreamMultiplexer.self).wait()
-        var reqFrame: HTTP2Frame.FramePayload? = nil
+        let reqFrame = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: true))
 
         handler.createStreamChannel(promise: nil) { channel in
             // We need END_STREAM set here, because that will force the stream to be closed on the response.
-            reqFrame = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: true))
             channel.writeAndFlush(reqFrame, promise: nil)
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -1831,7 +1831,7 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         try self.serverChannel.assertReceivedFrame().assertWindowUpdateFrame(streamID: 0, windowIncrement: 65535)
 
         // And only the request frame frame for the child stream, as there was no need to open its stream window.
-        childHandler.receivedFrames.assertFramePayloadsMatch([reqFrame!])
+        childHandler.receivedFrames.assertFramePayloadsMatch([reqFrame])
 
         // No other frames should be emitted, though the client may have many in a child stream.
         self.serverChannel.assertNoFramesReceived()


### PR DESCRIPTION
## Motivation:

When adding in the SPI methods for exposing async sequences of HTTP/2 streams we moved the stream initialization to a subtly different location so that it was easier to exfiltrate the outputs of those initialization functions (such as protocol negotiation outputs).

In some cases this broke ordering expectations.

## Modifications:

Yield the (optionally wrapped) channels as initializer outputs to the async stream when the initialization and activation steps succeed.

## Result:

Changes only exist within SPI. Async inbound stream channel initialization now matches previous behavior.