### PR TITLE
Upper-bound swift-docc-plugin dependency version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.60.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", "1.0.0"..<"1.4.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Motivation:

Building swift-nio-http2 with Swift 5.8 fails due to a compiler error when building swift-docc-plugin (https://github.com/swiftlang/swift-docc-plugin/issues/94).

Modifications:

- Adjust the dependency version of swift-docc-plugin from `from: "1.0.0"` to `"1.0.0"..<"1.4.0"`.

Result:

Building swift-nio-http2 with Swift 5.8 will now be successful.