### PR TITLE
Update main.yml integration tests to use swift_test_matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,5 +49,5 @@ jobs:
     needs: construct-integration-tests-matrix
     uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
-      name: "Examples"
+      name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       name: "HTTP/2 spec tests"
       matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"
 
-    construct-integration-tests-matrix:
+  construct-integration-tests-matrix:
     name: Construct Examples matrix
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,26 @@ jobs:
       name: "HTTP/2 spec tests"
       matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"
 
+    construct-integration-tests-matrix:
+    name: Construct Examples matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-tests-matrix: '${{ steps.generate-matrix.outputs.integration-tests-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-tests-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
+          MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q  jq"
+
   integration-tests:
     name: Integration Tests
-    # Workaround https://github.com/nektos/act/issues/1875
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-tests-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
-      name: "Integration tests"
-      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q  jq && ./scripts/integration_tests.sh"
+      name: "Examples"
+      matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'


### PR DESCRIPTION
Update main.yml integration tests to use `swift_test_matrix` as has been done on the PR workflow. This brings it off the deprecated workflow and should fix the nightly-6.1 issue