### PR TITLE
Use explicit 64-bit UInt64 to support 32-bit platforms

### DIFF
--- a/Sources/NIOHPACK/HPACKEncoder.swift
+++ b/Sources/NIOHPACK/HPACKEncoder.swift
@@ -133,12 +133,12 @@ public struct HPACKEncoder {
             self.state = .encoding
         case .resized(nil):
             // one resize
-            self.buffer.write(encodedInteger: UInt(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
             self.state = .encoding
         case let .resized(smallestSize?):
             // two resizes, one smaller than the other
-            self.buffer.write(encodedInteger: UInt(smallestSize), prefix: 5, prefixBits: 0x20)
-            self.buffer.write(encodedInteger: UInt(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(smallestSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
             self.state = .encoding
         default:
             break
@@ -174,12 +174,12 @@ public struct HPACKEncoder {
             self.state = .encoding
         case .resized(nil):
             // one resize
-            self.buffer.write(encodedInteger: UInt(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
             self.state = .encoding
         case let .resized(smallestSize?):
             // two resizes, one smaller than the other
-            self.buffer.write(encodedInteger: UInt(smallestSize), prefix: 5, prefixBits: 0x20)
-            self.buffer.write(encodedInteger: UInt(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(smallestSize), prefix: 5, prefixBits: 0x20)
+            self.buffer.write(encodedInteger: UInt64(self.allowedDynamicTableSize), prefix: 5, prefixBits: 0x20)
             self.state = .encoding
         default:
             break
@@ -250,13 +250,13 @@ public struct HPACKEncoder {
         if let (index, hasValue) = self.headerIndexTable.firstHeaderMatch(for: name, value: value) {
             if hasValue {
                 // purely indexed. Nice & simple.
-                self.buffer.write(encodedInteger: UInt(index), prefix: 7, prefixBits: 0x80)
+                self.buffer.write(encodedInteger: UInt64(index), prefix: 7, prefixBits: 0x80)
                 // everything is indexed-- nothing more to do!
                 return
             } else {
                 // no value, so append the index to represent the name, followed by the value's
                 // length
-                self.buffer.write(encodedInteger: UInt(index), prefix: 6, prefixBits: 0x40)
+                self.buffer.write(encodedInteger: UInt64(index), prefix: 6, prefixBits: 0x40)
                 // now encode and append the value string
                 self.appendEncodedString(value)
             }
@@ -278,10 +278,10 @@ public struct HPACKEncoder {
         if self.useHuffmanEncoding {
             // problem: we need to encode the length before the encoded bytes, so we can't just receive the length
             // after encoding to the target buffer itself. So we have to determine the length first.
-            self.buffer.write(encodedInteger: UInt(ByteBuffer.huffmanEncodedLength(of: utf8)), prefix: 7, prefixBits: 0x80)
+            self.buffer.write(encodedInteger: UInt64(ByteBuffer.huffmanEncodedLength(of: utf8)), prefix: 7, prefixBits: 0x80)
             self.buffer.writeHuffmanEncoded(bytes: utf8)
         } else {
-            self.buffer.write(encodedInteger: UInt(utf8.count), prefix: 7, prefixBits: 0)
+            self.buffer.write(encodedInteger: UInt64(utf8.count), prefix: 7, prefixBits: 0)
             self.buffer.writeBytes(utf8)
         }
     }
@@ -299,7 +299,7 @@ public struct HPACKEncoder {
         if let (index, _) = self.headerIndexTable.firstHeaderMatch(for: header, value: nil) {
             // we actually don't care if it has a value in this instance; we're only indexing the
             // name.
-            self.buffer.write(encodedInteger: UInt(index), prefix: 4, prefixBits: 0)
+            self.buffer.write(encodedInteger: UInt64(index), prefix: 4, prefixBits: 0)
             // now append the value
             self.appendEncodedString(value)
         } else {
@@ -320,7 +320,7 @@ public struct HPACKEncoder {
     private mutating func _appendNeverIndexed(header: String, value: String) {
         if let (index, _) = self.headerIndexTable.firstHeaderMatch(for: header, value: nil) {
             // we only use the index in this instance
-            self.buffer.write(encodedInteger: UInt(index), prefix: 4, prefixBits: 0x10)
+            self.buffer.write(encodedInteger: UInt64(index), prefix: 4, prefixBits: 0x10)
             // now append the value
             self.appendEncodedString(value)
         } else {

--- a/Sources/NIOHPACK/IntegerCoding.swift
+++ b/Sources/NIOHPACK/IntegerCoding.swift
@@ -24,7 +24,7 @@ import NIOCore
 ///   - prefixBits: Existing bits to place in that first byte of `buffer` before encoding `value`.
 /// - Returns: Returns the number of bytes used to encode the integer.
 @discardableResult
-func encodeInteger(_ value: UInt, to buffer: inout ByteBuffer,
+func encodeInteger(_ value: UInt64, to buffer: inout ByteBuffer,
                    prefix: Int, prefixBits: UInt8 = 0) -> Int {
     assert(prefix <= 8)
     assert(prefix >= 1)
@@ -51,7 +51,7 @@ func encodeInteger(_ value: UInt, to buffer: inout ByteBuffer,
     // the remaining bytes.
     // We can safely use unchecked subtraction here: we know that `k` is zero or greater, and that `value` is
     // either the same value or greater. As a result, this can be unchecked: it's always safe.
-    var n = value &- UInt(k)
+    var n = value &- UInt64(k)
     while n >= 128 {
         let nextByte = (1 << 7) | UInt8(truncatingIfNeeded: n & 0x7f)
         buffer.writeInteger(nextByte)
@@ -139,7 +139,7 @@ extension ByteBuffer {
         return result.value
     }
 
-    mutating func write(encodedInteger value: UInt, prefix: Int = 0, prefixBits: UInt8 = 0) {
+    mutating func write(encodedInteger value: UInt64, prefix: Int = 0, prefixBits: UInt8 = 0) {
         encodeInteger(value, to: &self, prefix: prefix, prefixBits: prefixBits)
     }
 }

--- a/Tests/NIOHPACKTests/IntegerCodingTests.swift
+++ b/Tests/NIOHPACKTests/IntegerCodingTests.swift
@@ -22,7 +22,7 @@ class IntegerCodingTests : XCTestCase {
     
     // MARK: - Array-based helpers
     
-    private func encodeIntegerToArray(_ value: UInt, prefix: Int) -> [UInt8] {
+    private func encodeIntegerToArray(_ value: UInt64, prefix: Int) -> [UInt8] {
         var data = [UInt8]()
         scratchBuffer.clear()
         let len = NIOHPACK.encodeInteger(value, to: &scratchBuffer, prefix: prefix)
@@ -91,7 +91,7 @@ class IntegerCodingTests : XCTestCase {
         XCTAssertEqual(data, [1, 255, 255, 255, 255, 255, 255, 255, 255, 33])
         
         // encoding max 64-bit unsigned integer, 1-bit prefix
-        data = encodeIntegerToArray(UInt(UInt64.max), prefix: 1)
+        data = encodeIntegerToArray(UInt64.max, prefix: 1)
         
         // calculations:
         //  subtract prefix:
@@ -149,6 +149,7 @@ class IntegerCodingTests : XCTestCase {
         XCTAssertEqual(try decodeInteger(from: [0b00101010], prefix: 8), 42)
 
         // Now some larger numbers:
+        #if !os(watchOS)
         XCTAssertEqual(try decodeInteger(from: [255, 129, 254, 255, 255, 255, 255, 255, 255, 33], prefix: 8), 2449958197289549824)
         XCTAssertEqual(try decodeInteger(from: [1, 255, 255, 255, 255, 255, 255, 255, 255, 33], prefix: 1), 2449958197289549824)
         XCTAssertEqual(try decodeInteger(from: [1, 254, 255, 255, 255, 255, 255, 255, 255, 127, 1], prefix: 1), Int.max)
@@ -158,6 +159,7 @@ class IntegerCodingTests : XCTestCase {
 
         // almost the same bytes, but a different prefix:
         XCTAssertEqual(try decodeInteger(from: [255, 128, 128, 128, 128, 128, 128, 128, 128, 127, 1], prefix: 8), 9151314442816848127)
+        #endif
 
         // now a silly version which should never have been encoded in so many bytes
         XCTAssertEqual(try decodeInteger(from: [255, 129, 128, 128, 128, 128, 128, 128, 128, 0], prefix: 8), 256)

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -1893,7 +1893,7 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
     }
 
     func testGreasedSettingsAreTolerated() throws {
-        let settings = nioDefaultSettings + [HTTP2Setting(parameter: .init(extensionSetting: 0xfafa), value: 0xf0f0f0f0)]
+        let settings = nioDefaultSettings + [HTTP2Setting(parameter: .init(extensionSetting: 0xfafa), value: 0xf0f0f0)]
         XCTAssertNoThrow(try self.basicHTTP2Connection(clientSettings: settings))
     }
 


### PR DESCRIPTION
## Motivation

This project doesn't currently build for watchOS because some tests make use of 64-bit integer literals.

```
IntegerCodingTests.swift:161:115: Integer literal '9151314442816848127' overflows when stored into 'Int'
```

Beyond the test code, the integer encoding logic makes use of `UInt`, which will be `UInt64` on some platforms and `UInt32` on others, e.g. some Apple Watch versions.

## Modifications

- Compile out the tests that use 64-bit integer literals with `#if !os(watchOS)`.
- Use explicit `UInt64` instead of `UInt` for encoding methods.

## Result

Code can now build for watchOS.


