### PR TITLE
Add a frame delegate

### DIFF
--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -113,7 +113,7 @@ public final class NIOHTTP2Handler: ChannelDuplexHandler {
     /// The maximum number of sequential CONTINUATION frames.
     private let maximumSequentialContinuationFrames: Int
 
-    /// A delegate which is told about frames which have eebn written.
+    /// A delegate which is told about frames which have been written.
     private let frameDelegate: NIOHTTP2FrameDelegate?
 
     @usableFromInline

--- a/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
+++ b/Sources/NIOHTTP2/HTTP2ChannelHandler.swift
@@ -1100,20 +1100,7 @@ extension NIOHTTP2Handler {
 
         // Tell the delegate, if there is one.
         if let delegate = self.frameDelegate {
-            switch frame.payload {
-            case .headers(let headers):
-                delegate.wroteHeaders(headers.headers, endStream: headers.endStream, streamID: frame.streamID)
-
-            case .data(let data):
-                switch data.data {
-                case .byteBuffer(let buffer):
-                    delegate.wroteData(buffer, endStream: data.endStream, streamID: frame.streamID)
-                case .fileRegion:
-                    ()
-                }
-            default:
-                ()
-            }
+            delegate.wroteFrame(frame)
         }
 
         // Ok, if we got here we're good to send data. We want to attach the promise to the latest write, not

--- a/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
+++ b/Sources/NIOHTTP2/HTTP2PipelineHelpers.swift
@@ -867,12 +867,49 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: NIOHTTP2Handler.Configuration = NIOHTTP2Handler.Configuration(),
         streamInitializer: @escaping NIOChannelInitializerWithOutput<Output>
     ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<Output> {
+        try self.configureAsyncHTTP2Pipeline(
+            mode: mode,
+            streamDelegate: streamDelegate,
+            frameDelegate: nil,
+            configuration: configuration,
+            streamInitializer: streamInitializer
+        )
+    }
+
+    /// Configures a `ChannelPipeline` to speak HTTP/2 and sets up mapping functions so that it may be interacted with from concurrent code.
+    ///
+    /// This operation **must** be called on the event loop.
+    ///
+    /// In general this is not entirely useful by itself, as HTTP/2 is a negotiated protocol. This helper does not handle negotiation.
+    /// Instead, this simply adds the handler required to speak HTTP/2 after negotiation has completed, or when agreed by prior knowledge.
+    /// Use this function to setup a HTTP/2 pipeline if you wish to use async sequence abstractions over inbound and outbound streams,
+    /// as it allows that pipeline to evolve without breaking your code.
+    ///
+    /// - Parameters:
+    ///   - mode: The mode this pipeline will operate in, server or client.
+    ///   - streamDelegate: A delegate which is called when streams are created and closed.
+    ///   - frameDelegate: A delegate which is called when frames are written to the network.
+    ///   - configuration: The settings that will be used when establishing the connection and new streams.
+    ///   - streamInitializer: A closure that will be called whenever the remote peer initiates a new stream.
+    ///     The output of this closure is the element type of the returned multiplexer
+    /// - Returns: An `EventLoopFuture` containing the `AsyncStreamMultiplexer` inserted into this pipeline, which can
+    /// be used to initiate new streams and iterate over inbound HTTP/2 stream channels.
+    @inlinable
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func configureAsyncHTTP2Pipeline<Output: Sendable>(
+        mode: NIOHTTP2Handler.ParserMode,
+        streamDelegate: NIOHTTP2StreamDelegate?,
+        frameDelegate: NIOHTTP2FrameDelegate?,
+        configuration: NIOHTTP2Handler.Configuration = NIOHTTP2Handler.Configuration(),
+        streamInitializer: @escaping NIOChannelInitializerWithOutput<Output>
+    ) throws -> NIOHTTP2Handler.AsyncStreamMultiplexer<Output> {
         let handler = NIOHTTP2Handler(
             mode: mode,
             eventLoop: self.eventLoop,
             connectionConfiguration: configuration.connection,
             streamConfiguration: configuration.stream,
             streamDelegate: streamDelegate,
+            frameDelegate: frameDelegate,
             inboundStreamInitializerWithAnyOutput: { channel in
                 streamInitializer(channel).map { $0 }
             }

--- a/Sources/NIOHTTP2/NIOHTTP2FrameDelegate.swift
+++ b/Sources/NIOHTTP2/NIOHTTP2FrameDelegate.swift
@@ -21,35 +21,10 @@ import NIOHPACK
 /// This delegate, when used by the ``NIOHTTP2Handler`` will be called on the event
 /// loop associated with the channel that the handler is a part of. As such you should
 /// avoid doing expensive or blocking work in this delegate.
-public protocol NIOHTTP2FrameDelegate: Sendable {
-    /// Called when a HEADERS frame is written by the connection channel.
+public protocol NIOHTTP2FrameDelegate {
+    /// Called when a frame is written by the connection channel.
     ///
     /// - Parameters:
-    ///   - headers: The headers sent to the remote peer.
-    ///   - endStream: Whether the end stream was set on the frame.
-    ///   - streamID: The ID of the stream the frame was written to.
-    func wroteHeaders(_ headers: HPACKHeaders, endStream: Bool, streamID: HTTP2StreamID)
-
-    /// Called when a DATA frame is written by the connection channel.
-    ///
-    /// The data you see here may be chunked differently to the data you sent
-    /// from a stream channel. This may happen as the connect may need to slice up
-    /// the data over multiple frames to respect flow control windows and various
-    /// connection settings (such as max frame size).
-    ///
-    /// - Parameters:
-    ///   - data: The content of the DATA frame.
-    ///   - endStream: Whether the end stream was set on the frame.
-    ///   - streamID: The ID of the stream the frame was written to.
-    func wroteData(_ data: ByteBuffer, endStream: Bool, streamID: HTTP2StreamID)
-}
-
-extension NIOHTTP2FrameDelegate {
-    public func wroteHeaders(_ headers: HPACKHeaders, endStream: Bool, streamID: HTTP2StreamID) {
-        // no-op
-    }
-
-    public func wroteData(_ data: ByteBuffer, endStream: Bool, streamID: HTTP2StreamID) {
-        // no-op
-    }
+    ///   - frame: The frame to write.
+    func wroteFrame(_ frame: HTTP2Frame)
 }

--- a/Sources/NIOHTTP2/NIOHTTP2FrameDelegate.swift
+++ b/Sources/NIOHTTP2/NIOHTTP2FrameDelegate.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOHPACK
+
+/// A delegate which can be used with the ``NIOHTTP2Handler`` which is notified
+/// when various frame types are written into the connection channel.
+///
+/// This delegate, when used by the ``NIOHTTP2Handler`` will be called on the event
+/// loop associated with the channel that the handler is a part of. As such you should
+/// avoid doing expensive or blocking work in this delegate.
+public protocol NIOHTTP2FrameDelegate: Sendable {
+    /// Called when a HEADERS frame is written by the connection channel.
+    ///
+    /// - Parameters:
+    ///   - headers: The headers sent to the remote peer.
+    ///   - endStream: Whether the end stream was set on the frame.
+    ///   - streamID: The ID of the stream the frame was written to.
+    func wroteHeaders(_ headers: HPACKHeaders, endStream: Bool, streamID: HTTP2StreamID)
+
+    /// Called when a DATA frame is written by the connection channel.
+    ///
+    /// The data you see here may be chunked differently to the data you sent
+    /// from a stream channel. This may happen as the connect may need to slice up
+    /// the data over multiple frames to respect flow control windows and various
+    /// connection settings (such as max frame size).
+    ///
+    /// - Parameters:
+    ///   - data: The content of the DATA frame.
+    ///   - endStream: Whether the end stream was set on the frame.
+    ///   - streamID: The ID of the stream the frame was written to.
+    func wroteData(_ data: ByteBuffer, endStream: Bool, streamID: HTTP2StreamID)
+}
+
+extension NIOHTTP2FrameDelegate {
+    public func wroteHeaders(_ headers: HPACKHeaders, endStream: Bool, streamID: HTTP2StreamID) {
+        // no-op
+    }
+
+    public func wroteData(_ data: ByteBuffer, endStream: Bool, streamID: HTTP2StreamID) {
+        // no-op
+    }
+}

--- a/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
+++ b/Tests/NIOHTTP2Tests/SimpleClientServerFramePayloadStreamTests.swift
@@ -2920,7 +2920,7 @@ class SimpleClientServerFramePayloadStreamTests: XCTestCase {
         // The first three are the max frame size of 2^14, the fourth is (2^14) - 1
         // as that's all that remains of the connection window. The final byte of the
         // message is sent later, after the server sends a WINDOW_UPDATE frame.
-        for _ in 1 ... 3 {
+        for _ in 1...3 {
             events.popFirst()?.assertDataFrame(
                 endStream: false,
                 streamID: 1,


### PR DESCRIPTION
Motivation:

Frames written from a child channel may not be written immediately by the connection channel. For example, a DATA frame written on a stream may be larger than the max frame size imposed on the connection and so the connection channel will have to slice it into multiple frames. Or the connection may not be writable and may delay the transmission of the frame. This behaviour isn't currently observable but is useful to know about.

Modifications:

- Add a frame delegate which is notified when certain frames are written by the connection channel.

Result:

Users can observer when headers and data frames are written into the connection channel.