### PR TITLE
Strict concurrency for NIOHPACK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,31 @@
 
 import PackageDescription
 
+let strictConcurrencyDevelopment = false
+
+let strictConcurrencySettings: [SwiftSetting] = {
+    var initialSettings: [SwiftSetting] = []
+    initialSettings.append(contentsOf: [
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+
+    if strictConcurrencyDevelopment {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
+        initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
+    }
+
+    return initialSettings
+}()
+
 let package = Package(
     name: "swift-nio-http2",
     products: [
         .library(name: "NIOHTTP2", targets: ["NIOHTTP2"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.60.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [
@@ -74,7 +92,8 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .testTarget(
             name: "NIOHPACKTests",
@@ -86,7 +105,8 @@ let package = Package(
             resources: [
                 .copy("Fixtures/large_complex_huffman_b64.txt"),
                 .copy("Fixtures/large_huffman_b64.txt"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
     ]
 )

--- a/Sources/NIOHPACK/HPACKErrors.swift
+++ b/Sources/NIOHPACK/HPACKErrors.swift
@@ -17,7 +17,7 @@ import NIOCore
 public protocol NIOHPACKError: Error, Equatable {}
 
 /// Errors raised by NIOHPACK while encoding/decoding data.
-public enum NIOHPACKErrors {
+public enum NIOHPACKErrors: Sendable {
     /// An indexed header referenced an index that doesn't exist in our
     /// header tables.
     public struct InvalidHeaderIndex: NIOHPACKError {


### PR DESCRIPTION
Motivation:

To increase concurrency safety the NIOPHACK module should compile without warning under strict concurrency checking.

Modifications:

- Add explicit Sendable annotations

Result:

No concurrency warnings.