### PR TITLE
Reject long sequences of CONTINUATION frames

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1129,7 +1129,7 @@ extension NIOHTTP2Handler {
         public var contentLengthValidation: ValidationState = .enabled
         public var maximumSequentialEmptyDataFrames: Int = 1
         public var maximumBufferedControlFrames: Int = 10000
-        public let maximumSequentialContinuationFrames: Int = 5
+        public var maximumSequentialContinuationFrames: Int = 5
         public init() {}
     }
 

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -232,14 +232,12 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     ///   - maximumBufferedControlFrames: Controls the maximum buffer size of buffered outbound control frames. If we are unable to send control frames as
     ///         fast as we produce them we risk building up an unbounded buffer and exhausting our memory. To protect against this DoS vector, we put an
     ///         upper limit on the depth of this queue. Defaults to 10,000.
-    ///   - maximumSequentialContinuationFrames: The maximum number of sequential CONTINUATION frames.
     public convenience init(mode: ParserMode,
                             initialSettings: HTTP2Settings = nioDefaultSettings,
                             headerBlockValidation: ValidationState = .enabled,
                             contentLengthValidation: ValidationState = .enabled,
                             maximumSequentialEmptyDataFrames: Int = 1,
-                            maximumBufferedControlFrames: Int = 10000,
-                            maximumSequentialContinuationFrames: Int = 5) {
+                            maximumBufferedControlFrames: Int = 10000) {
         self.init(mode: mode,
                   eventLoop: nil,
                   initialSettings: initialSettings,
@@ -247,7 +245,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                   contentLengthValidation: contentLengthValidation,
                   maximumSequentialEmptyDataFrames: maximumSequentialEmptyDataFrames,
                   maximumBufferedControlFrames: maximumBufferedControlFrames,
-                  maximumSequentialContinuationFrames: maximumSequentialContinuationFrames,
+                  maximumSequentialContinuationFrames: 5,
                   maximumResetFrameCount: 200,
                   resetFrameCounterWindow: .seconds(30))
 

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -39,6 +39,9 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     /// The magic string sent by clients at the start of a HTTP/2 connection.
     private static let clientMagic: StaticString = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
+    /// The default value for the maximum number of sequential CONTINUATION frames.
+    private static let defaultMaximumSequentialContinuationFrames: Int = 5
+
     /// The event loop on which this handler will do work.
     @usableFromInline internal let _eventLoop: EventLoop?
 
@@ -215,7 +218,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                   contentLengthValidation: contentLengthValidation,
                   maximumSequentialEmptyDataFrames: 1,
                   maximumBufferedControlFrames: 10000,
-                  maximumSequentialContinuationFrames: 5,
+                  maximumSequentialContinuationFrames: NIOHTTP2Handler.defaultMaximumSequentialContinuationFrames,
                   maximumResetFrameCount: 200,
                   resetFrameCounterWindow: .seconds(30))
     }
@@ -245,7 +248,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                   contentLengthValidation: contentLengthValidation,
                   maximumSequentialEmptyDataFrames: maximumSequentialEmptyDataFrames,
                   maximumBufferedControlFrames: maximumBufferedControlFrames,
-                  maximumSequentialContinuationFrames: 5,
+                  maximumSequentialContinuationFrames: NIOHTTP2Handler.defaultMaximumSequentialContinuationFrames,
                   maximumResetFrameCount: 200,
                   resetFrameCounterWindow: .seconds(30))
 
@@ -318,7 +321,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
                   contentLengthValidation: ValidationState = .enabled,
                   maximumSequentialEmptyDataFrames: Int = 1,
                   maximumBufferedControlFrames: Int = 10000,
-                  maximumSequentialContinuationFrames: Int = 5,
+                  maximumSequentialContinuationFrames: Int = NIOHTTP2Handler.defaultMaximumSequentialContinuationFrames,
                   tolerateImpossibleStateTransitionsInDebugMode: Bool = false,
                   maximumResetFrameCount: Int = 200,
                   resetFrameCounterWindow: TimeAmount = .seconds(30)) {
@@ -1129,7 +1132,7 @@ extension NIOHTTP2Handler {
         public var contentLengthValidation: ValidationState = .enabled
         public var maximumSequentialEmptyDataFrames: Int = 1
         public var maximumBufferedControlFrames: Int = 10000
-        public var maximumSequentialContinuationFrames: Int = 5
+        public var maximumSequentialContinuationFrames: Int = NIOHTTP2Handler.defaultMaximumSequentialContinuationFrames
         public init() {}
     }
 

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -105,7 +105,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     private var inboundStreamMultiplexerState: InboundStreamMultiplexerState
 
     /// The maximum number of sequential CONTINUATION frames.
-    private var maximumSequentialContinuationFrames: Int
+    private let maximumSequentialContinuationFrames: Int
 
     @usableFromInline
     internal var inboundStreamMultiplexer: InboundStreamMultiplexer? {
@@ -1129,7 +1129,7 @@ extension NIOHTTP2Handler {
         public var contentLengthValidation: ValidationState = .enabled
         public var maximumSequentialEmptyDataFrames: Int = 1
         public var maximumBufferedControlFrames: Int = 10000
-        public var maximumSequentialContinuationFrames: Int = 5
+        public let maximumSequentialContinuationFrames: Int = 5
         public init() {}
     }
 

--- a/Sources/NIOHTTP2/HTTP2Error.swift
+++ b/Sources/NIOHTTP2/HTTP2Error.swift
@@ -298,6 +298,11 @@ public enum NIOHTTP2Errors {
         return ExcessiveRSTFrames(file: file, line: line)
     }
 
+    /// Creates an ``ExcessiveContinuationFrames`` error with appropriate source context.
+    public static func excessiveContinuationFrames(file: String = #fileID, line: UInt = #line) -> ExcessiveContinuationFrames {
+        return ExcessiveContinuationFrames(file: file, line: line)
+    }
+
     /// Creates a ``StreamError`` error with appropriate source context.
     ///
     /// - Parameters:
@@ -1737,6 +1742,26 @@ public enum NIOHTTP2Errors {
 
     /// The client has issued RST frames at an excessive rate resulting in the connection being defensively closed.
     public struct ExcessiveRSTFrames: NIOHTTP2Error {
+        private let file: String
+        private let line: UInt
+
+        /// The location where the error was thrown.
+        public var location: String {
+            return _location(file: self.file, line: self.line)
+        }
+
+        fileprivate init(file: String, line: UInt) {
+            self.file = file
+            self.line = line
+        }
+
+        public static func ==(lhs: Self, rhs: Self) -> Bool {
+            return true
+        }
+    }
+
+    /// A remote peer has sent a sequence of `CONTINUATION` frames longer than the configured limit.
+    public struct ExcessiveContinuationFrames: NIOHTTP2Error {
         private let file: String
         private let line: UInt
 

--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -705,7 +705,7 @@ struct HTTP2FrameDecoder {
 
     internal var headerDecoder: HPACKDecoder
     private var state: ParserState
-    private var maximumSequentialContinuationFrames: Int
+    private let maximumSequentialContinuationFrames: Int
 
     // RFC 7540 § 6.5.2 puts the initial value of SETTINGS_MAX_FRAME_SIZE at 2**14 octets
     internal var maxFrameSize: UInt32 = 1<<14
@@ -796,9 +796,7 @@ struct HTTP2FrameDecoder {
     mutating func nextFrame() throws -> (HTTP2Frame, flowControlledLength: Int)? {
         // Start running through our state machine until we run out of bytes or we emit a frame.
         while true {
-            switch (
-                try self.processNextState()
-            ) {
+            switch (try self.processNextState()) {
             case .needMoreData:
                 return nil
             case .frame(let frame, let flowControlledLength):

--- a/Sources/NIOHTTP2/HTTP2FrameParser.swift
+++ b/Sources/NIOHTTP2/HTTP2FrameParser.swift
@@ -157,7 +157,7 @@ struct HTTP2FrameDecoder {
     private struct AwaitingPaddingLengthByteParserState {
         private var header: FrameHeader
         private var accumulatedBytes: ByteBuffer
-        private var maximumSequentialContinuationFrames: Int
+        private let maximumSequentialContinuationFrames: Int
 
         init(fromAccumulatingFrameHeader state: AccumulatingFrameHeaderParserState, frameHeader: FrameHeader) {
             precondition(frameHeader.type.supportsPadding)
@@ -554,7 +554,7 @@ struct HTTP2FrameDecoder {
         private var continuationPayload: ByteBuffer
         private var originalPaddingBytes: Int?
         private var sequentialContinuationFramesCount: Int
-        private var maximumSequentialContinuationFrames: Int
+        private let maximumSequentialContinuationFrames: Int
 
         init(
             fromAccumulatingHeaderBlockFragments acc: AccumulatingHeaderBlockFragmentsParserState,

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -133,7 +133,7 @@ class ConnectionStateMachineTests: XCTestCase {
     var clientEncoder: HTTP2FrameEncoder!
     var clientDecoder: HTTP2FrameDecoder!
 
-    var maximumSequentialContinuationFrames: Int = 5
+    let maximumSequentialContinuationFrames: Int = 5
 
     static let requestHeaders = {
         return HPACKHeaders([(":method", "GET"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -133,6 +133,8 @@ class ConnectionStateMachineTests: XCTestCase {
     var clientEncoder: HTTP2FrameEncoder!
     var clientDecoder: HTTP2FrameDecoder!
 
+    var maximumSequentialContinuationFrames: Int = 5
+
     static let requestHeaders = {
         return HPACKHeaders([(":method", "GET"), (":authority", "localhost"), (":scheme", "https"), (":path", "/"), ("user-agent", "test")])
     }()
@@ -150,9 +152,17 @@ class ConnectionStateMachineTests: XCTestCase {
         self.client = .init(role: .client)
 
         self.serverEncoder = HTTP2FrameEncoder(allocator: ByteBufferAllocator())
-        self.serverDecoder = HTTP2FrameDecoder(allocator: ByteBufferAllocator(), expectClientMagic: true)
+        self.serverDecoder = HTTP2FrameDecoder(
+            allocator: ByteBufferAllocator(),
+            expectClientMagic: true,
+            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+        )
         self.clientEncoder = HTTP2FrameEncoder(allocator: ByteBufferAllocator())
-        self.clientDecoder = HTTP2FrameDecoder(allocator: ByteBufferAllocator(), expectClientMagic: false)
+        self.clientDecoder = HTTP2FrameDecoder(
+            allocator: ByteBufferAllocator(),
+            expectClientMagic: false,
+            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+        )
     }
 
     private func exchangePreamble(client: HTTP2Settings = HTTP2Settings(), server: HTTP2Settings = HTTP2Settings()) {

--- a/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2FrameParserTests.swift
@@ -836,11 +836,11 @@ class HTTP2FrameParserTests: XCTestCase {
     }
 
     func testMaximumSequentialContinuationFrames() throws {
-        let CONTINUATION: [UInt8] = [
+        let continuationBytes: [UInt8] = [
             // CONTINUATION frame with the END_HEADERS flag not set
             0x00, 0x00, 0x00,           // 3-byte payload length (0 bytes)
             0x09,                       // 1-byte frame type (CONTINUATION)
-            0x00,                       // 1-byte flags (END_HEADERS)
+            0x00,                       // 1-byte flags (none)
             0x00, 0x00, 0x00, 0x03,     // 4-byte stream identifier
         ]
 
@@ -886,7 +886,7 @@ class HTTP2FrameParserTests: XCTestCase {
 
             // The CONTINUATION frame with the END_HEADERS flag not set will be inserted just before
             // the CONTINUATION frame with the END_HEADERS flag set.
-            frameBytes.insert(contentsOf: CONTINUATION, at: frameBytes.endIndex - CONTINUATION.count)
+            frameBytes.insert(contentsOf: continuationBytes, at: frameBytes.endIndex - continuationBytes.count)
         }
     }
 

--- a/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2InlineStreamMultiplexerTests.swift
@@ -35,14 +35,11 @@ private struct MyError: Error { }
 typealias IODataWriteRecorder = WriteRecorder<IOData>
 
 extension IODataWriteRecorder {
-    func drainConnectionSetupWrites(
-        mode: NIOHTTP2Handler.ParserMode = .server,
-        maximumSequentialContinuationFrames: Int
-    ) throws {
+    func drainConnectionSetupWrites(mode: NIOHTTP2Handler.ParserMode = .server) throws {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: ByteBufferAllocator(),
             expectClientMagic: mode == .client,
-            maximumSequentialContinuationFrames: maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
 
         while self.flushedWrites.count > 0 {
@@ -77,7 +74,6 @@ extension HPACKHeaders {
 final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
     var channel: EmbeddedChannel!
     let allocator = ByteBufferAllocator()
-    let maximumSequentialContinuationFrames = 5
 
     override func setUp() {
         self.channel = EmbeddedChannel()
@@ -283,9 +279,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(frameReceiver).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try frameReceiver.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try frameReceiver.drainConnectionSetupWrites()
 
         // Let's send a bunch of headers frames. These will all be answered by RST_STREAM frames.
         let streamIDs = stride(from: 1, to: 100, by: 2).map { HTTP2StreamID($0) }
@@ -300,7 +294,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         for (idx, expectedFrame) in expectedFrames.enumerated() {
             if case .byteBuffer(let flushedWriteBuffer) = frameReceiver.flushedWrites[idx] {
@@ -326,9 +320,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(frameReceiver).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try frameReceiver.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try frameReceiver.drainConnectionSetupWrites()
 
         XCTAssertNoThrow(try self.channel.connect(to: SocketAddress(unixDomainSocketPath: "/whatever"), promise: nil))
 
@@ -347,7 +339,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         if case .byteBuffer(let flushedWriteBuffer) = frameReceiver.flushedWrites[0] {
             frameDecoder.append(bytes: flushedWriteBuffer)
@@ -372,9 +364,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(frameReceiver).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try frameReceiver.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try frameReceiver.drainConnectionSetupWrites()
 
         XCTAssertNoThrow(try self.channel.connect(to: SocketAddress(unixDomainSocketPath: "/whatever"), promise: nil))
 
@@ -394,7 +384,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         if case .byteBuffer(let flushedWriteBuffer) = frameReceiver.flushedWrites[0] {
             frameDecoder.append(bytes: flushedWriteBuffer)
@@ -418,9 +408,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(frameReceiver).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try frameReceiver.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try frameReceiver.drainConnectionSetupWrites()
 
         // Let's send a headers frame to open the stream.
         let streamID = HTTP2StreamID(1)
@@ -457,7 +445,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         if case .byteBuffer(let flushedWriteBuffer) = frameReceiver.flushedWrites[0] {
             frameDecoder.append(bytes: flushedWriteBuffer)
@@ -483,9 +471,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(frameReceiver).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try frameReceiver.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try frameReceiver.drainConnectionSetupWrites()
 
         // Let's send a headers frame to open the stream.
         let streamID = HTTP2StreamID(1)
@@ -507,7 +493,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         if case .byteBuffer(let flushedWriteBuffer) = frameReceiver.flushedWrites[0] {
             frameDecoder.append(bytes: flushedWriteBuffer)
@@ -584,7 +570,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(writeRecorder).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try writeRecorder.drainConnectionSetupWrites(maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames)
+        try writeRecorder.drainConnectionSetupWrites()
 
         // Let's send a headers frame to open the stream, along with some DATA frames.
         let streamID = HTTP2StreamID(1)
@@ -617,7 +603,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         var frameDecoder = HTTP2FrameDecoder(
             allocator: channel.allocator,
             expectClientMagic: false,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
+            maximumSequentialContinuationFrames: 5
         )
         if case .byteBuffer(let flushedWriteBuffer) = writeRecorder.flushedWrites[0] {
             frameDecoder.append(bytes: flushedWriteBuffer)
@@ -651,9 +637,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(writeTracker).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         XCTAssertNoThrow(try connectionSetup())
-        try writeTracker.drainConnectionSetupWrites(
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try writeTracker.drainConnectionSetupWrites()
 
         // Let's open two streams.
         let firstStreamID = HTTP2StreamID(1)
@@ -1141,10 +1125,7 @@ final class HTTP2InlineStreamMultiplexerTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(writeRecorder).wait())
         XCTAssertNoThrow(try self.channel.pipeline.addHandler(http2Handler).wait())
         (self.channel.eventLoop as! EmbeddedEventLoop).run()
-        try writeRecorder.drainConnectionSetupWrites(
-            mode: .client,
-            maximumSequentialContinuationFrames: self.maximumSequentialContinuationFrames
-        )
+        try writeRecorder.drainConnectionSetupWrites(mode: .client)
 
         let multiplexer = try http2Handler.multiplexer.wait()
         multiplexer.createStreamChannel(promise: nil) { channel in

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -1803,12 +1803,10 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         )
 
         let headersFrame: [UInt8] = [
-            0x00, 0x00, 0x01,           // 3-byte payload length (1 byte)
+            0x00, 0x00, 0x00,           // 3-byte payload length (0 bytes)
             0x01,                       // 1-byte frame type (HEADERS)
             0x00,                       // 1-byte flags (none)
             0x00, 0x00, 0x00, 0x03,     // 4-byte stream identifier
-            0x00,                       // payload
-
         ]
         let continuationFrame: [UInt8] = [
             0x00, 0x00, 0x00,           // 3-byte payload length (0 bytes)

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -201,13 +201,16 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
     func basicHTTP2Connection(clientSettings: HTTP2Settings = nioDefaultSettings,
                               serverSettings: HTTP2Settings = nioDefaultSettings,
                               maximumBufferedControlFrames: Int = 10000,
+                              maximumSequentialContinuationFrames: Int = 5,
                               withMultiplexerCallback multiplexerCallback: NIOChannelInitializer? = nil) throws {
         XCTAssertNoThrow(try self.clientChannel.pipeline.addHandler(NIOHTTP2Handler(mode: .client,
                                                                                     initialSettings: clientSettings,
-                                                                                    maximumBufferedControlFrames: maximumBufferedControlFrames)).wait())
+                                                                                    maximumBufferedControlFrames: maximumBufferedControlFrames,
+                                                                                    maximumSequentialContinuationFrames: maximumSequentialContinuationFrames)).wait())
         XCTAssertNoThrow(try self.serverChannel.pipeline.addHandler(NIOHTTP2Handler(mode: .server,
                                                                                     initialSettings: serverSettings,
-                                                                                    maximumBufferedControlFrames: maximumBufferedControlFrames)).wait())
+                                                                                    maximumBufferedControlFrames: maximumBufferedControlFrames,
+                                                                                    maximumSequentialContinuationFrames: maximumSequentialContinuationFrames)).wait())
 
         if let multiplexerCallback = multiplexerCallback {
             XCTAssertNoThrow(try self.clientChannel.pipeline.addHandler(HTTP2StreamMultiplexer(mode: .client,
@@ -1706,7 +1709,9 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
 
     func testForbidsExceedingMaxHeaderListSizeBeforeDecoding() throws {
         // Begin by getting the connection up.
-        try self.basicHTTP2Connection()
+        // Ensure that the limit for the number of sequential CONTINUATION frames is enough to
+        // accommodate exceeding the set max header list size.
+        try self.basicHTTP2Connection(maximumSequentialContinuationFrames: 225)
 
         // The server is going to shrink its value for max header list size.
         let newSettings = [HTTP2Setting(parameter: .maxHeaderListSize, value: 225)]
@@ -1787,6 +1792,65 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         XCTAssertNoThrow(try self.clientChannel.writeInbound(responseFrame))
 
         try self.clientChannel.assertReceivedFrame().assertGoAwayFrame(lastStreamID: .maxID, errorCode: UInt32(HTTP2ErrorCode.protocolError.networkCode), opaqueData: nil)
+    }
+
+    func testForbidsExceedingMaximumSequentialContinuationFrames() throws {
+        let maximumSequentialContinuationFrames = 5
+
+        // Begin by getting the connection up.
+        try self.basicHTTP2Connection(
+            maximumSequentialContinuationFrames: maximumSequentialContinuationFrames
+        )
+
+        let headersFrame: [UInt8] = [
+            0x00, 0x00, 0x01,           // 3-byte payload length (1 byte)
+            0x01,                       // 1-byte frame type (HEADERS)
+            0x00,                       // 1-byte flags (none)
+            0x00, 0x00, 0x00, 0x03,     // 4-byte stream identifier
+            0x00,                       // payload
+
+        ]
+        let continuationFrame: [UInt8] = [
+            0x00, 0x00, 0x00,           // 3-byte payload length (0 bytes)
+            0x09,                       // 1-byte frame type (CONTINUATION)
+            0x00,                       // 1-byte flags (none)
+            0x00, 0x00, 0x00, 0x03      // 4-byte stream identifier
+        ]
+
+        var firstBuffer = self.serverChannel.allocator.buffer(capacity: 128)
+        firstBuffer.writeBytes(headersFrame)
+        for _ in 0..<maximumSequentialContinuationFrames {
+            firstBuffer.writeBytes(continuationFrame)
+        }
+
+        // Sending this should not result in an error.
+        XCTAssertNoThrow(try self.serverChannel.writeInbound(firstBuffer))
+        XCTAssertNoThrow(XCTAssertNil(try self.serverChannel.readOutbound(as: ByteBuffer.self)))
+
+        // But if we send one more frame, that will be treated as an excess CONTINUATION frame.
+        XCTAssertThrowsError(
+            try self.serverChannel.writeInbound(
+                firstBuffer.getSlice(at: firstBuffer.writerIndex - 9, length: 9)!
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NIOHTTP2Errors.ExcessiveContinuationFrames,
+                NIOHTTP2Errors.excessiveContinuationFrames()
+            )
+        }
+        guard let responseFrame = try assertNoThrowWithValue(
+            self.serverChannel.readOutbound(as: ByteBuffer.self)
+        ) else {
+            XCTFail("Did not receive response frame")
+            return
+        }
+        XCTAssertNoThrow(try self.clientChannel.writeInbound(responseFrame))
+
+        try self.clientChannel.assertReceivedFrame().assertGoAwayFrame(
+            lastStreamID: .maxID,
+            errorCode: UInt32(HTTP2ErrorCode.enhanceYourCalm.networkCode),
+            opaqueData: nil
+        )
     }
 
     func testNoStreamWindowUpdateOnEndStreamFrameFromServer() throws {

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -263,7 +263,11 @@ extension EmbeddedChannel {
     func decodedSentFrames(file: StaticString = #filePath, line: UInt = #line) throws -> [HTTP2Frame] {
         var receivedFrames: [HTTP2Frame] = Array()
 
-        var frameDecoder = HTTP2FrameDecoder(allocator: self.allocator, expectClientMagic: false)
+        var frameDecoder = HTTP2FrameDecoder(
+            allocator: self.allocator,
+            expectClientMagic: false,
+            maximumSequentialContinuationFrames: 5
+        )
         while let buffer = try assertNoThrowWithValue(self.readOutbound(as: ByteBuffer.self), file: (file), line: line) {
             frameDecoder.append(bytes: buffer)
             if let (frame, _) = try frameDecoder.nextFrame() {


### PR DESCRIPTION
Motivation:

Long sequences of CONTINUATION frames can be used to mount attacks by attempting to get a remote peer to consume large amounts of memory.

Modifications:

- Add a limit to the number of sequential CONTINUATION frames that can be received. This limit is configurable by users at the NIOHTTP2Handler level and has a default value of 5. When this limit is exceeded, the recipient responds with a GOAWAY frame and an "Enhance Your Calm" error of a newly created type `ExcessiveContinuationFrames`.

Result:

Long sequences of CONTINUATION frames are now rejected by the recipient.