### PR TITLE
Enable release mode builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,3 +79,7 @@ jobs:
   static-sdk:
     name: Static SDK
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,3 +83,7 @@ jobs:
   static-sdk:
     name: Static SDK
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main


### PR DESCRIPTION
### Motivation:

Some errors do not show up in debug builds. Enabling release mode builds improves the CI coverage.

### Modifications:

Enable release mode builds for pull requests and scheduled builds on main.

### Result:

Improved CI coverage.