### PR TITLE
Enable python lint in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+
+ignore =
+    # These are needed to make our license headers pass the linting
+    E265,
+    E266,
+
+# 10% larger than the standard 80 character limit. Conforms to the black
+# standard and Bugbear's B950.
+max-line-length = 88
+exclude =
+    Tests/hpack-test-case

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,7 @@ jobs:
     with:
       license_header_check_project_name: "SwiftNIO"
       format_check_enabled: false
-      unacceptable_language_check_enabled: true
       shell_check_enabled: false
-      python_lint_check_enabled: false
 
   unit-tests:
     name: Unit tests

--- a/.licenseignore
+++ b/.licenseignore
@@ -44,3 +44,4 @@ dev/update-benchmark-thresholds
 .gitmodules
 FuzzTesting/FailCases/*
 Tests/hpack-test-case/*
+.flake8


### PR DESCRIPTION
Motivation:

More checking is better

Modifications:

Enable and configure flake8

Result:

More CI checks