### PR TITLE
Set up merge queue checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,3 @@ jobs:
     with:
       name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'
-
-  macos-tests:
-    name: macOS tests
-    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
-    with:
-      build_scheme: swift-nio-http2-Package

--- a/.github/workflows/merge_group.yml
+++ b/.github/workflows/merge_group.yml
@@ -46,7 +46,7 @@ jobs:
     needs: construct-integration-tests-matrix
     uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
-      name: "Examples"
+      name: "Integration tests"
       matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'
 
   macos-tests:

--- a/.github/workflows/merge_group.yml
+++ b/.github/workflows/merge_group.yml
@@ -1,0 +1,56 @@
+name: Merge group
+
+on:
+  merge_group:
+
+jobs:
+  unit-tests:
+    name: Unit tests
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    with:
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+
+  cxx-interop:
+    name: Cxx interop
+    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+  h2spec:
+    name: HTTP/2 spec tests
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "HTTP/2 spec tests"
+      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q wget lsof && mkdir $HOME/.tools && wget -q https://github.com/summerwind/h2spec/releases/download/v2.2.1/h2spec_linux_amd64.tar.gz -O $HOME/.tools/h2spec.tar.gz && tar xzf $HOME/.tools/h2spec.tar.gz --directory $HOME/.tools && PATH=${PATH}:$HOME/.tools && ./scripts/test_h2spec.sh"
+
+  construct-integration-tests-matrix:
+    name: Construct Examples matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-tests-matrix: '${{ steps.generate-matrix.outputs.integration-tests-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-tests-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "./scripts/integration_tests.sh"
+          MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q  jq"
+
+  integration-tests:
+    name: Integration Tests
+    needs: construct-integration-tests-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Examples"
+      matrix_string: '${{ needs.construct-integration-tests-matrix.outputs.integration-tests-matrix }}'
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      build_scheme: swift-nio-http2-Package


### PR DESCRIPTION
### Motivation:

We would like to have macOS CI run on each PR but suspect that runner capacity is insufficient to have this run interactively on each commit. One solution to this is to use merge queues and only run the macOS checks once the PR is approved for merging.

### Modifications:

* Duplicate PR checks (minus soundness) and run them as part of checks on a merge.
* Remove macOS checks in `main.yml` for now so we don't duplicate work on the merges. We might want to rethink the trigger for this on repos with merge queues to only run on a timer.

### Result:

The repo is configured for use with merge queues.