### PR TITLE
Provide a senable view over the stream multiplexer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,8 @@ let package = Package(
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "NIOHPACK",

--- a/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
+++ b/Sources/NIOHTTP2/HTTP2StreamMultiplexer.swift
@@ -339,18 +339,25 @@ extension HTTP2StreamMultiplexer {
         )
         sendableView.createStreamChannel(promise: promise, streamStateInitializer)
     }
+
+    /// Returns a `Sendable` view over the ``HTTP2StreamMultiplexer`` providing only thread-safe
+    /// APIs.
+    ///
+    /// This is useful when you need to be able to create streams from off of the event loop.
+    public var sendableView: SendableView {
+        SendableView(http2StreamMultiplexer: self, eventLoop: self.channel.eventLoop)
+    }
 }
 
 extension HTTP2StreamMultiplexer {
-    /// HTTP2StreamMultiplexer.SendableView exposes only the thread-safe API of HTTP2StreamMultiplexer
-    ///
-    /// We use unckecked Sendable here because we always make sure we are on the right event loop
-    /// from this code on.
-    struct SendableView: @unchecked Sendable {
+    /// ``SendableView`` exposes only the thread-safe API of ``HTTP2StreamMultiplexer``.
+    public struct SendableView: @unchecked Sendable {
+        // @unckecked Sendable is fine here: each of the create functions always executes
+        // onto the appropriate event-loop.
         let http2StreamMultiplexer: HTTP2StreamMultiplexer
         let eventLoop: EventLoop
 
-        func createStreamChannel(
+        public func createStreamChannel(
             promise: EventLoopPromise<Channel>?,
             _ streamStateInitializer: @escaping NIOChannelInitializer
         ) {
@@ -371,7 +378,7 @@ extension HTTP2StreamMultiplexer {
             deprecated,
             message: "The signature of 'streamStateInitializer' has changed to '(Channel) -> EventLoopFuture<Void>'"
         )
-        func createStreamChannel(
+        public func createStreamChannel(
             promise: EventLoopPromise<Channel>?,
             _ streamStateInitializer: @escaping NIOChannelInitializerWithStreamID
         ) {
@@ -414,3 +421,6 @@ extension HTTP2StreamMultiplexer {
         self.commonStreamMultiplexer.requestStreamID(forChannel: channel)
     }
 }
+
+@available(*, unavailable)
+extension HTTP2StreamMultiplexer: Sendable {}


### PR DESCRIPTION
Motivation:

The HTTP2StreamMultiplexer isn't `Sendable`, but it has public API for creating streams which must operate from off of the `EventLoop`.

Modifications:

- Add a `SendableView` over the multiplexer which only provides the methods for creating streams. These are safe to call from any isolation domain.

Result:

Can create streams from off of the EL.