### PR TITLE
Reduce allocations on `InlineStreamMultiplexer/createStreamChannel`

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -40,7 +40,7 @@ services:
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=44050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -40,7 +40,7 @@ services:
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=44050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -40,7 +40,7 @@ services:
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=44050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -39,7 +39,7 @@ services:
       - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=889050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=37050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=44050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=37050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050


### PR DESCRIPTION
## Motivation
When creating stream channels on the `InlineStreamMultiplexer`, we are currently performing a `flatSubmit` on two different codepaths. This allocates two ELFs: one on `submit`, and one on `flatMap`. This is unnecessary, as we could do with just one allocation.

## Modifications
Create a single ELP and call `execute` on the EL instead of using `flatSubmit`.

## Result
Fewer allocations