### PR TITLE
Accept PING frames even when fully quiesced

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1187,15 +1187,12 @@ extension HTTP2ConnectionStateMachine {
         // RFC 7540 that says that sending PINGs with ACK flags set when no PING ACKs are expected is forbidden. This is
         // very strange, but we allow it.
         switch self.state {
-        case .prefaceSent, .active, .locallyQuiesced, .remotelyQuiesced, .bothQuiescing, .quiescingPrefaceSent:
+        case .prefaceSent, .active, .locallyQuiesced, .remotelyQuiesced, .bothQuiescing, .quiescingPrefaceSent, .fullyQuiesced:
             return .init(result: .succeed, effect: nil)
 
         case .idle, .prefaceReceived, .quiescingPrefaceReceived:
             // We're waiting for the local preface.
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.missingPreface(), type: .protocolError), effect: nil)
-
-        case .fullyQuiesced:
-            return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.ioOnClosedConnection(), type: .protocolError), effect: nil)
 
         case .modifying:
             preconditionFailure("Must not be left in modifying state")

--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -1169,15 +1169,12 @@ extension HTTP2ConnectionStateMachine {
         // RFC 7540 that says that receiving PINGs with ACK flags set when no PING ACKs are expected is forbidden. This is
         // very strange, but we allow it.
         switch self.state {
-        case .prefaceReceived, .active, .locallyQuiesced, .remotelyQuiesced, .bothQuiescing, .quiescingPrefaceReceived:
+        case .prefaceReceived, .active, .locallyQuiesced, .remotelyQuiesced, .bothQuiescing, .quiescingPrefaceReceived, .fullyQuiesced:
             return (.init(result: .succeed, effect: nil), ackFlagSet ? .nothing : .sendAck)
 
         case .idle, .prefaceSent, .quiescingPrefaceSent:
             // We're waiting for the remote preface.
             return (.init(result: .connectionError(underlyingError: NIOHTTP2Errors.missingPreface(), type: .protocolError), effect: nil), .nothing)
-
-        case .fullyQuiesced:
-            return (.init(result: .connectionError(underlyingError: NIOHTTP2Errors.ioOnClosedConnection(), type: .protocolError), effect: nil), .nothing)
 
         case .modifying:
             preconditionFailure("Must not be left in modifying state")

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -1064,7 +1064,6 @@ class ConnectionStateMachineTests: XCTestCase {
         assertConnectionError(type: .protocolError, self.client.receivePushPromise(originalStreamID: streamOne, childStreamID: streamTwo, headers: ConnectionStateMachineTests.requestHeaders))
 
         // Connectiony things don't work either.
-        assertConnectionError(type: .protocolError, self.client.sendPing())
         assertConnectionError(type: .protocolError, self.client.sendPriority())
         assertConnectionError(type: .protocolError, self.server.receivePriority())
         assertConnectionError(type: .protocolError, self.client.sendSettings([]))
@@ -1074,8 +1073,10 @@ class ConnectionStateMachineTests: XCTestCase {
         assertSucceeds(self.client.sendGoaway(lastStreamID: .rootStream))
         assertSucceeds(self.server.receiveGoaway(lastStreamID: .rootStream))
 
-        // Receiving ping is cool too.
+        // PINGing is cool too.
+        assertSucceeds(self.client.sendPing())
         assertSucceeds(self.server.receivePing(ackFlagSet: false))
+        assertSucceeds(self.client.receivePing(ackFlagSet: true))
     }
 
     func testPushesAfterSendingPrefaceAreInvalid() {

--- a/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConnectionStateMachineTests.swift
@@ -1065,7 +1065,6 @@ class ConnectionStateMachineTests: XCTestCase {
 
         // Connectiony things don't work either.
         assertConnectionError(type: .protocolError, self.client.sendPing())
-        assertConnectionError(type: .protocolError, self.server.receivePing(ackFlagSet: false))
         assertConnectionError(type: .protocolError, self.client.sendPriority())
         assertConnectionError(type: .protocolError, self.server.receivePriority())
         assertConnectionError(type: .protocolError, self.client.sendSettings([]))
@@ -1074,6 +1073,9 @@ class ConnectionStateMachineTests: XCTestCase {
         // Duplicate goaway is cool though.
         assertSucceeds(self.client.sendGoaway(lastStreamID: .rootStream))
         assertSucceeds(self.server.receiveGoaway(lastStreamID: .rootStream))
+
+        // Receiving ping is cool too.
+        assertSucceeds(self.server.receivePing(ackFlagSet: false))
     }
 
     func testPushesAfterSendingPrefaceAreInvalid() {

--- a/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerTests.swift
@@ -864,42 +864,6 @@ class SimpleClientServerTests: XCTestCase {
             XCTAssertTrue(error is NIOHTTP2Errors.UnableToParseFrame)
         }
     }
-
-    @available(*, deprecated, message: "Deprecated so deprecated functionality can be tested without warnings")
-    func testSuccessfullyReceiveAndSendPingEvenWhenConnectionIsFullyQuiesced() throws {
-        let serverHandler = FrameRecorderHandler()
-        try self.basicHTTP2Connection() { channel, streamID in
-            return channel.pipeline.addHandler(serverHandler)
-        }
-
-        let goAwayFrame = HTTP2Frame(streamID: .rootStream, payload: .goAway(lastStreamID: .rootStream, errorCode: .noError, opaqueData: nil))
-
-        // Fully quiesce the connection on the server.
-        serverChannel.writeAndFlush(goAwayFrame, promise: nil)
-
-        let pingFrame = HTTP2Frame(streamID: .rootStream, payload: .ping(HTTP2PingData(), ack: false))
-
-        // Send PING frame to the server.
-        clientChannel.writeAndFlush(pingFrame, promise: nil)
-
-        self.interactInMemory(self.clientChannel, self.serverChannel)
-
-        // The client receives the GOAWAY frame and fully quiesces the connection.
-        try self.clientChannel.assertReceivedFrame().assertGoAwayFrame(lastStreamID: .rootStream, errorCode: 0, opaqueData: nil)
-
-        // The server receives and responds to the PING.
-        try self.serverChannel.assertReceivedFrame().assertPingFrame(ack: false, opaqueData: HTTP2PingData())
-
-        // The client receives the PING response.
-        try self.clientChannel.assertReceivedFrame().assertPingFrame(ack: true, opaqueData: HTTP2PingData())
-
-        // No frames left.
-        self.clientChannel.assertNoFramesReceived()
-        self.serverChannel.assertNoFramesReceived()
-
-        XCTAssertNoThrow(try self.clientChannel.finish())
-        XCTAssertNoThrow(try self.serverChannel.finish())
-    }
 }
 
 final class ActionOnFlushHandler: ChannelOutboundHandler {


### PR DESCRIPTION
Motivation:

When the connection is fully quiesced, an endpoint responds with a connection error when it receives or tries to respond to a PING frame. This behaviour is unnecessary.

Modifications:

- Adjust `HTTP2ConnectionStateMachine` to successfully receive and send PING frames even when the connection is fully quiesced.

Result:

When the connection is fully quiesced, an endpoint will treat receipt and sending of a PING frame as it would when the connection is active.