### PR TITLE
Keep capacity when dropping pending reads in the stream channel

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -728,7 +728,7 @@ private extension HTTP2StreamChannel {
     /// Drop all pending reads.
     private func dropPendingReads() {
         /// We don't need to report the dropped reads, just remove them all.
-        self.pendingReads.removeAll()
+        self.pendingReads.removeAll(keepingCapacity: true)
     }
 
     /// Deliver all pending reads to the channel.

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -28,25 +28,25 @@ services:
   test:
     image: swift-nio-http2:22.04-5.10
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=34150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=33100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=40150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=39100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=286050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=255050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1200050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=38050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=38050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=33150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=32100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=39150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=38100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=284050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=253050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1198050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=282650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=281750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -28,25 +28,25 @@ services:
   test:
     image: swift-nio-http2:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=34150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=33100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=40150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=39100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=286050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=255050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1200050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=38050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=38050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=33150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=32100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=39150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=38100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=284050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=253050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1198050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=282650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=281750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -28,25 +28,25 @@ services:
   test:
     image: swift-nio-http2:22.04-5.9
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=34150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=33100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=40150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=39100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=286050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=271050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=255050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=246050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1200050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=891050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=38050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=38050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=33150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=32100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=39150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=38100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=284050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=269050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=253050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=244050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1198050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=292650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=291750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=282650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=281750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:

When the stream channel has closed it drops all of its pending reads. It does this by calling 'removeAll()' on its CircularBuffer. The buffers underlying storage is emptied and then a `nil` is appended (internally CircularBuffer is never empty) which triggers an allocation.

Modifications:

- Remove all but keep capacity

Result:

Fewer allocations