### PR TITLE
Adopt `release.yml`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none


### PR DESCRIPTION
# Motivation

We want to start using the GH based release notes drafting to make it easier for publishing new releases.

# Modification

This PR adds the `release.yml` and configured the correct labels