### PR TITLE
fix Bench1Conn10kRequests crash

### DIFF
--- a/Sources/NIOHTTP2PerformanceTester/Bench1Conn10kRequests.swift
+++ b/Sources/NIOHTTP2PerformanceTester/Bench1Conn10kRequests.swift
@@ -86,9 +86,8 @@ func sendOneRequest(channel: Channel, multiplexer: HTTP2StreamMultiplexer) throw
                                              ErrorHandler()],
                                             position: .last)
     }
-    let loopBoundMultiplexer = NIOLoopBound(multiplexer, eventLoop: channel.eventLoop)
-    channel.eventLoop.execute {
-        loopBoundMultiplexer.value.createStreamChannel(promise: nil, requestStreamInitializer)
+    channel.pipeline.handler(type: HTTP2StreamMultiplexer.self).whenSuccess { multiplexer in
+      multiplexer.createStreamChannel(promise: nil, requestStreamInitializer)
     }
     return try responseReceivedPromise.futureResult.wait()
 }


### PR DESCRIPTION
### Motivation:

`Bench1Conn10kRequests` performance tester incorrectly used a `NIOLoopBound` to access the `HTTP2StreamMultiplexer` to create streams.

### Modifications:

Access the multiplexer by safely obtaining a reference to the handler.

### Result:

- `Bench1Conn10kRequests` are not broken