### PR TITLE
Use Bionic module from new Android overlay in Swift 6 instead

### DIFF
--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -14,9 +14,10 @@
 
 #if canImport(Darwin)
 import Darwin.C
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
-#else
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 import XCTest


### PR DESCRIPTION
Swift 6 has switched to this new Android overlay, swiftlang/swift#74758, which I've been testing on this repo without a problem using my daily Android CI for weeks now, finagolfin/swift-android-sdk#151.