### PR TITLE
Add Sendable conformance to HTTP2StreamMultiplexer to support Swift concurrency patterns

### DIFF
--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -22,7 +22,7 @@ import NIOCore
 /// on ``HTTP2Frame`` or ``HTTP2Frame/FramePayload`` objects as their base communication
 /// atom, as opposed to the regular NIO `SelectableChannel` objects which use `ByteBuffer`
 /// and `IOData`.
-public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboundHandler {
+public final class HTTP2StreamMultiplexer: ChannelInboundHandler, ChannelOutboundHandler, Sendable {
     public typealias InboundIn = HTTP2Frame
     public typealias InboundOut = HTTP2Frame
     public typealias OutboundIn = HTTP2Frame


### PR DESCRIPTION
This is required to use NIOHTTPClient in Swift 6 w/ Connect for gRPC.

For example

```swift
        let protocolClient = ProtocolClient(
            httpClient: NIOHTTPClient(host: host, port: port),
            config: ProtocolClientConfig(
                host: host,
                networkProtocol: .grpc,
                codec: ProtoCodec()
            )
        )
```

Co-Authored-By: Grok <noreply@grok.com>