### PR TITLE
Don't fail close promise when an error occurs on closing

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamChannel.swift
@@ -676,7 +676,7 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
 
         self.eventLoop.execute {
             self.removeHandlers(pipeline: self.pipeline)
-            self.closePromise.succeed(())
+            self.closePromise.succeed()
             if let streamID = self.streamID {
                 self.multiplexer.streamClosed(id: streamID)
             } else {
@@ -694,14 +694,14 @@ final class HTTP2StreamChannel: Channel, ChannelCore, @unchecked Sendable {
         self.failPendingWrites(error: error)
         if let promise = self.pendingClosePromise {
             self.pendingClosePromise = nil
-            promise.fail(error)
+            promise.succeed()
         }
         self.pipeline.fireErrorCaught(error)
         self.pipeline.fireChannelInactive()
 
         self.eventLoop.execute {
             self.removeHandlers(pipeline: self.pipeline)
-            self.closePromise.fail(error)
+            self.closePromise.succeed()
             if let streamID = self.streamID {
                 self.multiplexer.streamClosed(id: streamID)
             } else {

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineInlineMultiplexerTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineInlineMultiplexerTests.swift
@@ -71,7 +71,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
             )
         )
 
-        clientMultiplexer.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientMultiplexer.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -82,9 +85,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -133,7 +137,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
             )
         )
 
-        clientMultiplexer.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientMultiplexer.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -144,9 +151,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -466,7 +474,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
             )
         )
 
-        clientMultiplexer.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientMultiplexer.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -476,9 +487,11 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent
@@ -556,7 +569,10 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
             )
         )
 
-        clientMultiplexer.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientMultiplexer.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -566,9 +582,11 @@ class ConfiguringPipelineInlineMultiplexerTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineTests.swift
@@ -61,7 +61,10 @@ class ConfiguringPipelineTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel, streamID in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel, streamID in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             XCTAssertEqual(streamID, HTTP2StreamID(1))
             channel.writeAndFlush(reqFrame).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
@@ -73,9 +76,10 @@ class ConfiguringPipelineTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -116,7 +120,10 @@ class ConfiguringPipelineTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel, streamID in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel, streamID in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             XCTAssertEqual(streamID, HTTP2StreamID(1))
             channel.writeAndFlush(reqFrame).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
@@ -128,9 +135,10 @@ class ConfiguringPipelineTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -403,7 +411,10 @@ class ConfiguringPipelineTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel, streamID in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel, streamID in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             XCTAssertEqual(streamID, HTTP2StreamID(1))
             channel.writeAndFlush(reqFrame).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
@@ -414,9 +425,11 @@ class ConfiguringPipelineTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         let serverChildChannel = try serverChildChannelPromise.futureResult.wait()
         try serverChildChannel.pipeline.handler(type: HTTP1ServerRequestRecorderHandler.self).map { serverRecorder in
@@ -492,7 +505,10 @@ class ConfiguringPipelineTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel, streamID in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel, streamID in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             XCTAssertEqual(streamID, HTTP2StreamID(1))
             channel.writeAndFlush(reqFrame).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
@@ -503,9 +519,11 @@ class ConfiguringPipelineTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         let serverChildChannel = try serverChildChannelPromise.futureResult.wait()
         try serverChildChannel.pipeline.handler(type: HTTP1ServerRequestRecorderHandler.self).map { serverRecorder in

--- a/Tests/NIOHTTP2Tests/ConfiguringPipelineWithFramePayloadStreamsTests.swift
+++ b/Tests/NIOHTTP2Tests/ConfiguringPipelineWithFramePayloadStreamsTests.swift
@@ -75,7 +75,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -86,9 +89,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -132,7 +136,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -143,9 +150,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
 
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // We should have received a HEADERS and a RST_STREAM frame.
         // The RST_STREAM frame is from closing an incomplete stream on the client side.
@@ -442,7 +450,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -452,9 +463,11 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent
@@ -528,7 +541,10 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
             )
         )
 
-        clientHandler.createStreamChannel(promise: nil) { channel in
+        let errorHandler = ErrorEncounteredHandler()
+        let streamChannelPromise = self.clientChannel.eventLoop.makePromise(of: Channel.self)
+        clientHandler.createStreamChannel(promise: streamChannelPromise) { channel in
+            try? channel.pipeline.addHandler(errorHandler).wait()
             channel.writeAndFlush(reqFrame.payload).whenComplete { _ in channel.close(promise: requestPromise) }
             return channel.eventLoop.makeSucceededFuture(())
         }
@@ -538,9 +554,11 @@ class ConfiguringPipelineWithFramePayloadStreamsTests: XCTestCase {
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
         self.interactInMemory(self.clientChannel, self.serverChannel)
         (self.clientChannel.eventLoop as! EmbeddedEventLoop).run()
-        XCTAssertThrowsError(try requestPromise.futureResult.wait()) { error in
-            XCTAssertTrue(error is NIOHTTP2Errors.StreamClosed)
-        }
+
+        let streamChannel = try XCTUnwrap(streamChannelPromise.futureResult.wait())
+        XCTAssertNoThrow(try streamChannel.closeFuture.wait())
+        XCTAssertNoThrow(try requestPromise.futureResult.wait())
+        XCTAssertTrue(errorHandler.encounteredError is NIOHTTP2Errors.StreamClosed)
 
         // Assert that the user-provided handler received the
         // HTTP1 parts corresponding to the H2 message sent

--- a/Tests/NIOHTTP2Tests/TestUtilities.swift
+++ b/Tests/NIOHTTP2Tests/TestUtilities.swift
@@ -1503,3 +1503,14 @@ internal func assertThrowsError<T>(
         verify(error)
     }
 }
+
+final class ErrorEncounteredHandler: ChannelInboundHandler {
+    typealias InboundIn = Never
+
+    var encounteredError: Error?
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.encounteredError = error
+        context.fireErrorCaught(error)
+    }
+    }


### PR DESCRIPTION
Strictly speaking, a `close` operation can't really fail (except when the closing mode isn't supported or the channel is already closed). Even if an error is encountered while closing a channel, or if an error caused the channel to be closed, the end result is the same: the channel will be closed. 

In this case in particular, when streams are closed from the client (i.e. by sending a RST_STREAM frame) the `HTTP2StreamChannel` would fail the close promise. This isn't appropriate however, as the channel is successfully closed: the promise failure is only giving additional information that can actually be exposed via other means.

This change stops failing both the stream channel's `closePromise` and the promise passed to the `close` method in the `HTTP2StreamChannel`. Instead, if the close happens uncleanly, the error will be fired down the pipeline. Close promises will now only be succeeded. 