### PR TITLE
Update allocation limits

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -32,23 +32,23 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=276050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=245050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=236050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1190050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=881050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=35050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -32,23 +32,23 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=276050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=245050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=236050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1190050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=881050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=35050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -32,23 +32,23 @@ services:
       - MAX_ALLOCS_ALLOWED_1k_requests_inline_noninterleaved=29100
       - MAX_ALLOCS_ALLOWED_1k_requests_interleaved=36150
       - MAX_ALLOCS_ALLOWED_1k_requests_noninterleaved=35100
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=278050
-      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=263050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response=247050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=238050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1192050
-      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=883050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=36050
-      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=36050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response=276050
+      - MAX_ALLOCS_ALLOWED_client_server_h1_request_response_inline=261050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response=245050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_inline=236050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many=1190050
+      - MAX_ALLOCS_ALLOWED_client_server_request_response_many_inline=881050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_inline_no_promise_based_API=35050
+      - MAX_ALLOCS_ALLOWED_create_client_stream_channel_no_promise_based_API=35050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace=200050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_long_string=300050
       - MAX_ALLOCS_ALLOWED_get_100000_headers_canonical_form_trimming_whitespace_from_short_string=200050
       - MAX_ALLOCS_ALLOWED_hpack_decoding=5050
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262650
-      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261750
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent=262550
+      - MAX_ALLOCS_ALLOWED_stream_teardown_100_concurrent_inline=261650
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
Motivation:

The most recent NIO release reduced allocations, now our limits are too high.

Modifications:

- Update alloc limits

Result:

CI passes