### PR TITLE
Avoid CoW while processing the next state when HTTP2FrameDecoder decodes

### DIFF
--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -1404,7 +1404,7 @@ extension HTTP2FrameDecoder {
             throw error
         }
     }
-    
+
     private var isAppending: Bool {
         if case .appending = self.state {
             return true

--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -796,17 +796,17 @@ struct HTTP2FrameDecoder {
                         newState = .awaitingClientMagic(state)
                         return .needMoreData
                     }
-                newState = .accumulatingFrameHeader(processResult)
-                return .continue
+                    newState = .accumulatingFrameHeader(processResult)
+                    return .continue
+                }
+                switch result {
+                case let .success(parseResult):
+                    return parseResult
+                case let .failure(error):
+                    newState = .awaitingClientMagic(state)
+                    throw error
+                }
             }
-            switch result {
-            case let .success(parseResult):
-                return parseResult
-            case let .failure(error):
-                newState = .awaitingClientMagic(state)
-                throw error
-            }
-        }
             
         case .initialized:
             // no bytes, no frame


### PR DESCRIPTION
Motivation:

CoWs appear when switching over the current state of the parser and holding it while also modifying it - inside `processNExtState()`. Following `append(bytes: ByteBuffer)`'s pattern, we should use a function that sets the state to an intermediary one with no associated data, before making the transformations.

Modifications:
- updated the `avoidParserCoW()` helper function to take into consideration throwing functions
- used it in the switch cases over the parser state inside `processNextState()` 

Result:

CoW will be avoided when changing the state of the HTTP2FrameDecoder while decoding, so we won't have unnecessary heap allocations.