### PR TITLE
Import new Android overlay instead in the tests

### DIFF
--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -24,8 +24,8 @@ import XCTest
 import Darwin.C
 #elseif canImport(Glibc)
 import Glibc
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #endif
 
 struct NoFrameReceived: Error {}


### PR DESCRIPTION
I added the `Bionic` import this summer in #448 and the compiler accepted it then, but it started erroring a couple months later without this full Android overlay, so add that instead.