### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,3 +90,14 @@ let package = Package(
         ),
     ]
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasLocalSettings.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOHPACK
+
 /// A protocol implemented by HTTP/2 connection state machine states with local settings.
 ///
 /// This protocol provides implementations that can apply changes to the local settings.

--- a/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
+++ b/Sources/NIOHTTP2/ConnectionStateMachine/HasRemoteSettings.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOHPACK
+
 /// A protocol implemented by HTTP/2 connection state machine states with remote settings.
 ///
 /// This protocol provides implementations that can apply changes to the remote settings.

--- a/Tests/NIOHTTP2Tests/HTTP2ErrorTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ErrorTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOHTTP2
+import NIOHPACK
 import XCTest
 
 class HTTP2ErrorTests: XCTestCase {

--- a/Tests/NIOHTTP2Tests/HTTP2ErrorTests.swift
+++ b/Tests/NIOHTTP2Tests/HTTP2ErrorTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOHTTP2
 import NIOHPACK
+import NIOHTTP2
 import XCTest
 
 class HTTP2ErrorTests: XCTestCase {


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.