### PR TITLE
Reduce allocs in HTTP2StreamChannel

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -925,7 +925,7 @@ internal extension HTTP2StreamChannel {
             // Do nothing here.
             return
         case .remoteActive, .active, .closing, .closingNeverActivated, .closed:
-            self.flags.withLockedValue { $0.isActive = localValue }
+            self.flags.withLockedValue { $0.isWritable = localValue }
             self.pipeline.fireChannelWritabilityChanged()
         }
     }

--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -169,8 +169,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
         self.streamID = streamID
         self.multiplexer = multiplexer
         self.windowManager = InboundWindowManager(targetSize: Int32(targetWindowSize))
-        self._isActiveAtomic = .init(false)
-        self._isWritable = .init(true)
+        self.flags = NIOLockedValueBox(Flags(isActive: false, isWritable: true))
         self.state = .idle
         self.streamDataType = streamDataType
         self.writabilityManager = StreamChannelFlowController(highWatermark: outboundBytesHighWatermark,
@@ -334,10 +333,18 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
         }
         self.modifyingState { $0.networkActive() }
 
-        if self.writabilityManager.isWritable != self._isWritable.load(ordering: .relaxed) {
-            // We have probably delayed telling the user that this channel isn't writable, but we should do
-            // it now.
-            self._isWritable.store(self.writabilityManager.isWritable, ordering: .relaxed)
+        let writabilityChanged = self.flags.withLockedValue {
+            if self.writabilityManager.isWritable != $0.isWritable {
+                $0.isWritable.toggle()
+                return true
+            } else {
+                return false
+            }
+        }
+
+        // We have probably delayed telling the user that this channel isn't writable, but we should do
+        // it now.
+        if writabilityChanged {
             self.pipeline.fireChannelWritabilityChanged()
         }
 
@@ -433,21 +440,24 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
         }
     }
 
-    public var isWritable: Bool {
-        return self._isWritable.load(ordering: .relaxed)
+    private struct Flags {
+        var isActive: Bool
+        var isWritable: Bool
     }
 
-    private let _isWritable: ManagedAtomic<Bool>
+    private let flags: NIOLockedValueBox<Flags>
+
+    public var isWritable: Bool {
+        self.flags.withLockedValue { $0.isWritable }
+    }
 
     private var _isActive: Bool {
         return self.state == .active || self.state == .closing || self.state == .localActive
     }
 
     public var isActive: Bool {
-        return self._isActiveAtomic.load(ordering: .relaxed)
+        self.flags.withLockedValue { $0.isActive }
     }
-
-    private let _isActiveAtomic: ManagedAtomic<Bool>
 
     public var _channelCore: ChannelCore {
         return self
@@ -709,7 +719,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
     }
 
     private func changeWritability(to newWritability: Bool) {
-        self._isWritable.store(newWritability, ordering: .relaxed)
+        self.flags.withLockedValue { $0.isWritable = newWritability }
         self.pipeline.fireChannelWritabilityChanged()
     }
 
@@ -915,7 +925,7 @@ internal extension HTTP2StreamChannel {
             // Do nothing here.
             return
         case .remoteActive, .active, .closing, .closingNeverActivated, .closed:
-            self._isWritable.store(localValue, ordering: .relaxed)
+            self.flags.withLockedValue { $0.isActive = localValue }
             self.pipeline.fireChannelWritabilityChanged()
         }
     }
@@ -930,7 +940,7 @@ extension HTTP2StreamChannel {
     // A helper function used to ensure that state modification leads to changes in the channel active atomic.
     private func modifyingState<ReturnType>(_ closure: (inout StreamChannelState) throws -> ReturnType) rethrows -> ReturnType {
         defer {
-            self._isActiveAtomic.store(self._isActive, ordering: .relaxed)
+            self.flags.withLockedValue { $0.isActive = self._isActive }
         }
         return try closure(&self.state)
     }

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -28,26 +28,27 @@ services:
   test:
     image: swift-nio-http2:22.04-5.10
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=30150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=272650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=271750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -28,20 +28,19 @@ services:
   test:
     image: swift-nio-http2:22.04-5.10
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=31150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=30100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=37150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=36100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=280050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=249050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=240050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1194050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=885050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -28,20 +28,19 @@ services:
   test:
     image: swift-nio-http2:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=31150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=30100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=37150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=36100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=280050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=249050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=240050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1194050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=885050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -28,26 +28,27 @@ services:
   test:
     image: swift-nio-http2:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=30150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=272650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=271750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -28,20 +28,19 @@ services:
   test:
     image: swift-nio-http2:22.04-5.9
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=31150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=30100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=37150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=36100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=280050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=249050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=240050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1194050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=885050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -28,26 +28,27 @@ services:
   test:
     image: swift-nio-http2:22.04-5.9
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=32150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=31100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=38150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=37100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=282050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=267050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=251050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=242050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1196050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=887050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=30150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=272650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=271750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -27,27 +27,27 @@ services:
   test:
     image: swift-nio-http2:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=31150
-      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=30100
-      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=37150
-      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=36100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=280050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=265050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=249050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=240050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1194050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=885050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_interleaved=30150
+      - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
+      - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
+      - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=272650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=271750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:

The HTTP2StreamChannel stores two atomic booleans for whether the channel is active and writable. These are only accessed externally and access is relatively infrequent. Each atomic requires an allocation, instead we can just protect each with a single lock.

Modifications:

- Combine the two atomics into a single 'flags' struct protected by a locked value box

Result:

Fewer alloations