### PR TITLE
DOSHeuristics DeadlineClock more explicit on 5.6

### DIFF
--- a/Sources/NIOHTTP2/DOSHeuristics.swift
+++ b/Sources/NIOHTTP2/DOSHeuristics.swift
@@ -30,6 +30,7 @@ struct DOSHeuristics<DeadlineClock: NIODeadlineClock> {
 
     private var resetFrameRateControlStateMachine: HTTP2ResetFrameRateControlStateMachine
 
+#if swift(>=5.7)
     internal init(maximumSequentialEmptyDataFrames: Int, maximumResetFrameCount: Int, resetFrameCounterWindow: TimeAmount, clock: DeadlineClock = RealNIODeadlineClock()) {
         precondition(maximumSequentialEmptyDataFrames >= 0,
                      "maximum sequential empty data frames must be positive, got \(maximumSequentialEmptyDataFrames)")
@@ -37,6 +38,20 @@ struct DOSHeuristics<DeadlineClock: NIODeadlineClock> {
         self.receivedEmptyDataFrames = 0
         self.resetFrameRateControlStateMachine = .init(countThreshold: maximumResetFrameCount, timeWindow: resetFrameCounterWindow, clock: clock)
     }
+#else
+    internal init(maximumSequentialEmptyDataFrames: Int, maximumResetFrameCount: Int, resetFrameCounterWindow: TimeAmount, clock: DeadlineClock) {
+        precondition(maximumSequentialEmptyDataFrames >= 0,
+                     "maximum sequential empty data frames must be positive, got \(maximumSequentialEmptyDataFrames)")
+        self.maximumSequentialEmptyDataFrames = maximumSequentialEmptyDataFrames
+        self.receivedEmptyDataFrames = 0
+
+        self.resetFrameRateControlStateMachine = .init(countThreshold: maximumResetFrameCount, timeWindow: resetFrameCounterWindow, clock: clock)
+    }
+
+    internal init(maximumSequentialEmptyDataFrames: Int, maximumResetFrameCount: Int, resetFrameCounterWindow: TimeAmount) where DeadlineClock == RealNIODeadlineClock {
+        self.init(maximumSequentialEmptyDataFrames: maximumSequentialEmptyDataFrames, maximumResetFrameCount: maximumResetFrameCount, resetFrameCounterWindow: resetFrameCounterWindow, clock: RealNIODeadlineClock())
+    }
+#endif
 }
 
 
@@ -89,6 +104,7 @@ extension DOSHeuristics {
         private var resetTimestamps: Deque<NIODeadline>
         private var _state: ResetFrameRateControlState = .noneReceived
 
+#if swift(>=5.7)
         init(countThreshold: Int, timeWindow: TimeAmount, clock: DeadlineClock = RealNIODeadlineClock()) {
             self.countThreshold = countThreshold
             self.timeWindow = timeWindow
@@ -96,6 +112,15 @@ extension DOSHeuristics {
 
             self.resetTimestamps = .init(minimumCapacity: self.countThreshold)
         }
+#else
+        init(countThreshold: Int, timeWindow: TimeAmount, clock: DeadlineClock) {
+            self.countThreshold = countThreshold
+            self.timeWindow = timeWindow
+            self.clock = clock
+
+            self.resetTimestamps = .init(minimumCapacity: self.countThreshold)
+        }
+#endif
 
         mutating func resetReceived() -> ResetFrameRateControlState {
             self.garbageCollect()

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=296050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=273050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=248050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1210050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=893050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
 
   shell:
     image: swift-nio-http2:20.04-5.6

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=296050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=273050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=248050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1210050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=893050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
 
   shell:
     image: swift-nio-http2:22.04-5.7

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -32,12 +32,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=296050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=273050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=248050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1210050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=893050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -45,8 +45,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -31,12 +31,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=296050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=273050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=248050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1210050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=893050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -44,8 +44,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -31,12 +31,12 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=34100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=41150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=40100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=294050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1208050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=296050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=273050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=265050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=248050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1210050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=893050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=39050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=39050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
@@ -44,8 +44,8 @@ services:
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292950
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=293050
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:

The type inference system isn't able to work out the default clock type in the DOSHeuristics init on Swift 5.6 so this change makes it more explicit

Modifications:

Add more explicit inits

Result:

The code should build on 5.6 and later