### PR TITLE
Add `Sendable` annotations to new async APIs

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1187,7 +1187,12 @@ extension NIOHTTP2Handler {
 
         switch self.inboundStreamMultiplexer {
         case let .some(.inline(multiplexer)):
-            return AsyncStreamMultiplexer(multiplexer, continuation: continuation, inboundStreamChannels: inboundStreamChannels)
+            return AsyncStreamMultiplexer(
+                multiplexer,
+                continuation: continuation,
+                inboundStreamChannels: inboundStreamChannels,
+                eventLoop: self.eventLoop!
+            )
         case .some(.legacy), .none:
             throw NIOHTTP2Errors.missingMultiplexer()
         }

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -605,7 +605,7 @@ extension ChannelPipeline.SynchronousOperations {
 }
 
 /// `NIONegotiatedHTTPVersion` is a generic negotiation result holder for HTTP/1.1 and HTTP/2
-public enum NIONegotiatedHTTPVersion<HTTP1Output: Sendable, HTTP2Output: Sendable> {
+public enum NIONegotiatedHTTPVersion<HTTP1Output: Sendable, HTTP2Output: Sendable>: Sendable {
     /// Protocol negotiation resulted in the connection using HTTP/1.1.
     case http1_1(HTTP1Output)
     /// Protocol negotiation resulted in the connection using HTTP/2.


### PR DESCRIPTION
# Motivation
We just released our new async APIs but forgot to mark the new types as `Sendable`. This is causing warnings for users and we should properly mark them as `Sendable` since we expect users to use them from concurrent contexts.

# Modification
Adding `Sendable` to the `NIONegotiatedHTTPVersion` was pretty straight forward; however, adding `Sendable` to `AsyncStreamMultiplexer` was a bit more complicated since it stored the `InlineStreamMultiplexer` which we cannot easily make `Sendable`. Hence, we are now holding the `InlineStreamMultiplexer` in a `NIOLoopBound` and are submitting the work to the correct `EventLoop` before we call the underlying multiplexer.

# Result
No more `Sendable` warnings for our users.