### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -22,6 +22,7 @@ import NIOHTTP1
 import NIOHTTP2
 import NIOTLS
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
     var clientChannel: NIOAsyncTestingChannel!
     var serverChannel: NIOAsyncTestingChannel!

--- a/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FramePayloadStreamMultiplexerTests.swift
@@ -589,6 +589,7 @@ final class HTTP2FramePayloadStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.finish())
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testFlushingOneChannelDoesntFlushThemAll() async throws {
         let writeTracker = FrameWriteRecorder()
         let (channelsStream, channelsContinuation) = AsyncStream.makeStream(of: Channel.self)
@@ -801,6 +802,7 @@ final class HTTP2FramePayloadStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.finish())
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testReadIsPerChannel() async throws {
         let firstStreamID = HTTP2StreamID(1)
         let secondStreamID = HTTP2StreamID(3)

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
@@ -598,6 +598,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.finish())
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testFlushingOneChannelDoesntFlushThemAll() async throws {
         let writeTracker = IODataWriteRecorder()
         let (channelsStream, channelsContinuation) = AsyncStream.makeStream(of: Channel.self)

--- a/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2StreamMultiplexerTests.swift
@@ -782,6 +782,7 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
     }
 
     @available(*, deprecated, message: "Deprecated so deprecated functionality can be tested without warnings")
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testFlushingOneChannelDoesntFlushThemAll() async throws {
         let writeTracker = FrameWriteRecorder()
 
@@ -998,6 +999,7 @@ final class HTTP2StreamMultiplexerTests: XCTestCase {
     }
 
     @available(*, deprecated, message: "Deprecated so deprecated functionality can be tested without warnings")
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testReadIsPerChannel() async throws {
         let firstStreamID = HTTP2StreamID(1)
         let secondStreamID = HTTP2StreamID(3)

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -66,6 +66,7 @@ extension XCTestCase {
     /// they make no forward progress.
     ///
     /// ** This function is racy and can lead to deadlocks, prefer the one-way variant which is less error-prone**
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func interactInMemory(_ first: NIOAsyncTestingChannel, _ second: NIOAsyncTestingChannel, file: StaticString = #filePath, line: UInt = #line) async throws {
         var operated: Bool
 
@@ -88,6 +89,7 @@ extension XCTestCase {
     }
 
     /// Have a `NIOAsyncTestingChannel` send data to another until it makes no forward progress.
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     static func deliverAllBytes(from source: NIOAsyncTestingChannel, to destination: NIOAsyncTestingChannel, file: StaticString = #filePath, line: UInt = #line) async throws {
         var operated: Bool
 
@@ -157,6 +159,7 @@ extension XCTestCase {
     ///
     /// If the handshake has not occurred, this will definitely call `XCTFail`. It may also throw if the
     /// channel is now in an indeterminate state.
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func assertDoHandshake(client: NIOAsyncTestingChannel, server: NIOAsyncTestingChannel,
                            clientSettings: [HTTP2Setting] = nioDefaultSettings, serverSettings: [HTTP2Setting] = nioDefaultSettings,
                            file: StaticString = #filePath, line: UInt = #line) async throws {
@@ -272,6 +275,7 @@ extension EmbeddedChannel {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension NIOAsyncTestingChannel {
     /// This function attempts to obtain a HTTP/2 frame from a connection. It must already have been
     /// sent, as this function does not call `interactInMemory`. If no frame has been received, this
@@ -896,6 +900,7 @@ func assertNoThrowWithValue<T>(
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func assertNoThrowWithValue<T>(
     _ body: @autoclosure () async throws -> T,
     defaultValue: T? = nil,
@@ -915,6 +920,7 @@ func assertNoThrowWithValue<T>(
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func assertNoThrow<T>(
     _ body: @autoclosure () async throws -> T,
     defaultValue: T? = nil,


### PR DESCRIPTION
## Motivation

Some of the test code was missing availability guards for Apple platforms, resulting in build failures for these platforms, e.g.

```
error: 'NIOAsyncTestingChannel' is only available in iOS 13.0 or newer
         var clientChannel: NIOAsyncTestingChannel!
```

## Modifications

Add missing availability guards. I've tried to keep them as scoped as possible. Some test suites used these as class properties, so these got a guard at suite level.

## Result

Tests can now build and run on iOS and other Apple platforms.