### PR TITLE
Delete Thresholds/nightly-6.1.json symlink

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,10 +32,26 @@ jobs:
       name: "HTTP/2 spec tests"
       matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"
 
+  construct-integration-tests-matrix:
+    name: Construct Examples matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-tests-matrix: '${{ steps.generate-matrix.outputs.integration-tests-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-tests-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
+          MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q  jq"
+
   integration-tests:
     name: Integration Tests
-    # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-tests-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
-      name: "Integration tests"
-      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q  jq && ./scripts/integration_tests.sh"
+      name: "Examples"
+      matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'

--- a/IntegrationTests/tests_01_allocation_counters/Thresholds/nightly-6.1.json
+++ b/IntegrationTests/tests_01_allocation_counters/Thresholds/nightly-6.1.json
@@ -1,1 +1,0 @@
-./nightly-next.json


### PR DESCRIPTION
Following on from https://github.com/apple/swift-nio-http2/pull/496 delete `Thresholds/nightly-6.1.json` which is no longer needed now that the shared benchmarks workflow has been updated