### PR TITLE
Fix bug where client ignores HEADERS frames on open stream when locally quiescing

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1753,19 +1753,6 @@ extension HTTP2StreamID {
     }
 }
 
-extension HTTP2ConnectionStateMachine.ConnectionRole {
-    /// Obtain the inverse role to self
-    /// - Returns: The inverse role
-    fileprivate func inverse() -> Self {
-        switch self {
-        case .server:
-            return .client
-        case .client:
-            return .server
-        }
-    }
-}
-
 /// A simple protocol that provides helpers that apply to all connection states that keep track of a role.
 protocol ConnectionStateWithRole {
     var role: HTTP2ConnectionStateMachine.ConnectionRole { get }
@@ -1773,7 +1760,12 @@ protocol ConnectionStateWithRole {
 
 extension ConnectionStateWithRole {
     var peerRole: HTTP2ConnectionStateMachine.ConnectionRole {
-        return self.role.inverse()
+        switch self.role {
+        case .client:
+            return .server
+        default:
+            return .client
+        }
     }
 }
 

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1764,7 +1764,7 @@ extension ConnectionStateWithRole {
         switch self.role {
         case .client:
             return .server
-        default:
+        case .server:
             return .client
         }
     }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1753,20 +1753,27 @@ extension HTTP2StreamID {
     }
 }
 
+extension HTTP2ConnectionStateMachine.ConnectionRole {
+    /// Obtain the inverse role to self
+    /// - Returns: The inverse role
+    fileprivate func inverse() -> Self {
+        switch self {
+        case .server:
+            return .client
+        case .client:
+            return .server
+        }
+    }
+}
 
 /// A simple protocol that provides helpers that apply to all connection states that keep track of a role.
-private protocol ConnectionStateWithRole {
+protocol ConnectionStateWithRole {
     var role: HTTP2ConnectionStateMachine.ConnectionRole { get }
 }
 
 extension ConnectionStateWithRole {
     var peerRole: HTTP2ConnectionStateMachine.ConnectionRole {
-        switch self.role {
-        case .client:
-            return .server
-        case .server:
-            return .client
-        }
+        return self.role.inverse()
     }
 }
 

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1753,6 +1753,7 @@ extension HTTP2StreamID {
     }
 }
 
+
 /// A simple protocol that provides helpers that apply to all connection states that keep track of a role.
 protocol ConnectionStateWithRole {
     var role: HTTP2ConnectionStateMachine.ConnectionRole { get }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
@@ -17,7 +17,7 @@ import NIOHPACK
 /// can validly accept headers.
 ///
 /// This protocol should only be conformed to by states for the HTTP/2 connection state machine.
-protocol ReceivingHeadersState: HasFlowControlWindows, HasLocalExtendedConnectSettings, HasRemoteExtendedConnectSettings {
+protocol ReceivingHeadersState: HasFlowControlWindows, HasLocalExtendedConnectSettings, HasRemoteExtendedConnectSettings, ConnectionStateWithRole {
     var role: HTTP2ConnectionStateMachine.ConnectionRole { get }
 
     var headerBlockValidation: HTTP2ConnectionStateMachine.ValidationState { get }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
@@ -61,6 +61,7 @@ extension ReceivingHeadersState {
     }
 }
 
+
 extension ReceivingHeadersState where Self: LocallyQuiescingState {
     /// Called when we receive a HEADERS frame in this state.
     ///

--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
@@ -61,19 +61,6 @@ extension ReceivingHeadersState {
     }
 }
 
-extension HTTP2ConnectionStateMachine.ConnectionRole {
-    /// Obtain the inverse role to self
-    /// - Returns: The inverse role
-    fileprivate func inverse() -> Self {
-        switch self {
-        case .server:
-            return .client
-        case .client:
-            return .server
-        }
-    }
-}
-
 extension ReceivingHeadersState where Self: LocallyQuiescingState {
     /// Called when we receive a HEADERS frame in this state.
     ///
@@ -86,10 +73,10 @@ extension ReceivingHeadersState where Self: LocallyQuiescingState {
         let localSupportsExtendedConnect = self.localSupportsExtendedConnect
         let remoteSupportsExtendedConnect = self.remoteSupportsExtendedConnect
 
-        // We are in `LocallyQuiescingState`. The sender of the GOAWAY is `self.role`, so the receiver is the inverse of `self.role`.
-        let receiver = self.role.inverse()
+        // We are in `LocallyQuiescingState`. The sender of the GOAWAY is `self.role`, so the remote peer is the inverse of `self.role`.
+        let remotePeer = self.peerRole
 
-        if streamID.mayBeInitiatedBy(receiver) && streamID > self.lastRemoteStreamID {
+        if streamID.mayBeInitiatedBy(remotePeer) && streamID > self.lastRemoteStreamID {
             return StateMachineResultWithEffect(result: .ignoreFrame, effect: nil)
         }
 

--- a/Sources/NIOHTTP2/ConnectionStateMachine/LocallyQuiescingState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/LocallyQuiescingState.swift
@@ -16,6 +16,6 @@
 /// the remote peer may not initiate new streams.
 ///
 /// This protocol should only be conformed to by states for the HTTP/2 connection state machine.
-protocol LocallyQuiescingState {
+protocol LocallyQuiescingState: ConnectionStateWithRole {
     var lastRemoteStreamID: HTTP2StreamID { get set }
 }

--- a/Sources/NIOHTTP2/ConnectionStateMachine/LocallyQuiescingState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/LocallyQuiescingState.swift
@@ -16,6 +16,6 @@
 /// the remote peer may not initiate new streams.
 ///
 /// This protocol should only be conformed to by states for the HTTP/2 connection state machine.
-protocol LocallyQuiescingState: ConnectionStateWithRole {
+protocol LocallyQuiescingState {
     var lastRemoteStreamID: HTTP2StreamID { get set }
 }

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -988,7 +988,7 @@ class ConnectionStateMachineTests: XCTestCase {
     func testHeadersOnOpenStreamLocallyQuiescing() {
         let streamOne = HTTP2StreamID(1)
 
-        exchangePreamble()
+        self.exchangePreamble()
 
         // Client sends headers
         assertSucceeds(client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: false))

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -985,6 +985,29 @@ class ConnectionStateMachineTests: XCTestCase {
         XCTAssertTrue(self.client.fullyQuiesced)
     }
 
+    func testHeadersOnOpenStreamLocallyQuiescing() {
+        let streamOne = HTTP2StreamID(1)
+
+        exchangePreamble()
+
+        // Client sends headers
+        assertSucceeds(client.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: false))
+        assertSucceeds(server.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.requestHeaders, isEndStreamSet: false))
+
+        // Server responds with headers
+        assertSucceeds(server.sendHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+        assertSucceeds(client.receiveHeaders(streamID: streamOne, headers: ConnectionStateMachineTests.responseHeaders, isEndStreamSet: false))
+
+        // Client sends a GOAWAY with lastStreamID = 0
+        assertGoawaySucceeds(client.sendGoaway(lastStreamID: 0), droppingStreams: nil)
+        assertGoawaySucceeds(server.receiveGoaway(lastStreamID: 0), droppingStreams: nil)
+
+        // Server sends a header frame with end stream = true
+        let headerFrame = HPACKHeaders([("content-length", "0")])
+        assertSucceeds(server.sendHeaders(streamID: streamOne, headers: headerFrame, isEndStreamSet: true))
+        assertSucceeds(client.receiveHeaders(streamID: streamOne, headers: headerFrame, isEndStreamSet: true))
+    }
+
     func testImplicitConnectionCompletion() {
         // Connections can become totally idle by way of the server quiescing the client, and then having no outstanding streams.
         // This test validates that we spot it and consider the connection closed at this stage.


### PR DESCRIPTION
### Motivation:

Currently, HEADERS frames are ignored by the client on a client-initiated stream after the client sends a GOAWAY.

As per [Section 6.8 (GOAWAY) in RFC 9113](https://httpwg.org/specs/rfc9113#GOAWAY):
_"Once the GOAWAY is sent, the sender will ignore frames sent on streams **initiated by the receiver** if the stream has an identifier higher than the included last stream identifier."_

In this case, the client (sender) should **not** ignore the HEADERS frame as the stream is initiated by the _client_, not the receiver.

### Modifications:

Fixed the condition in the `receiveHeaders` function (given `LocallyQuiescingState`) in `ReceivingHeadersState.swift` to work for _both_ the client and server roles -- before this change, the condition is only correct when `self.role == ConnectionRole.server`.

### Result:

HEADERS frames are not ignored by the client on a client-initiated stream when locally quiescing.