### PR TITLE
Remove upper bound for swift-docc-plugin version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.60.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", branch: "fix-swift-5.7-compilation-issues"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.60.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", "1.0.0"..<"1.4.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", branch: "fix-swift-5.7-compilation-issues"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Updates the swift-docc-plugin dependency to remove the upper bound (fixed by https://github.com/swiftlang/swift-docc-plugin/pull/96).

~~This PR is in a draft state so that we can verify that https://github.com/swiftlang/swift-docc-plugin/pull/96 resolves this issue in this project before merging and creating a tag.~~

We've created the tag and I updated the PR.