### PR TITLE
Handle race condition between sending GOAWAY and HEADERS

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/ConnectionStateMachine.swift
@@ -704,7 +704,7 @@ extension HTTP2ConnectionStateMachine {
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.missingPreface(), type: .protocolError), effect: nil)
 
         case .fullyQuiesced:
-            return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.ioOnClosedConnection(), type: .protocolError), effect: nil)
+            return .init(result: .streamError(streamID: streamID, underlyingError: NIOHTTP2Errors.ioOnClosedConnection(), type: .refusedStream), effect: nil)
 
         case .modifying:
             preconditionFailure("Must not be left in modifying state")
@@ -1042,7 +1042,7 @@ extension HTTP2ConnectionStateMachine {
             return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.missingPreface(), type: .protocolError), effect: nil)
 
         case .fullyQuiesced:
-            return .init(result: .connectionError(underlyingError: NIOHTTP2Errors.ioOnClosedConnection(), type: .protocolError), effect: nil)
+            return .init(result: .succeed, effect: nil)
 
         case .modifying:
             preconditionFailure("Must not be left in modifying state")

--- a/Tests/NIOHTTP2Tests/SimpleClientServerInlineStreamMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerInlineStreamMultiplexerTests.swift
@@ -328,4 +328,48 @@ class SimpleClientServerInlineStreamMultiplexerTests: XCTestCase {
         promise.succeed(())
         stream.writeAndFlush(headerPayload, promise: promise)
     }
+
+    func testOpenStreamBeforeReceivingAlreadySentGoAway() throws {
+        let serverHandler = InboundFramePayloadRecorder()
+        try self.basicHTTP2Connection() { channel in
+            return channel.pipeline.addHandler(serverHandler)
+        }
+
+        let clientHandler = InboundFramePayloadRecorder()
+        let childChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        let multiplexer = try (self.clientChannel.pipeline.context(handlerType: NIOHTTP2Handler.self).wait().handler as! NIOHTTP2Handler).multiplexer.wait()
+        multiplexer.createStreamChannel(promise: childChannelPromise) { channel in
+            return channel.pipeline.addHandler(clientHandler)
+        }
+        (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
+        let childChannel = try childChannelPromise.futureResult.wait()
+
+        // Server sends GOAWAY frame.
+        let goAwayFrame = HTTP2Frame(streamID: .rootStream, payload: .goAway(lastStreamID: .maxID, errorCode: .noError, opaqueData: nil))
+        serverChannel.writeAndFlush(goAwayFrame, promise: nil)
+
+        // Client sends headers.
+        let headers = HPACKHeaders([(":path", "/"), (":method", "POST"), (":scheme", "https"), (":authority", "localhost")])
+        let reqFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers))
+        childChannel.writeAndFlush(reqFramePayload, promise: nil)
+
+        self.interactInMemoryExpectingErrors(self.clientChannel, self.serverChannel) { error in
+            XCTAssert(error is NIOHTTP2Errors.IOOnClosedConnection)
+        }
+
+        // Client receives GOAWAY and RST_STREAM frames.
+        try self.clientChannel.assertReceivedFrame().assertGoAwayFrame(lastStreamID: .maxID, errorCode: 0, opaqueData: nil)
+        clientHandler.receivedFrames.assertFramePayloadsMatch([HTTP2Frame.FramePayload.rstStream(.refusedStream)])
+
+        // No frames left.
+        self.clientChannel.assertNoFramesReceived()
+        self.serverChannel.assertNoFramesReceived()
+
+        // The stream closes with an error.
+        self.clientChannel.embeddedEventLoop.run()
+        XCTAssertThrowsError(try childChannel.closeFuture.wait())
+
+        XCTAssertNoThrow(try self.clientChannel.finish())
+        XCTAssertNoThrow(try self.serverChannel.finish())
+    }
 }


### PR DESCRIPTION
Motivation:

A potential race exists between a server sending a GOAWAY frame and a client opening a new stream (i.e., sending a HEADERS frame before receiving an already sent GOAWAY frame). If there are no open streams when the server sends the GOAWAY frame, the connection state on the server transitions to being fully quiesced, which throws a connection error on receipt of a HEADERS frame.

Modifications:

- Adjust the connection state machine on the server to throw a stream error (instead of a connection error), and consequently, send a RST_STREAM frame sent to the client.

Result:

This condition will be treated as a stream-level error instead.