### PR TITLE
Better handle new streams when server is quiescing

### DIFF
--- a/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/FrameReceivingStates/ReceivingHeadersState.swift
@@ -115,7 +115,7 @@ extension ReceivingHeadersState where Self: LocallyQuiescingState {
         }
 
         // At this stage we've quiesced, so the remote peer is not allowed to create new streams.
-        let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true) {
+        let result = self.streamState.modifyStreamState(streamID: streamID, ignoreRecentlyReset: true, isQuiescing: true) {
             $0.receiveHeaders(
                 headers: headers,
                 validateHeaderBlock: validateHeaderBlock,


### PR DESCRIPTION
Motivation:

When the server is in the locally quiescing state and a client attempts to open a new stream, the connection state machine treats receiving the headers as a connection error. This results in the connection being closed and in-flight requests being failed.

This can happen because of the inherent race between the server sending a GOAWAY frame and the client receiving it, during which time the client can open a stream not knowing it's doomed to failure.

Rather than the server treating this as a connection error, it should reject the stream with a RST_STREAM frame and emit a stream error.

Modifications:

- Emit a stream error when receiving HEADERS in the locally quiesced state

Result:

Better handling of new streams when the server is quiescing