### PR TITLE
Remove retroactive `CustomDebugStringConvertible` conformance in tests

### DIFF
--- a/Tests/NIOHPACKTests/HPACKIntegrationTests.swift
+++ b/Tests/NIOHPACKTests/HPACKIntegrationTests.swift
@@ -335,15 +335,3 @@ fileprivate func encodeHex(data: ByteBuffer) -> String {
     }
     return result
 }
-
-extension ByteBufferView : CustomDebugStringConvertible {
-    public var debugDescription: String {
-        var desc = "\(self.count) bytes: ["
-        for byte in self {
-            let hexByte = String(byte, radix: 16)
-            desc += " \(hexByte.count == 1 ? "0" : "")\(hexByte)"
-        }
-        desc += " ]"
-        return desc
-    }
-}


### PR DESCRIPTION
# Motivation
We had a retroactive `CustomDebugStringConvertible` conformance to `ByteBufferView` in one of our tests harnesses which caused compiler errors in the latest nightlies.

# Modification
This PR removes the retroactive conformance.

# Result
No more compiler errors.