### PR TITLE
test compiler not language version

### DIFF
--- a/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2CommonInboundStreamMultiplexer.swift
@@ -533,7 +533,7 @@ extension NIOHTTP2AsyncSequence.AsyncIterator: Sendable {}
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension NIOHTTP2AsyncSequence: Sendable where Output: Sendable {}
 
-#if swift(<5.9)
+#if compiler(<5.9)
 // this should be available in the std lib from 5.9 onwards
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingStream {

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineAsyncMultiplexerTests.swift
@@ -505,7 +505,7 @@ final class ConfiguringPipelineAsyncMultiplexerTests: XCTestCase {
     }
 }
 
-#if swift(<5.9)
+#if compiler(<5.9)
 // this should be available in the std lib from 5.9 onwards
 extension AsyncStream {
     internal static func makeStream(


### PR DESCRIPTION
We should check the compiler and not the language version. Technically it should be the SDK but `Async*Stream` ship in the standard library so this is fine. Checking the language version is definitely not correct.

https://github.com/apple/swift-nio/issues/2718