### PR TITLE
Add HTTP/2 spec tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,3 +18,10 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  h2spec:
+    name: HTTP/2 spec tests
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "HTTP/2 spec tests"
+      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,3 +26,10 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  h2spec:
+    name: HTTP/2 spec tests
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "HTTP/2 spec tests"
+      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,3 +18,10 @@ jobs:
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  h2spec:
+    name: HTTP/2 spec tests
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "HTTP/2 spec tests"
+      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"


### PR DESCRIPTION
Motivation:

More testing is better.

Modifications:

Setup github actions to run http/2 spec tests.

Result:

Testing against http/2 spec occurs on pull requests