### PR TITLE
Enable Swift 6.2 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/IntegrationTests/tests_01_allocation_counters/Thresholds/6.2.json
+++ b/IntegrationTests/tests_01_allocation_counters/Thresholds/6.2.json
@@ -1,0 +1,23 @@
+{
+    "1k_requests_inline_interleaved": 30150,
+    "1k_requests_inline_noninterleaved": 29100,
+    "1k_requests_interleaved": 36150,
+    "1k_requests_noninterleaved": 35100,
+    "client_server_h1_request_response": 280050,
+    "client_server_h1_request_response_inline": 265050,
+    "client_server_request_response": 249050,
+    "client_server_request_response_inline": 240050,
+    "client_server_request_response_many": 1194050,
+    "client_server_request_response_many_inline": 885050,
+    "create_client_stream_channel": 35050,
+    "create_client_stream_channel_inline": 35050,
+    "create_client_stream_channel_inline_no_promise_based_API": 35050,
+    "create_client_stream_channel_no_promise_based_API": 35050,
+    "get_100000_headers_canonical_form": 200050,
+    "get_100000_headers_canonical_form_trimming_whitespace": 200050,
+    "get_100000_headers_canonical_form_trimming_whitespace_from_long_string": 300050,
+    "get_100000_headers_canonical_form_trimming_whitespace_from_short_string": 200050,
+    "hpack_decoding": 5050,
+    "stream_teardown_100_concurrent": 253550,
+    "stream_teardown_100_concurrent_inline": 252150
+}


### PR DESCRIPTION
Motivation:

Swift 6.2 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.2 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
